### PR TITLE
Updates Asset model

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -50,6 +50,9 @@ class Asset < ActiveFedora::Base
     self[:admin_data_gid] = new_admin_data.gid
   end
 
+  # TODO: Use RDF::Vocab for applicable terms.
+  # See https://github.com/ruby-rdf/rdf-vocab/tree/develop/lib/rdf/vocab
+
   property :asset_types, predicate: ::RDF::URI.new("http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasType"), multiple: true do |index|
     index.as :stored_searchable, :facetable
   end
@@ -110,7 +113,7 @@ class Asset < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :pbs_nola_code, predicate: ::RDF::URI.new("http://id.loc.gov/ontologies/bibframe.html#p_code"), multiple: true do |index|
+  property :pbs_nola_code, predicate: ::RDF::Vocab::EBUCore.hasIdentifier, multiple: true do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/digital_instantiation.rb
+++ b/app/models/digital_instantiation.rb
@@ -22,6 +22,8 @@ class DigitalInstantiation < ActiveFedora::Base
   validates :location, presence: { message: 'Your work must have a Location.' }
   validates :digital_format, presence: { message: 'Your work must have a Digital Format.' }
   validates :media_type, presence: { message: 'Your work must have a Media Type.' }
+  validates :duration, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for duration. Use HH:MM:SS, H:MM:SS, MM:SS, or M:SS" }
+  validates :time_start, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for time start. Use HH:MM:SS, H:MM:SS, MM:SS, or M:SS" }
 
   def pbcore_validate_instantiation_xsd
     if digital_instantiation_pbcore_xml.file
@@ -34,7 +36,7 @@ class DigitalInstantiation < ActiveFedora::Base
       errors.add(:digital_instantiation_pbcore_xml,"Please select pbcore xml document")
     end
   end
-  
+
   property :date, predicate: ::RDF::URI.new("http://purl.org/dc/terms/date"), multiple: true, index_to_parent: true do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/models/essence_track.rb
+++ b/app/models/essence_track.rb
@@ -9,6 +9,8 @@ class EssenceTrack < ActiveFedora::Base
 
   validates :track_type, presence: { message: 'Your work must have track type.' }
   validates :track_id, presence: { message: 'Your work must have track ID.' }
+  validates :duration, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for duration. Use HH:MM:SS, H:MM:SS, MM:SS, M:SS, or HH:MM:SS" }
+  validates :time_start, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for time start. Use HH:MM:SS, H:MM:SS, MM:SS, MM:SS or HH::MM::SS;FF" }
 
   property :track_type, predicate: ::RDF::URI.new("http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#trackType"), multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/physical_instantiation.rb
+++ b/app/models/physical_instantiation.rb
@@ -11,6 +11,8 @@ class PhysicalInstantiation < ActiveFedora::Base
   validates :format, presence: { message: 'Your work must have a format.' }
   validates :location, presence: { message: 'Your work must have a location.' }
   validates :media_type, presence: { message: 'Your work must have a media type.' }
+  validates :duration, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for duration. Use HH:MM:SS, H:MM:SS, MM:SS, or M:SS" }
+  validates :time_start, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for time start. Use HH:MM:SS, H:MM:SS, MM:SS, or M:SS" }
 
 
   property :date, predicate: ::RDF::URI.new("http://purl.org/dc/terms/date"), multiple: true, index_to_parent: true do |index|

--- a/app/services/ams/time_code_service.rb
+++ b/app/services/ams/time_code_service.rb
@@ -1,0 +1,13 @@
+module AMS
+  module TimeCodeService
+    class << self
+      def regex
+        Regexp.new regex_for_html
+      end
+
+      def regex_for_html
+        '\A(\d+:\d\d:\d\d|\d\d?:\d\d)(\.\d+)?\z'
+      end
+    end
+  end
+end

--- a/app/views/records/edit_fields/_dimensions.html.erb
+++ b/app/views/records/edit_fields/_dimensions.html.erb
@@ -1,1 +1,1 @@
-<%= f.input :dimensions, input_html: { type: 'number' }, required: f.object.required?(key), disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key) %>
+<%= f.input :dimensions, required: f.object.required?(key), disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key) %>

