### PR TITLE
DO NOT MERGE - JUST FOR REFERENCE - Adds association between Asset and Series

### DIFF
--- a/app/actors/hyrax/actors/add_assets_to_series_actor.rb
+++ b/app/actors/hyrax/actors/add_assets_to_series_actor.rb
@@ -1,0 +1,68 @@
+module Hyrax
+  module Actors
+    # Attach or remove child works to/from this work. This decodes parameters
+    # that follow the rails nested parameters conventions:
+    # e.g.
+    #   'series_assets_attributes' => {
+    #     '0' => { 'id' = '12312412'},
+    #     '1' => { 'id' = '99981228', '_destroy' => 'true' }
+    #   }
+    #
+    # The goal of this actor is to mutate the ordered_members with as few writes
+    # as possible, because changing ordered_members is slow. This class only
+    # writes changes, not the full ordered list.
+    class AddAssetsToSeriesActor < Hyrax::Actors::AbstractActor
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if update was successful
+      def update(env)
+        series_asset_attributes = env.attributes.delete(:work_member_attributes)
+        series = env.curation_concern
+        assign_nested_attributes_for_series(series, series_asset_attributes) &&
+          next_actor.update(env)
+      end
+
+      private
+
+        # Attaches any unattached Assets.  Deletes those that are marked _delete
+        # @param [Hash<Hash>] an array of Asset attribute hashes
+        def assign_nested_attributes_for_series(series, series_asset_attributes)
+          return true unless series_asset_attributes
+
+          series_asset_attributes = series_asset_attributes.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes }
+
+          # checking for existing works to avoid rewriting/loading works that are
+          # already attached
+          existing_assets = series.asset_ids
+          series_asset_attributes.each do |attributes|
+            next if attributes['id'].blank?
+            if existing_assets.include?(attributes['id'])
+              remove(series, attributes['id']) if has_destroy_flag?(attributes)
+            else
+              add(series, attributes['id'])
+            end
+          end
+        end
+
+        # Adds the item to the ordered members so that it displays in the items
+        # along side the FileSets on the show page
+        def add(series, id)
+          asset = Asset.find(id)
+          series.assets << asset
+        end
+
+        # Remove the object from the members set and the ordered members list
+        def remove(series, id)
+          asset = Asset.find(id)
+          series.assets.delete(asset)
+          series.assets.delete(asset)
+        end
+
+        # Determines if a hash contains a truthy _destroy key.
+        # rubocop:disable Style/PredicateName
+        def has_destroy_flag?(hash)
+          ActiveFedora::Type::Boolean.new.cast(hash['_destroy'])
+        end
+      # rubocop:enable Style/PredicateName
+    end
+  end
+end

--- a/app/authorities/qa/authorities/find_assets.rb
+++ b/app/authorities/qa/authorities/find_assets.rb
@@ -1,0 +1,26 @@
+module Qa::Authorities
+  class FindAssets < Qa::Authorities::Base
+    class_attribute :search_builder_class
+    self.search_builder_class = Hyrax::My::FindAssetsSearchBuilder
+
+    def search(_q, controller)
+      # The My::FindWorksSearchBuilder expects a current_user
+      return [] unless controller.current_user
+      repo = CatalogController.new.repository
+      builder = search_builder(controller)
+      response = repo.search(builder)
+      docs = response.documents
+      docs.map do |doc|
+        id = doc.id
+        title = doc.title
+        { id: id, label: title, value: id }
+      end
+    end
+
+    private
+
+      def search_builder(controller)
+        search_builder_class.new(controller)
+      end
+  end
+end

--- a/app/controllers/hyrax/series_controller.rb
+++ b/app/controllers/hyrax/series_controller.rb
@@ -10,5 +10,11 @@ module Hyrax
 
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::SeriesPresenter
+
+    def update
+      # TODO: where should this really go?
+      Hyrax::CurationConcern.actor_factory.swap Hyrax::Actors::AttachMembersActor, Hyrax::Actors::AddAssetsToSeriesActor
+      super
+    end
   end
 end

--- a/app/forms/hyrax/series_form.rb
+++ b/app/forms/hyrax/series_form.rb
@@ -7,5 +7,12 @@ module Hyrax
     self.terms -= [:relative_path, :import_url, :date_created, :resource_type, :contributor, :keyword, :license, :rights_statement, :publisher, :subject, :language, :identifier, :based_near, :related_url, :bibliographic_citation, :source]
     self.required_fields += [:description]
     self.required_fields -= [:creator, :keyword, :rights_statement]
