### PR TITLE
Adds typed title field

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -3,6 +3,52 @@
 module Hyrax
   module Actors
     class AssetActor < Hyrax::Actors::BaseActor
+      def create(env)
+        add_title_types(env)
+        add_description_types(env)
+        super
+      end
+
+      def update(env)
+        add_title_types(env)
+        add_description_types(env)
+        super
+      end
+
+      private
+
+        def add_title_types(env)
+          env.attributes[:title] = get_titles_by_type('default', env.attributes)
+          env.attributes[:episode_title] = get_titles_by_type('episode', env.attributes)
+          env.attributes[:segment_title] = get_titles_by_type('segment', env.attributes)
+          env.attributes[:raw_footage_title] = get_titles_by_type('raw_footage', env.attributes)
+          env.attributes[:promo_title] = get_titles_by_type('promo', env.attributes)
+          env.attributes[:clip_title] = get_titles_by_type('clip', env.attributes)
+
+          # Now that we're done with these attributes, remove them from the
+          # environment to avoid errors later in the save process.
+          env.attributes.delete(:title_type)
+          env.attributes.delete(:title_value)
+        end
+
+        def add_description_types(env)
+        end
+
+        def get_titles_by_type(title_type, attributes)
+          attributes[:title_value].select.with_index do |title_value, index|
+            attributes[:title_type][index] == title_type
+          end
+        end
+
+        # def get_descriptions_by_type(description_type, attributes)
+        #   attributes[:description_value].select.with_index do |description_value, index|
+        #     attributes[:description_type][index] == description_type
+        #   end
+        # end
+
+        def remove_attributes(*attrs)
+          attrs.each { |attr| env.attributes.delete(:attr) }
+        end
     end
   end
 end

--- a/app/forms/hyrax/asset_form.rb
+++ b/app/forms/hyrax/asset_form.rb
@@ -2,10 +2,62 @@
 #  `rails generate hyrax:work Asset`
 module Hyrax
   class AssetForm < Hyrax::Forms::WorkForm
+
     self.model_class = ::Asset
-    self.terms += [:genre, :asset_types, :resource_type, :broadcast, :created, :date, :copyright_date, :episode_number, :description, :spatial_coverage, :temporal_coverage, :audience_level, :audience_rating, :annotation, :rights_summary, :rights_link, :local_identifier, :pbs_nola_code, :eidr_id, :topics]
-    self.terms -= [:relative_path, :import_url, :date_created, :resource_type, :creator, :contributor, :keyword, :license, :rights_statement, :publisher, :language, :identifier, :based_near, :related_url, :bibliographic_citation, :source]
-    self.required_fields += [:description]
-    self.required_fields -= [:creator, :keyword, :rights_statement]
+    # Add terms tha we want to be a part of the "Additional Fields" section
+    self.terms += [:genre, :asset_types, :resource_type, :broadcast, :created, :date, :copyright_date,
+                   :episode_number, :description, :spatial_coverage, :temporal_coverage, :audience_level,
+                   :audience_rating, :annotation, :rights_summary, :rights_link, :local_identifier, :pbs_nola_code,
+                   :eidr_id, :topics]
+
+    # Remove terms that we don't want to be a part of the form.
+    self.terms -= [:relative_path, :import_url, :date_created, :resource_type,
+                   :creator, :contributor, :keyword, :license,
+                   :rights_statement, :publisher, :language, :identifier,
+                   :based_near, :related_url, :bibliographic_citation, :source,
+                   :episode_title, :segment_title, :raw_footage_title,
+                   :promo_title, :clip_title]
+
+    # Add fields that we want to be required
+    self.required_fields += [:titles_with_types, :description]
+
+    # Remove fields tha we don't want to be required.
+    self.required_fields -= [:creator, :keyword, :rights_statement, :title]
+
+
+    def title_type
+      # This is a fucking pointless no-op method that is stupidly required
+      # by form builder object, because we can't use form builder object to build
+      # forms containing arbitrary form inputs, no we can't. We absolutely must have
+      # a corresponding method in the form object that was passed to the form builder
+      # or else we get fatal errors. So here's a method that does nothing in order to
+      # make the machinery work. Yay.
+      # TODO: Is this really necessary? C'mon.
+    end
+
+    def title_value
+      # See #title_type method.
+    end
+
+    def titles_with_types
+      titles_with_types = []
+      titles_with_types += model.title.map { |title| [:default, title] }
+      titles_with_types += model.episode_title.map { |title| [:episode, title] }
+      titles_with_types += model.segment_title.map { |title| [:segment, title] }
+      titles_with_types += model.raw_footage_title.map { |title| [:raw_footage, title] }
+      titles_with_types += model.promo_title.map { |title| [:promo, title] }
+      titles_with_types += model.clip_title.map { |title| [:clip, title] }
+      titles_with_types
+    end
+
+    # Augment the list of permmitted params to accept our fields that have
+    # types associated with them, e.g. title + title type
+    # NOTE: `super` in this case is HyraxEditor::Form.permitted_params
+    def self.permitted_params
+      super.tap do |permitted_params|
+        permitted_params << { title_type: [] }
+        permitted_params << { title_value: [] }
+      end
+    end
   end
 end

