### PR TITLE
Only return Asset work types in search results.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,8 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'hyrax', '~> 2.1.0'
+# gem 'hyrax', '~> 2.1.0'
+gem 'hyrax', github: 'WGBH-MLA/hyrax', branch: '3174_show_work_types_excluded_from_search_results'
 gem 'rsolr', '>= 1.0'
 gem 'jquery-rails'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,56 @@
+GIT
+  remote: https://github.com/WGBH-MLA/hyrax.git
+  revision: 6dd303841d91f5205bf5b19aee709e46972eadca
+  branch: 3174_show_work_types_excluded_from_search_results
+  specs:
+    hyrax (2.1.0)
+      active-fedora (~> 11.5, >= 11.5.2)
+      almond-rails (~> 0.1)
+      awesome_nested_set (~> 3.1)
+      blacklight (~> 6.14)
+      blacklight-gallery (~> 0.7)
+      breadcrumbs_on_rails (~> 3.0)
+      browse-everything (>= 0.10.5)
+      carrierwave (~> 1.0)
+      clipboard-rails (~> 1.5)
+      dry-equalizer (~> 0.2)
+      dry-struct (~> 0.1)
+      dry-validation (~> 0.9)
+      flipflop (~> 2.3)
+      flot-rails (~> 0.0.6)
+      font-awesome-rails (~> 4.2)
+      hydra-derivatives (~> 3.3)
+      hydra-editor (>= 3.3, < 5.0)
+      hydra-head (>= 10.5.0)
+      hydra-works (~> 0.16)
+      iiif_manifest (>= 0.3, < 0.5)
+      jquery-datatables-rails (~> 3.4)
+      jquery-ui-rails (~> 6.0)
+      json-schema
+      kaminari_route_prefix (~> 0.1.1)
+      legato (~> 0.3)
+      linkeddata
+      mailboxer (~> 0.12)
+      nest (~> 3.1)
+      noid-rails (~> 3.0.0)
+      oauth
+      oauth2 (~> 1.2)
+      posix-spawn
+      power_converter (~> 0.1, >= 0.1.2)
+      pul_uv_rails (~> 2.0)
+      qa (~> 2.0)
+      rails (~> 5.0)
+      rails_autolink (~> 1.1)
+      rdf-rdfxml
+      redis-namespace (~> 1.5)
+      redlock (>= 0.1.2)
+      retriable (>= 2.9, < 4.0)
+      samvera-nesting_indexer (~> 2.0)
+      select2-rails (~> 3.5)
+      signet
+      simple_form (~> 3.2, <= 3.5.0)
+      tinymce-rails (~> 4.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -66,21 +119,21 @@ GEM
       io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.0.0)
+    autoprefixer-rails (9.1.1)
       execjs
     awesome_nested_set (3.1.4)
       activerecord (>= 4.0.0, < 5.3)
     aws-eventstream (1.0.1)