+
+    # Delegate #assets and #assets_attributes= to the Series model.
+    # The #assets method comes from Series.has_and_belongs_to_many(:assets).
+    # The #assets_attributes= method comes from
+    # Series.accetps_nested_attributes_for(:assets).
+    # See app/models/series.rb
+    delegate :assets, :asset_attributes=, to: :model
   end
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -3,6 +3,8 @@
 class Asset < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
 
+  has_and_belongs_to_many :series, predicate: ::RDF::URI.new('http://example.org#TODO-find-appropriate-predicate'), class_name: Series, inverse_of: :assets
+
   self.indexer = AssetIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -3,6 +3,9 @@
 class Series < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
 
+  has_and_belongs_to_many :assets, predicate: ::RDF::URI.new('http://example.org#TODO-find-appropriate-predicate'), class_name: Asset, inverse_of: :series
+  accepts_nested_attributes_for :assets
+
   self.indexer = SeriesIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/app/search_builders/hyrax/my/find_assets_search_builder.rb
+++ b/app/search_builders/hyrax/my/find_assets_search_builder.rb
@@ -1,0 +1,26 @@
+# Search for possible works that user can edit and could be a work's child or parent.
+class Hyrax::My::FindAssetsSearchBuilder < Hyrax::My::SearchBuilder
+  include Hyrax::FilterByType
+
+  self.default_processor_chain += [:filter_on_title]
+  self.default_processor_chain -= [:add_access_controls_to_solr_params, :show_only_resources_deposited_by_current_user]
+
+  # Excludes the id that is part of the params
+  def initialize(context)
+    super(context)
+    # Without an id this class will produce an invalid query.
+    @id = context.params[:id] || raise("missing required parameter: id")
+    @q = context.params[:q]
+  end
+
+  def filter_on_title(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] += [ActiveFedora::SolrQueryBuilder.construct_query(title_tesim: @q)]
+  end
+
+  private
+
+    def models
+      [Asset]
+    end
+end

--- a/app/views/hyrax/series/_find_asset_widget.html.erb
+++ b/app/views/hyrax/series/_find_asset_widget.html.erb
@@ -1,0 +1,10 @@
+<%= text_field_tag "find_#{name}",
+                   '',
+                   placeholder: t('.placeholder', default: "Search for a #{Asset.human_readable_type}"),
+                   autocomplete: 'on',
+                   style: "width: 100%",
+                   data: {
+                     autocomplete: 'work',
+                     'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/find_assets',
+                     'exclude-work': id # exclude this item from the result set.
+                   } %>

--- a/app/views/hyrax/series/_form_child_asset_relationships.html.erb
+++ b/app/views/hyrax/series/_form_child_asset_relationships.html.erb
@@ -1,0 +1,52 @@
+<%# Form UI behavior code and details;
+Code:
+  app/assets/javascripts/hyrax/relationships
+CSS:
+  [data-behavior="remove-relationship"] : Button to remove its parent TR from the table
+  [data-behavior="add-relationship"] : Button to clone its parent TR and inject a new row into the table
+  .message.has-warning : Used to display UI errors related to input values and server errors
+HTML Properties:
+  table:
+    [data-behavior="child-relationships"] : allows the javascript to be initialized
+    data-param-key : the parameter key value for this model type
+%>
+<div class="form-group multi_value optional managed">
+  <table class="table table-striped related-files" data-behavior="child-relationships" data-param-key="<%= f.object.model_name.param_key %>">
+    <thead>
+    <tr>
+      <th><%= Asset.human_readable_type.pluralize %></th>
+      <th>&nbsp;</th>
+    </tr>
+    </thead>
+    <tbody>
+      <%= f.fields_for :assets do |asset_form_builder| %>
+        <tr>
+          <td>
+            <%= link_to asset_form_builder.object.title.first, [main_app, asset_form_builder.object] %>
+          </td>
+          <td>
+            <a class="btn btn-danger" data-behavior="remove-relationship" data-index="<%= asset_form_builder.index %>">Remove</a>
+          </td>
+        </tr>
+      <% end %>
+      <tr>
+        <td>
+          <%= render "find_asset_widget", f: f,
+                                         name: 'child_asset',
+                                         id: f.object.model.id %>
+          <div class="message has-warning hidden"></div>
+        </td>
+        <td>
+          <a class="btn btn-primary" data-behavior="add-relationship">Add</a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<script type="text/x-tmpl" id="tmpl-child-work">
+<tr>
+  <td>{%= o.title %}</td>
+  <td><button class="btn btn-danger" data-behavior="remove-relationship">Remove</button></td>
+</tr>
+</script>

