### PR TITLE
Adds msg re: uploading technical metadata

### DIFF
--- a/app/views/hyrax/digital_instantiations/_form_metadata.html.erb
+++ b/app/views/hyrax/digital_instantiations/_form_metadata.html.erb
@@ -1,0 +1,49 @@
+<div class="base-terms">
+  <% f.object.primary_terms.each do |term| %>
+    <%= render_edit_field_partial(term, f: f) %>
+  <% end %>
+</div>
+<% if f.object.display_additional_fields? %>
+  <%= link_to t('hyrax.works.form.additional_fields'),
+              '#extended-terms',
+              class: 'btn btn-default additional-fields',
+              data: {toggle: 'collapse'},
+              role: "button",
+              'aria-expanded' => "false",
+              'aria-controls' => "extended-terms" %>
+  <div id="extended-terms" class='collapse'>
+    <%= render 'form_media', f: f %>
+    <% f.object.secondary_terms.each do |term| %>
+      <%= render_edit_field_partial(term, f: f) %>
+    <% end %>
+  </div>
+<% end %>
+<% if f.object.respond_to?(:field_groups) %>
+    <div class="panel-group" id="accordion">
+    <% f.object.field_groups.map do |group, fields| %>
+      <% if fields.any? %>
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h4 class="panel-title">
+              <a class="accordion-toggle" data-toggle="collapse" href="#collapse-<%= group %>">
+                <%= t("form.#{group}") %>
+              </a>
+            </h4>
+          </div>
+          <div id="collapse-<%= group %>" class="panel-collapse collapse  <%= "in" if f.object.expand_field_group?(group) %>" aria-expanded="<%= f.object.expand_field_group?(group) ? "true" : "false" %>">
+            <div class="panel-body">
+              <!--  Custom override of DigitalInstantiation form -->
+              <% if group == :technical_info %>
+                <div class="alert alert-warning" role="alert">These fields are disabled. To add or update techincal metadata for Digital Instantiations you must upload a PBCore file above.</div>
+              <% end %>
+
+              <% fields.each do |term| %>
+                <%= render_edit_field_partial(term, f: f) %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+    </div>
+  <% end %>

--- a/lib/tasks/hydra_clean_server.rake
+++ b/lib/tasks/hydra_clean_server.rake
@@ -26,6 +26,8 @@ namespace :hydra do
         # and there's nothing left to do.
         false
       end
+      puts "Seeding the database"
+      Rake::Task['db:seed'].invoke
     end
 
     desc 'Resets Fedora, Solr, Database, and creates default admin set for test environment'


### PR DESCRIPTION
This involves overriding app/views/base/_form_metadata.html.erb partial, which
in turn overrides the partial of the same name from Hyrax gem.

Here, we need extra customization for Digitial Instantiations, so
we override the partial by addifng a new partial for
app/views/digital_instantiations/_form_metadata.html.erb

Also...
* Adds seeding of database to hydra:clean:server and hydra:clean:test_server
  rake tasks to ensure that running either task will result in a clean state
  of the persistence layer.