--- a/app/input/multiple_text_select_combo_input.rb
+++ b/app/input/multiple_text_select_combo_input.rb
@@ -1,0 +1,41 @@
+class MultipleTextSelectComboInput < MultiValueInput
+
+  def build_field(value, index)
+    # TODO: this data needs to come from a controlled vocab of title types
+    # rather than being hardcoded here.
+    title_type_choices = [
+      ['', 'default'],
+      ['Episode', 'episode'],
+      ['Segment', 'segment'],
+      ['Raw Footage', 'raw_footage'],
+      ['Promo', 'promo'],
+      ['Clip', 'clip']
+    ]
+
+    select_input_html_options = { name: "#{@builder.object_name}[title_type][]"}
+    text_input_html_options = { name: "#{@builder.object_name}[title_value][]", value: value[1] }
+
+
+    output = @builder.select(:title_type, title_type_choices, { selected: value[0] }, select_input_html_options)
+    output += @builder.text_field(:title_value, text_input_html_options)
+    output
+  end
+
+
+  # Overrides MultiValueInput#collection from Hydra-editor. The original
+  # method calls object[attribute_name] instead of object.send(attribute_name)
+  # to retrieve the value. By using the square brackets, it bypasses any
+  # accessor method on the form object that you may have created to decorate
+  # the values, which is exactly what we are doing.
+  # TODO: Create a PR for hydra-editor to change `object[attribute_name]` to
+  # `object.send(attribute_name)` in MultiValueInput#collection.
+  def collection
+    @collection ||= begin
+      # As of this writing, the line below is the only once changed from the
+      # original.
+      val = object.send(attribute_name)
+      col = val.respond_to?(:to_ary) ? val.to_ary : val
+      col.reject { |value| value.to_s.strip.blank? } + ['']
+    end
+  end
+end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -6,7 +6,7 @@ class Asset < ActiveFedora::Base
   self.indexer = AssetIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
-  validates :title, presence: { message: 'Your asset must have a title.' }
+  # validates :title, presence: { message: 'Your asset must have a title.' }
   validates :description, presence: { message: 'Your asset must have a description.' }
 
   self.human_readable_type = 'Asset'
@@ -84,6 +84,26 @@ class Asset < ActiveFedora::Base
   end
 
   property :subject, predicate: ::RDF::URI.new("http://purl.org/dc/elements/1.1/subject"), multiple: true do |index|
+    index.as :stored_searchable
+  end
+
+  property :episode_title, predicate: ::RDF::URI.new('http://pbcore.org#hasEpisodeTitle'), multiple: :true do |index|
+    index.as :stored_searchable
+  end
+
+  property :segment_title, predicate: ::RDF::URI.new('http://pbcore.org#hasSegmentTitle'), multiple: :true do |index|
+    index.as :stored_searchable
+  end
+
+  property :raw_footage_title, predicate: ::RDF::URI.new('http://pbcore.org#hasRawFootageTitle'), multiple: :true do |index|
+    index.as :stored_searchable
+  end
+
+  property :promo_title, predicate: ::RDF::URI.new('http://pbcore.org#hasPromoTitle'), multiple: :true do |index|
+    index.as :stored_searchable
+  end
+
+  property :clip_title, predicate: ::RDF::URI.new('http://pbcore.org#hasClipTitle'), multiple: :true do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -220,4 +220,24 @@ class SolrDocument
   def alternative_modes
     self[Solrizer.solr_name('alternative_modes')]
   end
+
+  def episode_title
+    self[Solrizer.solr_name('episode_title')]
+  end
+
+  def segment_title
+    self[Solrizer.solr_name('segment_title')]
+  end
+
+  def raw_footage_title
+    self[Solrizer.solr_name('raw_footage_title')]
+  end
+
+  def promo_title
+    self[Solrizer.solr_name('promo_title')]
+  end
+
+  def clip_title
+    self[Solrizer.solr_name('clip_title')]
+  end
 end