--- a/app/views/hyrax/series/_form_relationships.html.erb
+++ b/app/views/hyrax/series/_form_relationships.html.erb
@@ -1,0 +1,13 @@
+<% if Flipflop.assign_admin_set? %>
+  <%# TODO: consider `Hyrax::AdminSetOptionsPresenter.select_options_for(controller: controller)` instead %>
+  <%= f.input :admin_set_id, as: :select,
+      include_blank: false,
+      collection: Hyrax::AdminSetOptionsPresenter.new(Hyrax::AdminSetService.new(controller)).select_options,
+      input_html: { class: 'form-control' } %>
+<% end %>
+
+<%= render 'form_in_works', f: f %>
+
+<% if f.object.persisted? %>
+  <%= render 'form_child_asset_relationships', f: f  %>
+<% end %>

--- a/spec/actors/hyrax/actors/add_assets_to_series_actor_spec.rb
+++ b/spec/actors/hyrax/actors/add_assets_to_series_actor_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::AddAssetsToSeriesActor do
+  let(:ability) { ::Ability.new(depositor) }
+  let(:env) { Hyrax::Actors::Environment.new(series, ability, attributes) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:depositor) { create(:user) }
+  let(:series) { create(:series) }
+  let(:attributes) { HashWithIndifferentAccess.new(series_assets_attributes: { '0' => { id: id } }) }
+
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+    stack.build(terminator)
+  end
+
+  describe "#update" do
+    subject { middleware.update(env) }
+
+    before do
+      series.assets << existing_child_asset
+    end
+    let(:existing_child_asset) { create(:asset) }
+    let(:id) { existing_child_asset.id }
+
+    context "without useful attributes" do
+      let(:attributes) { {} }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the id already exists in the assets" do
+      it "does nothing" do
+        expect { subject }.not_to change { series.assets.to_a }
+      end
+
+      context "and the _destroy flag is set" do
+        let(:attributes) { HashWithIndifferentAccess.new(series_assets_attributes: { '0' => { id: id, _destroy: 'true' } }) }
+
+        it "removes from the member and the ordered assets" do
+          expect { subject }.to change { series.assets.to_a }
+          expect(series.asset_ids).not_to include(existing_child_asset.id)
+          expect(series.asset_ids).not_to include(existing_child_asset.id)
+        end
+      end
+    end
+
+    context "when the id does not exist in the assets" do
+      let(:another_asset) { create(:asset) }
+      let(:id) { another_asset.id }
+
+      it "is added to the assets" do
+        expect { subject }.to change { series.assets.to_a }
+        expect(series.asset_ids).to include(existing_child_asset.id, another_asset.id)
+      end
+    end
+  end
+end

--- a/spec/authorities/qa/authorities/find_assets_spec.rb
+++ b/spec/authorities/qa/authorities/find_assets_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Qa::Authorities::FindAssets do
+  let(:controller) { Qa::TermsController.new }
+  let(:user1) { create(:user) }
+  # let(:user2) { create(:user) }
+  let(:ability) { instance_double(Ability, admin?: false, user_groups: [], current_user: user1) }
+  let(:q) { "foo" }
+  let(:params) { ActionController::Parameters.new(q: q, id: asset1.id, user: user1.email, controller: "qa/terms", action: "search", vocab: "find_assets") }
+  let(:service) { described_class.new }
+  let!(:asset1) { create(:asset, title: ['foo']) }
+  let!(:asset2) { create(:asset, title: ['foo foo']) }
+  # let!(:work3) { create(:generic_work, :public, title: ['bar'], user: user1) }
+  # let!(:work4) { create(:generic_work, :public, title: ['another foo'], user: user1) }
+  # let!(:work5) { create(:generic_work, :public, title: ['foo foo foo'], user: user2) }
+
+  before do
+    allow(controller).to receive(:params).and_return(params)
+    allow(controller).to receive(:current_user).and_return(user1)
+    allow(controller).to receive(:current_ability).and_return(ability)
+  end
+
+  subject { service.search(q, controller) }
+
+  describe '#search' do
+    it 'displays a list of all assets' do
+      expect(subject.map { |result| result[:id] }).to match_array [asset1.id, asset2.id]
+    end
+  end
+end

