### PR TITLE
Adds concatenated titles

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -215,6 +215,17 @@ class SolrDocument
     self[Solrizer.solr_name('alternative_modes')]
   end
 
+  def title
+    concatenated_titles = [
+      program_title, episode_number, episode_title, segment_title, clip_title,
+      promo_title, raw_footage_title,
+      self[Solrizer.solr_name('title')]
+    ].flatten.select(&:present?).join('; ')
+    # Wrap the return value in an array to behave like a multi-valued field,
+    # even though this will always be a single value.
+    Array(concatenated_titles)
+  end
+
   def program_title
     self[Solrizer.solr_name('program_title')]
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -3,290 +3,258 @@
 require 'rails_helper'
 
 RSpec.describe Asset do
+  let(:asset) { build(:asset) }
 
-
-  context "title" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has title" do
+  describe "#title" do
+    it "returns the title" do
       asset.title = ["Test title 1","Test title 2"]
       expect(asset.resource.dump(:ttl)).to match(/terms\/title/)
       expect(asset.title.include?("Test title 1")).to be true
     end
   end
 
-  context "asset_types" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has asset_types" do
+  describe "#asset_types" do
+    it "returns the asset_types" do
       asset.asset_types = ["Clip","Album"]
       expect(asset.resource.dump(:ttl)).to match(/ebucore\/ebucore#hasType/)
       expect(asset.asset_types.include?("Clip")).to be true
     end
   end
 
-  context "genre" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has genre" do
+  describe "#genre" do
+    it "returns the genre" do
       asset.genre = ["Debate","Documentary"]
       expect(asset.resource.dump(:ttl)).to match(/ebucore\/ebucore#hasGenre/)
       expect(asset.genre.include?("Debate")).to be true
     end
   end
 
-  context "date" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has date" do
+  describe "#date" do
+    it "returns the date" do
       asset.date = ["02-11-2001"]
       expect(asset.resource.dump(:ttl)).to match(/terms\/date/)
       expect(asset.date.include?("02-11-2001")).to be true
     end
   end
 
-  context "broadcast_date" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has broadcast_date" do
+  describe "#broadcast_date" do
+    it "returns the broadcast_date" do
       asset.broadcast_date = ["02-11-2002"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasBroadcastDate/)
       expect(asset.broadcast_date.include?("02-11-2002")).to be true
     end
   end
 
-  context "created_date" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has created_date" do
+  describe "#created_date" do
+    it "returns the created_date" do
       asset.created_date = ["03-11-2001"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasCreatedDate/)
       expect(asset.created_date.include?("03-11-2001")).to be true
     end
   end
 
-  context "copyright_date" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has copyright_date" do
+  describe "#copyright_date" do
+    it "returns the copyright_date" do
       asset.copyright_date = ["03-09-2001"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasCopyrightDate/)
       expect(asset.copyright_date.include?("03-09-2001")).to be true
     end
   end
 
-  context "episode_number" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has episode_number" do
+  describe "#episode_number" do
+    it "returns the episode_number" do
       asset.episode_number = ["SSPE12"]
       expect(asset.resource.dump(:ttl)).to match(/ebucore\/ebucore#episodeNumber/)
       expect(asset.episode_number.include?("SSPE12")).to be true
     end
   end
 
-  context "spatial_coverage" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has spatial_coverage" do
+  describe "#spatial_coverage" do
+    it "returns the spatial_coverage" do
       asset.spatial_coverage = ["Test Coverage"]
       expect(asset.resource.dump(:ttl)).to match(/terms\/coverage/)
       expect(asset.spatial_coverage.include?("Test Coverage")).to be true
     end
   end
 
-  context "temporal_coverage" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has temporal_coverage" do
+  describe "#temporal_coverage" do
+    it "returns the temporal_coverage" do
       asset.temporal_coverage = ["Test temporal Coverage"]
       expect(asset.resource.dump(:ttl)).to match(/bibframe.html#p_temporalCoverage/)
       expect(asset.temporal_coverage.include?("Test temporal Coverage")).to be true
     end
   end
 
-  context "audience_level" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has audience_level" do
+  describe "#audience_level" do
+    it "returns the audience_level" do
       asset.audience_level = ["Test audience_level"]
       expect(asset.resource.dump(:ttl)).to match(/ebucore\/ebucore#hasTargetAudience/)
       expect(asset.audience_level.include?("Test audience_level")).to be true
     end
   end
 
-  context "audience_rating" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has audience_rating" do
+  describe "#audience_rating" do
+    it "returns the audience_rating" do
       asset.audience_rating = ["Test Rating"]
       expect(asset.resource.dump(:ttl)).to match(/ebucore\/index.html#Type/)
       expect(asset.audience_rating.include?("Test Rating")).to be true
     end
   end
 
-  context "annotation" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has annotation" do
+  describe "#annotation" do
+    it "returns the annotation" do
       asset.annotation = ["Test annotation"]
       expect(asset.resource.dump(:ttl)).to match(/skos\/core#note/)
       expect(asset.annotation.include?("Test annotation")).to be true
     end
   end
 
-  context "rights_summary" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has rights_summary" do
+  describe "#rights_summary" do
+    it "returns the rights_summary" do
       asset.rights_summary = ["Test rights_summary"]
       expect(asset.resource.dump(:ttl)).to match(/elements\/1.1\/rights/)
       expect(asset.rights_summary.include?("Test rights_summary")).to be true
     end
   end
 
-  context "rights_link" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has rights_link" do
+  describe "#rights_link" do
+    it "returns the rights_link" do
       asset.rights_link = ["Test rights_link"]
       expect(asset.resource.dump(:ttl)).to match(/europeana.eu\/rights/)
       expect(asset.rights_link.include?("Test rights_link")).to be true
     end
   end
 
-  context "local_identifier" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has local_identifier" do
+  describe "#local_identifier" do
+    it "returns the local_identifier" do
       asset.local_identifier = ["Test local_identifier"]
       expect(asset.resource.dump(:ttl)).to match(/identifiers\/local/)
       expect(asset.local_identifier.include?("Test local_identifier")).to be true
     end
   end
 
-  context "pbs_nola_code" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has pbs_nola_code" do
+  describe "#pbs_nola_code" do
+    it "returns the pbs_nola_code" do
       asset.pbs_nola_code = ["Test pbs_nola_code"]
       expect(asset.resource.dump(:ttl)).to match(/bibframe.html\#p_code/)
       expect(asset.pbs_nola_code.include?("Test pbs_nola_code")).to be true
     end
   end
 
-  context "eidr_id" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has eidr_id" do
+  describe "#eidr_id" do
+    it "returns the eidr_id" do
       asset.eidr_id = ["Test eidr_id"]
       expect(asset.resource.dump(:ttl)).to match(/2002\/07\/owl#sameAs/)
       expect(asset.eidr_id.include?("Test eidr_id")).to be true
     end
   end
 
-  context "topics" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has topics" do
+  describe "#topics" do
+    it "returns the topics" do
       asset.topics = ["Test topics"]
       expect(asset.resource.dump(:ttl)).to match(/ebucore\/ebucore#hasKeyword/)
       expect(asset.topics.include?("Test topics")).to be true
     end
   end
 
-  context "subject" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has subject" do
+  describe "#subject" do
+    it "returns the subject" do
       asset.subject = ["Test subject"]
       expect(asset.resource.dump(:ttl)).to match(/elements\/1.1\/subject/)
       expect(asset.subject.include?("Test subject")).to be true
     end
   end
 
-  context "program_title" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has program_title" do
+  describe "#program_title" do
+    it "returns the program_title" do
       asset.program_title = ["Test program_title"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasProgramTitle/)
       expect(asset.program_title.include?("Test program_title")).to be true
     end
   end
 
-  context "episode_title" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has episode_title" do
+  describe "#episode_title" do
+    it "returns the episode_title" do
       asset.episode_title = ["Test episode_title"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasEpisodeTitle/)
       expect(asset.episode_title.include?("Test episode_title")).to be true
     end
   end
 
-  context "segment_title" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has segment_title" do
+  describe "#segment_title" do
+    it "returns the segment_title" do
       asset.segment_title = ["Test segment_title"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasSegmentTitle/)
       expect(asset.segment_title.include?("Test segment_title")).to be true
     end
   end
 
-  context "raw_footage_title" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has raw_footage_title" do
+  describe "#raw_footage_title" do
+    it "returns the raw_footage_title" do
       asset.raw_footage_title = ["Test raw_footage_title"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasRawFootageTitle/)
       expect(asset.raw_footage_title.include?("Test raw_footage_title")).to be true
     end
   end
 
-  context "promo_title" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has promo_title" do
+  describe "#promo_title" do
+    it "returns the promo_title" do
       asset.promo_title = ["Test promo_title"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasPromoTitle/)
       expect(asset.promo_title.include?("Test promo_title")).to be true
     end
   end
 
-  context "clip_title" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has clip_title" do
+  describe "#clip_title" do
+    it "returns the clip_title" do
       asset.clip_title = ["Test clip_title"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasClipTitle/)
       expect(asset.clip_title.include?("Test clip_title")).to be true
     end
   end
 
-  context "program_description" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has program_description" do
+  describe "#program_description" do
+    it "returns the program_description" do
       asset.program_description = ["Test program_description"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasProgramDescription/)
       expect(asset.program_description.include?("Test program_description")).to be true
     end
   end
 
-  context "episode_description" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has episode_description" do
+  describe "#episode_description" do
+    it "returns the episode_description" do
       asset.episode_description = ["Test episode_description"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasEpisodeDescription/)
       expect(asset.episode_description.include?("Test episode_description")).to be true
     end
   end
 
-  context "segment_description" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has segment_description" do
+  describe "#segment_description" do
+    it "returns the segment_description" do
       asset.segment_description = ["Test segment_description"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasSegmentDescription/)
       expect(asset.segment_description.include?("Test segment_description")).to be true
     end
   end
 
-  context "raw_footage_description" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has raw_footage_description" do
+  describe "#raw_footage_description" do
+    it "returns the raw_footage_description" do
       asset.raw_footage_description = ["Test raw_footage_description"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasRawFootageDescription/)
       expect(asset.raw_footage_description.include?("Test raw_footage_description")).to be true
     end
   end
 
-  context "promo_description" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has promo_description" do
+  describe "#promo_description" do
+    it "returns the promo_description" do
       asset.promo_description = ["Test promo_description"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasPromoDescription/)
       expect(asset.promo_description.include?("Test promo_description")).to be true
     end
   end
 
-  context "clip_description" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has clip_description" do
+  describe "#clip_description" do
+    it "returns the clip_description" do
       asset.clip_description = ["Test clip_description"]
       expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasClipDescription/)
       expect(asset.clip_description.include?("Test clip_description")).to be true

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe SolrDocument do
+  let(:solr_document) { described_class.new }
+  describe '#title' do
+    context 'when other titles are present' do
+      let(:other_titles) do
+        {
+          program_title: 'test program title',
+          episode_number: '123',
+          episode_title: 'test episode title',
+          segment_title: 'test segment title',
+          clip_title: 'test clip title',
+          promo_title: 'test promo title',
+          raw_footage_title: 'test raw footage title',
+        }
+      end
+
+      context 'when all other titles are present' do
+        before do
+          other_titles.each { |k,v| allow(solr_document).to receive(k).and_return(v) }
+        end
+
+        it 'displays all titles concatenated together with a semicolon' do
+          expect(solr_document.title).to eq [other_titles.values.join('; ') ]
+        end
+      end
+
+      context 'when a subset of titles are present' do
+        # Take a random sampling of other titles, preserving the order.
+        let(:subset_of_other_titles) { other_titles.select { rand(2) == 0 } }
+        before do
+          subset_of_other_titles.each { |k,v| allow(solr_document).to receive(k).and_return(v) }
+        end
+        it 'only displays titles that are present, concatenated with a semicolon' do
+          expect(solr_document.title).to eq [ subset_of_other_titles.values.join('; ') ]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Works having multiple title types should concatenate them together if present.

Also, modifies spec for Asset model:
  * use convention of using 'describe' for describing method calls
  * use convention of using '#' to denote instance methods.
  * use single `let` statement for top-level describe block  instead of one
    for each context in the spec.