--- a/app/views/records/edit_fields/_duration.html.erb
+++ b/app/views/records/edit_fields/_duration.html.erb
@@ -1,1 +1,2 @@
-<%= f.input :duration, input_html: { type: 'number'} , required: f.object.required?(key), disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key) %>
+<!-- The pattern matches HH:MM:SS, H:MM:SS, MM:SS, or M:SS  -->
+<%= f.input :duration, input_html: { pattern: AMS::TimeCodeService.regex_for_html } , required: f.object.required?(key), disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key) %>

--- a/app/views/records/edit_fields/_time_start.html.erb
+++ b/app/views/records/edit_fields/_time_start.html.erb
@@ -1,0 +1,2 @@
+<!-- The pattern matches HH:MM:SS, H:MM:SS, MM:SS, or M:SS  -->
+<%= f.input :time_start, input_html: { pattern: AMS::TimeCodeService.regex_for_html } , required: f.object.required?(key), disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key) %>

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -5,285 +5,50 @@ require 'rails_helper'
 RSpec.describe Asset do
   let(:asset) { build(:asset) }
 
-  describe "#title" do
-    it "returns the title" do
-      asset.title = ["Test title 1","Test title 2"]
-      expect(asset.resource.dump(:ttl)).to match(/terms\/title/)
-      expect(asset.title.include?("Test title 1")).to be true
-    end
-  end
+  context 'properties' do
 