--- a/spec/factories/asset.rb
+++ b/spec/factories/asset.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :asset, class: Asset do
+    sequence(:title) { |n| ["Test Asset #{n}"] }
+    sequence(:description) { |n| ["Test Description of Asset #{n}"] }
+  end
+end

--- a/spec/factories/series.rb
+++ b/spec/factories/series.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :series, class: Series do
     sequence(:title) { |n| ["Test Series #{n}"] }
+    sequence(:description) { |n| ["Description for Series #{n}"] }
   end
 end

--- a/spec/features/udpate_series_spec.rb
+++ b/spec/features/udpate_series_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Update and Validate Series', js: true do
+  context 'Create adminset, create series' do
+    let(:admin_user) { create :admin_user }
+    let!(:user_with_role) { create :user_with_role, role_name: 'user' }
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(admin_set_id: admin_set_id) }
+    let!(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+
+    let(:series_attributes) do
+      {
+        title: "My Test Series",
+        description: "A test Series for testing!",
+        audience_level: 'My Test Audience level',
+        audience_rating: 'My Test Audience rating',
+        annotation: 'My Test Annotation',
+        rights_summary: 'My Test Rights summary',
+        rights_link: 'http://somerightslink.com/testlink'
+      }
+    end
+
+    scenario 'Update and Validate Series, Search series' do
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'group',
+        agent_id: 'user',
+        access: 'deposit'
+      )
+      # Login role user to create series
+      login_as(user_with_role)
+
+      # create series
+      visit '/dashboard'
+      click_link "Works"
+      click_link ""
+      expect(page).to have_content "Add New Series", wait: 20
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+
+      # Expect the required metadata indicator to indicate 'incomplete'
+      expect(page.find("#required-metadata")[:class]).to include "incomplete"
+
+      click_link "Descriptions" # switch tab
+      fill_in('Title', with: series_attributes[:title])
+      fill_in('Description', with: series_attributes[:description])
+
+      # Expect the required metadata indicator to indicate 'complete'
+      expect(page.find("#required-metadata")[:class]).to include "complete"
+
+      click_link "Additional fields" # additional metadata
+
+      fill_in('Audience level', with: series_attributes[:audience_level])
+      fill_in('Audience rating', with: series_attributes[:audience_rating])
+      fill_in('Annotation', with: series_attributes[:annotation])
+      fill_in('Rights summary', with: series_attributes[:rights_summary])
+      fill_in('Rights link', with: series_attributes[:rights_link])
+
+      click_link "Relationships" # define adminset relation
+      find("#series_admin_set_id option[value='#{admin_set_id}']").select_option
+
+      # set it public
+      find('body').click
+      choose('series_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      click_on('Save')
+
+      wait_for(10) { Series.where(title: series_attributes[:title]).first }
+
+      visit '/'
+      find("#search-submit-header").click
+
+      # expect series is showing up
+      expect(page).to have_content series_attributes[:title]
+      expect(page).to have_content series_attributes[:description]
+
+      # open series with detail show
+      click_on(series_attributes[:title])
+      expect(page).to have_content series_attributes[:title]
+      expect(page).to have_content series_attributes[:description]
+      expect(page).to have_content series_attributes[:audience_level]
+      expect(page).to have_content series_attributes[:audience_rating]
+      expect(page).to have_content series_attributes[:annotation]
+      expect(page).to have_content series_attributes[:rights_summary]
+      expect(page).to have_content series_attributes[:rights_link]
+      exit
+    end
+  end
+end
+


### PR DESCRIPTION
* Association is a 'has and belongs to many'.
* Adds association to models.
* Modifies Series form to make adding Assets clearer, changes labels, etc.
* Adds an authority for returning Assets that can be added to a Series.
* Creates search builder for returning Assets that can be related to Series.
* Adds custom actor for adding Assets to Series.
* Modifies default actor stack to use custom actor.

Also,

* Fixes Series factory to include description (a required field).