--- a/app/presenters/hyrax/asset_presenter.rb
+++ b/app/presenters/hyrax/asset_presenter.rb
@@ -4,6 +4,9 @@ module Hyrax
   class AssetPresenter < Hyrax::WorkShowPresenter
     delegate :genre, :asset_types, :broadcast, :created, :copyright_date, :episode_number,
                          :description, :spatial_coverage, :temporal_coverage, :audience_level,
-                         :audience_rating, :annotation, :rights_summary, :rights_link, :date, :local_identifier, :pbs_nola_code, :eidr_id, :topics, :subject, to: :solr_document
+                         :audience_rating, :annotation, :rights_summary, :rights_link, :date,
+                         :local_identifier, :pbs_nola_code, :eidr_id, :topics, :subject,
+                         :episode_title, :segment_title, :raw_footage_title, :promo_title,
+                         :clip_title, to: :solr_document
   end
 end

--- a/app/services/title_and_description_types_service.rb
+++ b/app/services/title_and_description_types_service.rb
@@ -1,0 +1,23 @@
+module TitleAndDescriptionTypesService
+  mattr_accessor :authority
+  self.authority = Qa::Authorities::Local.subauthority_for('title_and_description_types')
+
+  def self.select_all_options
+    authority.all.map do |element|
+      [element[:label], element[:id]]
+    end
+  end
+
+  def self.all_terms
+
+    select_all_options.map { |(term, id)| term }
+  end
+
+  def self.all_ids
+    select_all_options.map { |(term, id)| id }
+  end
+
+  def self.label(id)
+    authority.find(id).fetch('term')
+  end
+end

--- a/app/views/hyrax/assets/_attribute_rows.html.erb
+++ b/app/views/hyrax/assets/_attribute_rows.html.erb
@@ -1,3 +1,8 @@
+<%= presenter.attribute_to_html(:episode_title, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:segment_title, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:raw_footage_title, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:promo_title, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:clip_title, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:asset_types, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:genre, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:broadcast, render_as: :faceted) %>

--- a/app/views/records/edit_fields/_titles_with_types.html.erb
+++ b/app/views/records/edit_fields/_titles_with_types.html.erb
@@ -1,0 +1,8 @@
+<%=
+f.input :titles_with_types,
+            as: :multiple_text_select_combo,
+            wrapper_html: { class: 'multi_value' },
+            input_html: { class: 'form-control' },
+            required: true,
+            label: 'Title'
+%>

--- a/config/authorities/asset_types.yml
+++ b/config/authorities/asset_types.yml
@@ -14,4 +14,4 @@ terms:
   - id: RawFootage
     term: Raw Footage
   - id: Segment
-    term: Segmen
+    term: Segment

--- a/config/authorities/title_and_description_types.yml
+++ b/config/authorities/title_and_description_types.yml
@@ -1,0 +1,11 @@
+terms:
+  - id: Episode
+    term: Episode
+  - id: Segment
+    term: Segment
+  - id: RawFootage
+    term: Raw Footage
+  - id: Promo
+    term: Promo
+  - id: Clip
+    term: Clip

--- a/spec/features/create_asset_with_asset_types_vocabulary_spec.rb
+++ b/spec/features/create_asset_with_asset_types_vocabulary_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Create Asset with Asset Type', js: true do
+RSpec.feature 'Create Asset with Asset Type', js: true, include: :asset_form_helpers do
   context 'Create adminset, create asset' do
     let(:admin_user) { create :admin_user }
     let!(:user_with_role) { create :user_with_role, role_name: 'user' }
@@ -45,7 +45,7 @@ RSpec.feature 'Create Asset with Asset Type', js: true do
       page.find("#required-metadata")[:class].include?("incomplete")
 
       click_link "Descriptions" # switch tab
-      fill_in('Title', with: asset_attributes[:title])
+      fill_in_title asset_attributes[:title]  # see AssetFormHelpers#fill_in_title
       fill_in('Description', with: asset_attributes[:description])
 
       # validated metadata without errors

--- a/spec/features/create_asset_with_genre_vocabulary_spec.rb
+++ b/spec/features/create_asset_with_genre_vocabulary_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Create Asset with Asset Type', js: true do
+RSpec.feature 'Create Asset with Asset Type', js: true, include: :asset_form_helpers do
   context 'Create adminset, create asset' do
     let(:admin_user) { create :admin_user }
     let!(:user_with_role) { create :user_with_role, role_name: 'user' }
@@ -45,7 +45,7 @@ RSpec.feature 'Create Asset with Asset Type', js: true do
       page.find("#required-metadata")[:class].include?("incomplete")
 
       click_link "Descriptions" # switch tab