-  describe "#asset_types" do
-    it "returns the asset_types" do
-      asset.asset_types = ["Clip","Album"]
-      expect(asset.resource.dump(:ttl)).to match(/ebucore\/ebucore#hasType/)
-      expect(asset.asset_types.include?("Clip")).to be true
-    end
-  end
+    subject { build :asset }
 
-  describe "#genre" do
-    it "returns the genre" do
-      asset.genre = ["Debate","Documentary"]
-      expect(asset.resource.dump(:ttl)).to match(/ebucore\/ebucore#hasGenre/)
-      expect(asset.genre.include?("Debate")).to be true
-    end
-  end
-
-  describe "#date" do
-    it "returns the date" do
-      asset.date = ["2001-11-01"]
-      expect(asset.resource.dump(:ttl)).to match(/terms\/date/)
-      expect(asset.date.include?("2001-11-01")).to be true
-    end
-  end
-
-  describe "#broadcast_date" do
-    it "returns the broadcast_date" do
-      asset.broadcast_date = ["2021-11-01"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasBroadcastDate/)
-      expect(asset.broadcast_date.include?("2021-11-01")).to be true
-    end
-  end
-
-  describe "#created_date" do
-    it "returns the created_date" do
-      asset.created_date = ["2011-11-01"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasCreatedDate/)
-      expect(asset.created_date.include?("2011-11-01")).to be true
-    end
-  end
-
-  describe "#copyright_date" do
-    it "returns the copyright_date" do
-      asset.copyright_date = ["1866-11-01"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasCopyrightDate/)
-      expect(asset.copyright_date.include?("1866-11-01")).to be true
-    end
-  end
-
-  describe "#episode_number" do
-    it "returns the episode_number" do
-      asset.episode_number = ["SSPE12"]
-      expect(asset.resource.dump(:ttl)).to match(/ebucore\/ebucore#episodeNumber/)
-      expect(asset.episode_number.include?("SSPE12")).to be true
-    end
-  end
-
-  describe "#spatial_coverage" do
-    it "returns the spatial_coverage" do
-      asset.spatial_coverage = ["Test Coverage"]
-      expect(asset.resource.dump(:ttl)).to match(/terms\/coverage/)
-      expect(asset.spatial_coverage.include?("Test Coverage")).to be true
-    end
-  end
-
-  describe "#temporal_coverage" do
-    it "returns the temporal_coverage" do
-      asset.temporal_coverage = ["Test temporal Coverage"]
-      expect(asset.resource.dump(:ttl)).to match(/bibframe.html#p_temporalCoverage/)
-      expect(asset.temporal_coverage.include?("Test temporal Coverage")).to be true
-    end
-  end
-
-  describe "#audience_level" do
-    it "returns the audience_level" do
-      asset.audience_level = ["Test audience_level"]
-      expect(asset.resource.dump(:ttl)).to match(/ebucore\/ebucore#hasTargetAudience/)
-      expect(asset.audience_level.include?("Test audience_level")).to be true
-    end
-  end
-
-  describe "#audience_rating" do
-    it "returns the audience_rating" do
-      asset.audience_rating = ["Test Rating"]
-      expect(asset.resource.dump(:ttl)).to match(/ebucore\/index.html#Type/)
-      expect(asset.audience_rating.include?("Test Rating")).to be true
-    end
-  end
-
-  describe "#annotation" do
-    it "returns the annotation" do
-      asset.annotation = ["Test annotation"]
-      expect(asset.resource.dump(:ttl)).to match(/skos\/core#note/)
-      expect(asset.annotation.include?("Test annotation")).to be true
-    end
-  end
-
-  describe "#rights_summary" do
-    it "returns the rights_summary" do
-      asset.rights_summary = ["Test rights_summary"]
-      expect(asset.resource.dump(:ttl)).to match(/elements\/1.1\/rights/)
-      expect(asset.rights_summary.include?("Test rights_summary")).to be true
-    end
-  end
-
-  describe "#rights_link" do
-    it "returns the rights_link" do
-      asset.rights_link = ["Test rights_link"]
-      expect(asset.resource.dump(:ttl)).to match(/europeana.eu\/rights/)
-      expect(asset.rights_link.include?("Test rights_link")).to be true
-    end
-  end
-
-  describe "#local_identifier" do
-    it "returns the local_identifier" do
-      asset.local_identifier = ["Test local_identifier"]
-      expect(asset.resource.dump(:ttl)).to match(/identifiers\/local/)
-      expect(asset.local_identifier.include?("Test local_identifier")).to be true
-    end
-  end
-
-  describe "#pbs_nola_code" do
-    it "returns the pbs_nola_code" do
-      asset.pbs_nola_code = ["Test pbs_nola_code"]
-      expect(asset.resource.dump(:ttl)).to match(/bibframe.html\#p_code/)
-      expect(asset.pbs_nola_code.include?("Test pbs_nola_code")).to be true
-    end
-  end
-
-  describe "#eidr_id" do
-    it "returns the eidr_id" do
-      asset.eidr_id = ["Test eidr_id"]
-      expect(asset.resource.dump(:ttl)).to match(/2002\/07\/owl#sameAs/)
-      expect(asset.eidr_id.include?("Test eidr_id")).to be true
-    end
-  end
-
-  describe "#topics" do
-    it "returns the topics" do
-      asset.topics = ["Test topics"]
-      expect(asset.resource.dump(:ttl)).to match(/ebucore\/ebucore#hasKeyword/)
-      expect(asset.topics.include?("Test topics")).to be true
-    end
-  end
-
-  describe "#subject" do
-    it "returns the subject" do
-      asset.subject = ["Test subject"]
-      expect(asset.resource.dump(:ttl)).to match(/elements\/1.1\/subject/)
-      expect(asset.subject.include?("Test subject")).to be true
-    end
-  end
-
-  describe "#program_title" do
-    it "returns the program_title" do
-      asset.program_title = ["Test program_title"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasProgramTitle/)
-      expect(asset.program_title.include?("Test program_title")).to be true
-    end
-  end
-
-  describe "#episode_title" do
-    it "returns the episode_title" do
-      asset.episode_title = ["Test episode_title"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasEpisodeTitle/)
-      expect(asset.episode_title.include?("Test episode_title")).to be true
-    end
-  end
-
-  describe "#segment_title" do
-    it "returns the segment_title" do
-      asset.segment_title = ["Test segment_title"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasSegmentTitle/)
-      expect(asset.segment_title.include?("Test segment_title")).to be true
-    end
-  end
-
-  describe "#raw_footage_title" do
-    it "returns the raw_footage_title" do
-      asset.raw_footage_title = ["Test raw_footage_title"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasRawFootageTitle/)
-      expect(asset.raw_footage_title.include?("Test raw_footage_title")).to be true
-    end
-  end
-
-  describe "#promo_title" do
-    it "returns the promo_title" do
-      asset.promo_title = ["Test promo_title"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasPromoTitle/)
-      expect(asset.promo_title.include?("Test promo_title")).to be true
-    end
-  end
-
-  describe "#clip_title" do
-    it "returns the clip_title" do
-      asset.clip_title = ["Test clip_title"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasClipTitle/)
-      expect(asset.clip_title.include?("Test clip_title")).to be true
-    end
-  end
-
-  describe "#program_description" do
-    it "returns the program_description" do
-      asset.program_description = ["Test program_description"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasProgramDescription/)
-      expect(asset.program_description.include?("Test program_description")).to be true
-    end
-  end
-
-  describe "#episode_description" do
-    it "returns the episode_description" do
-      asset.episode_description = ["Test episode_description"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasEpisodeDescription/)
-      expect(asset.episode_description.include?("Test episode_description")).to be true
-    end
-  end
-
-  describe "#segment_description" do
-    it "returns the segment_description" do
-      asset.segment_description = ["Test segment_description"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasSegmentDescription/)
-      expect(asset.segment_description.include?("Test segment_description")).to be true
-    end
-  end
-
-  describe "#raw_footage_description" do
-    it "returns the raw_footage_description" do
-      asset.raw_footage_description = ["Test raw_footage_description"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasRawFootageDescription/)
-      expect(asset.raw_footage_description.include?("Test raw_footage_description")).to be true
-    end
-  end
-
-  describe "#promo_description" do
-    it "returns the promo_description" do
-      asset.promo_description = ["Test promo_description"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasPromoDescription/)
-      expect(asset.promo_description.include?("Test promo_description")).to be true
-    end
-  end
-
-  describe "#clip_description" do
-    it "returns the clip_description" do
-      asset.clip_description = ["Test clip_description"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasClipDescription/)
-      expect(asset.clip_description.include?("Test clip_description")).to be true
-    end
-  end
-
-  context "clip_description" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has clip_description" do
-      asset.clip_description = ["Test clip_description"]
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasClipDescription/)
-      expect(asset.clip_description.include?("Test clip_description")).to be true
-    end
-    end
-
-  context "producing_organization" do
-    let(:asset) { FactoryBot.build(:asset) }
-    it "has producing_organization" do
-      asset.clip_description = ["Test producing_organization"]
-      expect(asset.resource.dump(:ttl)).to match(Regexp.new(Regexp.escape('http://purl.org/dc/elements/1.1/creator')))
-      expect(asset.clip_description.include?("Test producing_organization")).to be true
-    end
+    it { is_expected.to have_property(:title).with_predicate(::RDF::Vocab::DC.title) }
+    it { is_expected.to have_property(:asset_types).with_predicate(::RDF::Vocab::EBUCore.hasType) }
+    it { is_expected.to have_property(:genre).with_predicate(::RDF::Vocab::EBUCore.hasGenre) }
+    it { is_expected.to have_property(:date).with_predicate(::RDF::Vocab::DC.date) }
+    it { is_expected.to have_property(:broadcast_date).with_predicate('http://pbcore.org#hasBroadcastDate') }
+    it { is_expected.to have_property(:created_date).with_predicate('http://pbcore.org#hasCreatedDate') }
+    it { is_expected.to have_property(:copyright_date).with_predicate('http://pbcore.org#hasCopyrightDate') }
+    it { is_expected.to have_property(:episode_number).with_predicate(::RDF::Vocab::EBUCore.episodeNumber) }
+    it { is_expected.to have_property(:spatial_coverage).with_predicate(::RDF::Vocab::DC.coverage) }
+    it { is_expected.to have_property(:temporal_coverage).with_predicate('http://id.loc.gov/ontologies/bibframe.html#p_temporalCoverage') }
+    it { is_expected.to have_property(:audience_level).with_predicate(::RDF::Vocab::EBUCore.hasTargetAudience) }
+    it { is_expected.to have_property(:audience_rating).with_predicate('https://www.ebu.ch/metadata/ontologies/ebucore/index.html#Type') }
+    it { is_expected.to have_property(:annotation).with_predicate(::RDF::Vocab::SKOS.note) }
+    it { is_expected.to have_property(:rights_summary).with_predicate(::RDF::Vocab::DC11.rights) }
+    it { is_expected.to have_property(:rights_link).with_predicate('http://www.europeana.eu/rights') }
+    it { is_expected.to have_property(:local_identifier).with_predicate('http://id.loc.gov/vocabulary/identifiers/local') }
+    it { is_expected.to have_property(:pbs_nola_code).with_predicate(::RDF::Vocab::EBUCore.hasIdentifier) }
+    it { is_expected.to have_property(:eidr_id).with_predicate('https://www.w3.org/2002/07/owl#sameAs') }
+    it { is_expected.to have_property(:topics).with_predicate(::RDF::Vocab::EBUCore.hasKeyword) }
+    it { is_expected.to have_property(:subject).with_predicate(::RDF::Vocab::DC11.subject) }
+    it { is_expected.to have_property(:program_title).with_predicate('http://pbcore.org#hasProgramTitle') }
+    it { is_expected.to have_property(:episode_title).with_predicate('http://pbcore.org#hasEpisodeTitle') }
+    it { is_expected.to have_property(:segment_title).with_predicate('http://pbcore.org#hasSegmentTitle') }
+    it { is_expected.to have_property(:raw_footage_title).with_predicate('http://pbcore.org#hasRawFootageTitle') }
+    it { is_expected.to have_property(:promo_title).with_predicate('http://pbcore.org#hasPromoTitle') }
+    it { is_expected.to have_property(:clip_title).with_predicate('http://pbcore.org#hasClipTitle') }
+    it { is_expected.to have_property(:program_description).with_predicate('http://pbcore.org#hasProgramDescription') }
+    it { is_expected.to have_property(:episode_description).with_predicate('http://pbcore.org#hasEpisodeDescription') }
+    it { is_expected.to have_property(:segment_description).with_predicate('http://pbcore.org#hasSegmentDescription') }
+    it { is_expected.to have_property(:raw_footage_description).with_predicate('http://pbcore.org#hasRawFootageDescription') }
+    it { is_expected.to have_property(:promo_description).with_predicate('http://pbcore.org#hasPromoDescription') }
+    it { is_expected.to have_property(:clip_description).with_predicate('http://pbcore.org#hasClipDescription') }
+    it { is_expected.to have_property(:producing_organization).with_predicate(::RDF::Vocab::DC11.creator) }
   end
 
   context "admin_data_gid" do
     let(:admin_data) { FactoryBot.create(:admin_data) }
     let(:asset) { FactoryBot.build(:asset, with_admin_data:admin_data.gid) }
     it "has admin_data_gid" do
-      expect(asset.resource.dump(:ttl)).to match(/pbcore.org#hasAAPBAdminData/)
+      expect(asset).to have_property(:admin_data_gid).with_predicate(/pbcore.org#hasAAPBAdminData/)
       expect(asset.admin_data_gid).to eq(admin_data.gid)
     end
     it "has throws ActiveRecord::RecordNotFound if cannot find admin_data for the gid" do

--- a/spec/services/ams/duration_service_spec.rb
+++ b/spec/services/ams/duration_service_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe AMS::TimeCodeService do
+  let(:regex) { AMS::TimeCodeService.regex }
+
+  describe '.regex_for_html' do
+    let(:regex_for_html) { AMS::TimeCodeService.regex_for_html }
+
+    it 'returns the string equivalent of the regular expression for use in HTML5 pattern attribute' do
+      expect(Regexp.new(regex_for_html)).to eq regex
+    end
+
+    it 'is not the same things as calling #regex.to_s (which is invalid syntax for HTML5 pattern attribute)' do
+      expect(regex_for_html).to_not eq regex.to_s
+    end
+  end
+
+  describe 'regex' do
+    def valid_formats
+      @valid_formats ||= %w(
+        1:23
+        1:23.4
+        1:23.45
+        1:23.456
+        12:34
+        12:34.5
+        12:34.56
+        12:34.567
+        1:23:45
+        1:23:45.6
+        1:23:45.67
+        1:23:45.678
+        12:34:56
+        12:34:56.7
+        12:34:56.78
+        12:34:56.789
+        123:45:67
+        123:45:67.8
+        123:45:67.89
+        123:45:67.890
+      )
+    end
+
+    def invalid_formats
+      @invalid_formats ||= %w(
+        1
+        12
+        12.3
+        12.34
+        12.345
+        1:2
+        1:2.3
+        1:2.34
+        1:2.345
+        12:3
+        12:3.4
+        12:3.45
+        12:3.456
+        1:23:4
+        1:23:4.5
+        1:23:4.56
+        1:23:4.567
+        1:2:34
+        1:2:34.5
+        1:2:34.56
+        1:2:34.567
+        :1
+        :12
+        :12.3
+        :12.34
+        :12.345
+        :12:34
+        :12:34.5
+        :12:34.56
+        :12:34.567
+        :2:34
+        :2:34.5
+        :2:34.56
+        :2:34.567
+      )
+    end
+
+    it 'returns a Regexp object' do
+      expect(regex).to be_a Regexp
+    end
+
+    it 'matches variations on the HH::MM:SS.SSS format for a time duration' do
+      valid_formats.each do |valid_format|
+        expect(valid_format).to match regex
+      end
+    end
+
+    it 'does not match invalid variations on duration' do
+      invalid_formats.each do |invalid_format|
+        expect(invalid_format).to_not match regex
+      end
+    end
+  end
+end

--- a/spec/support/have_propety_matcher.rb
+++ b/spec/support/have_propety_matcher.rb
@@ -1,0 +1,63 @@
+# Helper methods for the have_property matcher defined below.
+# These helpers keep the matcher itself cleaner.
+module HavePropertyHelpers
+  def has_property?(model, property_name)
+    model.send(:properties).key? property_name.to_s
+  end
+
+  def has_predicate?(model, property_name, compare_predicate)
+    if has_property?(model, property_name)
+      predicate = model.send(:properties)[property_name.to_s].predicate
+      if compare_predicate.is_a? Regexp
+        return !!(predicate =~ compare_predicate)
+      else
+        return predicate == compare_predicate
+      end
+    end
+    false
+  end
+
+  def get_failure_message(model, property_name, predicate: nil)
+    if !has_property?(model, property_name)
+      "expected #{model} to have property: '#{property_name}'"
+    elsif predicate && !has_predicate?(model, property_name, predicate)
+      "expected #{model} property '#{property_name}' to have predicate: '#{predicate}'"
+    end
+  end
+
+  def get_negated_failure_message(model, property_name, predicate: nil)
+    if predicate && has_predicate?(model, property_name, predicate)
+      "expected #{model} property '#{property_name}' to not have predicate: '#{predicate}'"
+    elsif has_property?(model, property_name)
+      "expected #{model} to not have property: '#{property_name}''"
+    end
+  end
+
+  def object_is_not_af_model_error(obj)
+    ArgumentError.new("the 'have_property' matcher only works for " \
+                      "instances of ActiveFedora::Base, not #{obj.class}")
+  end
+end
+
+# Custom RSpec matcher for ActiveFedora model instances.
+# Usage:
+#   expect(model).to have_property :title
+#   expect(model).to have_property :title, predicate: ::RDF::Vocab::DC.title
+#   expect(model).to have_property :title, predicate: "http://purl.org/dc/terms/title"
+#   expect(model).to have_property :title, predicate: /purl\.org\/dc.*title/
+RSpec::Matchers.define :have_property do |property_name|
+  include HavePropertyHelpers
+  match do |model|
+    raise object_is_not_af_model_error(model) unless model.is_a? ActiveFedora::Base
+    pass = has_property?(model, property_name)
+    pass &= has_predicate?(model, property_name, @predicate) if @predicate
+    pass
+  end
+
+  # Allows you to chain a .with_predicate() matcher.
+  # Example: expect(model).to have_propety(:title).with_predicate(::RDF::Vocab::DC.title)
+  chain(:with_predicate) { |predicate| @predicate = predicate }
+
+  failure_message { |model| get_failure_message(model, property_name, predicate: @predicate) }
+  failure_message_when_negated { |model| get_negated_failure_message(model, property_name, predicate: @predicate) }
+end


### PR DESCRIPTION
* Changes predicate for PBS Nola Code to EBUCore hasIdentifier.
* Changes input validation for Duration fields.
* Changes input type for Dimensions fields.
* Adds a DurationService to ensure consistency with validation by regex.

Also,
  * Adds a custom matcher for checking properties and predicates of ActiveFedora models.
  * Refactors Asset model test to use new factor (cuts back on a lot of loc).

Closes AMS2-393.