-    aws-partitions (1.96.0)
+    aws-partitions (1.97.0)
     aws-sdk-codedeploy (1.6.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-core (3.22.1)
+    aws-sdk-core (3.24.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.6.0)
+    aws-sdk-kms (1.7.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
     aws-sdk-s3 (1.17.0)
@@ -113,7 +166,7 @@ GEM
       blacklight (~> 6.0)
       cancancan (~> 1.8)
       deprecation (~> 1.0)
-    blacklight-gallery (0.10.0)
+    blacklight-gallery (0.11.0)
       blacklight (~> 6.3)
       bootstrap-sass (~> 3.0)
       openseadragon (>= 0.2.0)
@@ -123,7 +176,7 @@ GEM
       sass (>= 3.3.4)
     bootstrap_form (2.7.0)
     breadcrumbs_on_rails (3.0.1)
-    browse-everything (0.16.0)
+    browse-everything (0.16.1)
       addressable (~> 2.5)
       aws-sdk-s3
       bootstrap-sass (~> 3.2)
@@ -131,6 +184,7 @@ GEM
       font-awesome-rails
       google-api-client (~> 0.21)
       google_drive (~> 2.1)
+      googleauth (= 0.6.2)
       rails (>= 4.2)
       ruby-box
       sass-rails
@@ -202,7 +256,7 @@ GEM
       dry-container (~> 0.2, >= 0.2.6)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
-    dry-struct (0.5.0)
+    dry-struct (0.5.1)
       dry-core (~> 0.4, >= 0.4.3)
       dry-equalizer (~> 0.2)
       dry-types (~> 0.13)
@@ -321,54 +375,7 @@ GEM
       hydra-file_characterization (~> 0.3, >= 0.3.3)
       hydra-pcdm (>= 0.9)
       om (~> 3.1)
-    hyrax (2.1.0)
-      active-fedora (~> 11.5, >= 11.5.2)
-      almond-rails (~> 0.1)
-      awesome_nested_set (~> 3.1)
-      blacklight (~> 6.14)
-      blacklight-gallery (~> 0.7)
-      breadcrumbs_on_rails (~> 3.0)
-      browse-everything (>= 0.10.5)
-      carrierwave (~> 1.0)
-      clipboard-rails (~> 1.5)
-      dry-equalizer (~> 0.2)
-      dry-struct (~> 0.1)
-      dry-validation (~> 0.9)
-      flipflop (~> 2.3)
-      flot-rails (~> 0.0.6)
-      font-awesome-rails (~> 4.2)
-      hydra-derivatives (~> 3.3)
-      hydra-editor (>= 3.3, < 5.0)
-      hydra-head (>= 10.5.0)
-      hydra-works (~> 0.16)
-      iiif_manifest (>= 0.3, < 0.5)
-      jquery-datatables-rails (~> 3.4)
-      jquery-ui-rails (~> 6.0)
-      json-schema
-      kaminari_route_prefix (~> 0.1.1)
-      legato (~> 0.3)
-      linkeddata
-      mailboxer (~> 0.12)
-      nest (~> 3.1)
-      noid-rails (~> 3.0.0)
-      oauth
-      oauth2 (~> 1.2)
-      posix-spawn
-      power_converter (~> 0.1, >= 0.1.2)
-      pul_uv_rails (~> 2.0)
-      qa (~> 2.0)
-      rails (~> 5.0)
-      rails_autolink (~> 1.1)
-      rdf-rdfxml
-      redis-namespace (~> 1.5)
-      redlock (>= 0.1.2)
-      retriable (>= 2.9, < 4.0)
-      samvera-nesting_indexer (~> 2.0)
-      select2-rails (~> 3.5)
-      signet
-      simple_form (~> 3.2, <= 3.5.0)
-      tinymce-rails (~> 4.1)
-    i18n (1.0.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iiif_manifest (0.4.0)
@@ -478,9 +485,9 @@ GEM
       rails (>= 5.0.0)
     memoist (0.16.0)
     method_source (0.9.0)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2018.0812)
     mini_magick (4.8.0)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
@@ -634,7 +641,7 @@ GEM
       rdf (~> 3.0)
     redic (1.5.0)
       hiredis
-    redis (4.0.1)
+    redis (4.0.2)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
     redlock (0.2.2)
@@ -692,7 +699,7 @@ GEM
       json
       multipart-post
       oauth2
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
     samvera-nesting_indexer (2.0.0)
@@ -784,7 +791,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    tinymce-rails (4.8.0)
+    tinymce-rails (4.8.2)
       railties (>= 3.1.1)
     turbolinks (5.1.1)
       turbolinks-source (~> 5.1)
@@ -836,7 +843,7 @@ DEPENDENCIES
   fcrepo_wrapper
   hydra-editor (>= 4.0.2)
   hydra-role-management
-  hyrax (~> 2.1.0)
+  hyrax!
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -5,6 +5,10 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Hydra::AccessControlsEnforcement
   include Hyrax::SearchFilters
 
+  # Overrides private method Hyrax::FilterByType#models
+  def models
+    [Asset]
+  end
 
   ##
   # @example Adding a new step to the processor chain

--- a/spec/features/create_asset_with_digitalinstantiation_spec.rb
+++ b/spec/features/create_asset_with_digitalinstantiation_spec.rb
@@ -109,17 +109,13 @@ RSpec.feature 'Create and Validate Asset,Digital Instantiation, EssenseTrack', j
 
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
 
-
       click_on('Save & Create Digital Instantiation')
 
       expect(page).to have_content 'Add New Digital Instantiation', wait: 5
 
-      #show all fields groups
-      sleep(5)
       # TODO: Why do we need to call this twice?
       disable_collapse
       disable_collapse
-
 
       attach_file('Digital instantiation pbcore xml', File.absolute_path(digital_instantiation_attributes[:pbcore_xml_doc]))
       fill_in('Location', with: digital_instantiation_attributes[:location])
@@ -137,50 +133,15 @@ RSpec.feature 'Create and Validate Asset,Digital Instantiation, EssenseTrack', j
       choose('digital_instantiation_visibility_open')
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
 
+      click_link "Relationships" # define adminset relation
+      find("#digital_instantiation_admin_set_id option[value='#{admin_set_id}']").select_option
+
       click_on('Save')
+      # Wait for the DigitalInstantiation to be saved
+      Timeout::timeout(10) { DigitalInstantiation.where(title: digital_instantiation_attributes[:title]).first }
 
-      wait_for(10) { DigitalInstantiation.where(title: digital_instantiation_attributes[:title]).first }
-
-      visit '/'
-      find("#search-submit-header").click
-
-      within('#facets') do
-        # Filter resources types
-        click_on('Type')
-        click_on('Asset')
-      end
-
-      # Expect metadata for Asset to be displayed on the search results page.
-      expect(page).to have_content main_title
-
-      # open asset with detail show
-      click_on main_title
-      wait_for(5)
-
-      expect(page).to have_content asset_attributes[:spatial_coverage]
-      expect(page).to have_content asset_attributes[:temporal_coverage]
-      expect(page).to have_content asset_attributes[:audience_level]
-      expect(page).to have_content asset_attributes[:audience_rating]
-      expect(page).to have_content asset_attributes[:annotation]
-      expect(page).to have_content asset_attributes[:rights_summary]
-      expect(page).to have_current_path(guid_regex)
-      
-
-      visit '/'
-      find("#search-submit-header").click
-
-      # expect digital instantiation is showing up
+      # Expect page to have the main_title as the DigitalInstantiation's title.
       expect(page).to have_content digital_instantiation_attributes[:main_title]
-
-      within('#facets', wait: 5) do
-        # Filter resources types
-        click_on('Type')
-        click_on('Digital Instantiation')
-      end
-
-      # open digital instantiation with detail show
-      click_on(main_title)
-      expect(page).to have_content main_title
       expect(page).to have_content digital_instantiation_attributes[:location]
       expect(page).to have_content pbcore_xml_doc.digital.value
       expect(page).to have_content pbcore_xml_doc.media_type.value


### PR DESCRIPTION
* Modifies SearchBuilder#models to only return Asset model.
* Temporarily tells Gemfile to fetch Hyrax from WGBH-MLA/hyrax fork in Github.
  Once the patch to Hyrax is backported to 2.x and published, we can fetch Hyrax
  from rubygems.org again.

Also,
  * Fixes Create Asset with Digital Instantiation spec.