-      fill_in('Title', with: asset_attributes[:title])
+      fill_in_title asset_attributes[:title] # see AssetFormHelpers#fill_in_title
       fill_in('Description', with: asset_attributes[:description])
 
       # validated metadata without errors

--- a/spec/support/asset_form_helpers.rb
+++ b/spec/support/asset_form_helpers.rb
@@ -1,0 +1,80 @@
+
+# This module contains helper methods for use in Capybara specs that deal with
+# entering data into the Asset create and edit forms.
+# To use in your specs, add the metadata `include: :asset_form_helpers` to
+# your context or scenario.
+module AssetFormHelpers
+
+  # Fills in a title, and optionally selects a title type.
+  # @param title [String] The title to enter.
+  # @param type [String] The title type to select.
+  # @param index [Integer] If there are multiple title/title_type pairs, use
+  #  `index` to specify which pair you want to set.
+  def fill_in_title_with_type(title, type: nil, index: nil)
+    select_title_type(type, index: index) if type
+    fill_in_title(title, index: index)
+  end
+
+
+  # Fills in multiple titles with their types.
+  # @param Array titles_with_types An array where each element is a 2-element
+  #  array containing the title and the title type.
+  def fill_in_titles_with_types(titles_with_types)
+    raise ArgumentError, "First argument must be enumerable, but #{titles_with_types.class} was given" unless titles_with_types.respond_to?(:each)
+    titles_with_types.each_with_index do |title_with_type, index|
+      raise ArgumentError, "Each element of first argument must be an array of 2 elements, but #{title_with_type} was given" unless (title_with_type.is_a?(Array) && title_with_type.count == 2)
+      title, title_type = title_with_type
+      fill_in_title_with_type(title, type: title_type)
+      click_button 'Add another Title' unless (index+1 == titles_with_types.count)
+    end
+  end
+
+  # Fills in a title.
+  # @param title [String] The title.
+  # @param index [Integer] If there are multiple titles, use
+  #  `index` to specify which title you want to set. If no index is given
+  #  it will set the last one found.
+  def fill_in_title(title, index: nil)
+    title_value_input(index).set title
+  end
+
+  # Selects a title type.
+  # @param title_type [String] The title type option you want to select.
+  # @param index [Integer] If there are multiple title types, use
+  #  `index` to specify which title type you want to set. If no index is given
+  #  it will set the last one found.
+  def select_title_type(title_type, index: nil)
+    title_type_select(index).select title_type
+  end
+
+  # Returns an input for entering a title.
+  # @param index [Integer] If there are multiple titles, use
+  #  `index` to specify which title you want to set. If no index is given
+  #  it will set the last one found.
+  def title_value_input(index=nil)
+    # Get all inputs for entering titles.
+    input_elements = page.all(:css, 'input[name="asset[title_value][]"]')
+    # If no specific index was passed, return the last one found.
+    index ||= input_elements.count - 1
+    input_elements[index]
+  end
+
+  # Returns an element for selecting a title type.
+  # @param index [Integer] If there are multiple title types, use
+  #  `index` to specify which title type you want to set. If no index is given
+  #  it will set the last one found.
+  def title_type_select(index=nil)
+    # Get all elements for selecting title types.
+    select_elements = page.all(:css, 'select[name="asset[title_type][]"]')
+    # If no specific index was passed, return the last one found.
+    index ||= select_elements.count - 1
+    select_elements[index]
+  end
+end
+
+
+# Include helper methods for all specs that are tagged with
+# `include: :asset_form_helpers`
+RSpec.configure do |config|
+  config.include AssetFormHelpers, include: :asset_form_helpers
+end


### PR DESCRIPTION
* Adds distinct properties for various title types to the Asset model.
* Creates a custom input that combines a text inputs with a selet box for the
  type.
* Modifies AssetForm object to split distinct properties for each title type
  into a structure suitable for displaying as a combination of select box (for
  the title type) and a text box (for the title).
* Adds logic to AssetActor to modify the environment on #create and #update. The
  modifications combine the title and title type fields from the submitted
  form data into distinct properties for each title type on the model before
  saving.
* Modifies form partials for edit fields to allow for multiple title/title_type
  paris, and ensure they are pre-populated.
* Modifies AssetPresenter, relevant view partials to display all the different
  title types.
* Adds a controlled vocabulary for title and description types.
* Adds helper methods for dealing with Asset create/update forms in Capybara.

Also,

* MultipleTextSelectComboInput#collection overrides MultiValueInput#collection
  (from hydra_editor). This may be a useful patch to hydra_editor.