### PR TITLE
Updates solr_wrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :development, :test do
   gem 'capybara', '~> 2.18'
   gem 'database_cleaner'
   gem 'fcrepo_wrapper'
-  gem 'solr_wrapper', '>= 0.3'
+  gem 'solr_wrapper', '~> 2.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    retriable (3.1.1)
+    retriable (3.1.2)
     rsolr (2.1.0)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
@@ -732,7 +732,7 @@ GEM
       actionpack (> 4, < 5.2)
       activemodel (> 4, < 5.2)
     slop (4.6.2)
-    solr_wrapper (1.2.0)
+    solr_wrapper (2.0.0)
       faraday
       retriable
       ruby-progressbar
@@ -847,7 +847,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   simple_form (= 3.5.0)
-  solr_wrapper (>= 0.3)
+  solr_wrapper (~> 2.0)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
@@ -857,4 +857,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
Apache stopped publishing the version of Solr that the previous
version of solr_wrapper was trying to pull down. Upgrading to
~> 2.0 fixes this.