### PR TITLE
AMS2-489 adds csv export and minor fixes

### DIFF
--- a/app/assets/stylesheets/global/search_results.css
+++ b/app/assets/stylesheets/global/search_results.css
@@ -1,6 +1,14 @@
 div.facets h3 {
   font-size: 1.3em;
 }
-a.advanced_search {
-    margin-left:2px !important;
+
+.search-form .form-control {
+    height: 35px;
+}
+.search-form a.advanced_search {
+    margin: 0 !important;
+    border-left: 0;
+}
+.search-form .input-group-btn .scope_select {
+    border-radius: 0;
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -6,12 +6,14 @@ class CatalogController < ApplicationController
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show
 
+  add_results_collection_tool :export_search_results
+
 
 
   configure_blacklight do |config|
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
-    # config.advanced_search[:qt] ||= 'advanced'
+    #config.advanced_search[:qt] ||= 'advanced'
     config.advanced_search[:url_key] ||= 'advanced'
     config.advanced_search[:query_parser] ||= 'dismax'
     config.advanced_search[:form_solr_parameters] ||= {}
@@ -480,5 +482,12 @@ class CatalogController < ApplicationController
   # this method is not called in that context.
   def render_bookmarks_control?
     false
+  end
+
+  def export
+    search_params = params
+    search_params.delete :page
+    response, response_documents = search_results(search_params)
+    @documents = response_documents
   end
 end

--- a/app/models/ams/csv_export_extension.rb
+++ b/app/models/ams/csv_export_extension.rb
@@ -1,0 +1,33 @@
+module AMS
+  module CsvExportExtension
+    CSV_FIELDS = {:GUID=>:id,:Title=>:title,:dates=>:all_dates,:producing_organization=>:producing_organization,
+                  :description=>:description,:level_of_user_access=>:level_of_user_access,:minimally_cataloged=>:minimally_cataloged,
+                  :holding_organization =>:holding_organization_ssim}.freeze
+
+    def self.get_csv_header
+      return CSV.generate do |csv|
+        header_row = []
+        CSV_FIELDS.each do |label,responder|
+          header_row << label
+        end
+        csv << header_row
+      end
+    end
+
+    def self.extended(document)
+      document.will_export_as(:csv, "application/csv")
+    end
+
+    def export_as_csv
+      return CSV.generate do |csv|
+        row = []
+        CSV_FIELDS.each do |csv_field,responder|
+          val = self.send(responder)
+          val = val.join("; ") if val.class == Array
+          row << val
+        end
+        csv << row
+      end
+    end
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -14,6 +14,8 @@ class SolrDocument
   # SMS uses the semantic field mappings below to generate the body of an SMS email.
   SolrDocument.use_extension(Blacklight::Document::Sms)
 
+  SolrDocument.use_extension(AMS::CsvExportExtension)
+
   # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document
   # Semantic mappings of solr stored fields. Fields may be multi or
   # single valued. See Blacklight::Document::SemanticFields#field_semantics
@@ -281,6 +283,13 @@ class SolrDocument
     self[Solrizer.solr_name('clip_description')]
   end
 
+  def all_dates
+    concatenated_dates = [date,
+                          broadcast_date,
+                          created_date,
+                          copyright_date].flatten.select(&:present?).join('; ')
+  end
+
   def date
     self[Solrizer.solr_name('date')]
   end
@@ -299,7 +308,11 @@ class SolrDocument
 
   def holding_organization
     self[Solrizer.solr_name('holding_organization')]
-    end
+  end
+
+  def holding_organization_ssim
+    self[Solrizer.solr_name('holding_organization','ssim')]
+  end
 
   def affiliation
     self[Solrizer.solr_name('affiliation')]

--- a/app/search_builders/ams/search_builder.rb
+++ b/app/search_builders/ams/search_builder.rb
@@ -3,7 +3,7 @@ module AMS
     include BlacklightAdvancedSearch::AdvancedSearchBuilder
 
     # Add date filters to the processor chain.
-    self.default_processor_chain += [:apply_date_filter,:add_advanced_parse_q_to_solr]
+    self.default_processor_chain += [:apply_date_filter,:add_advanced_parse_q_to_solr,:add_advanced_search_to_solr]
 
     # Overrides Hyrax::FilterModels.
     def models

--- a/app/views/catalog/_export_search_results.html.erb
+++ b/app/views/catalog/_export_search_results.html.erb
@@ -1,0 +1,10 @@
+<!-- Single button -->
+<div class="btn-group">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    Export <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu">
+    <li><%= link_to("CSV",catalog_export_path({:format=>"csv"}.merge(search_state.to_h))) %></li>
+    <li><%= link_to("PBCore XML",catalog_export_path({:format=>"pbcore"}.merge(search_state.to_h))) %></li>
+  </ul>
+</div>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -23,7 +23,7 @@
         <%= t('hyrax.search.button.html') %>
       </button>
       <% if current_user %>
-        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
+        <button class="btn btn-default dropdown-toggle scope_select" type="button" data-toggle="dropdown" aria-expanded="false">
 
           <span class="sr-only" data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
           <span aria-hidden="true"><%= t("hyrax.search.form.option.all.label_short") %></span>

--- a/app/views/catalog/export.csv.erb
+++ b/app/views/catalog/export.csv.erb
@@ -1,0 +1,1 @@
+<%= AMS::CsvExportExtension.get_csv_header %><% @documents.each { |d| %><%= d.export_as_csv.html_safe %> <% } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     concerns :searchable
   end
 
+  get 'catalog_export', to: 'catalog#export'
+
   mount Hydra::RoleManagement::Engine => '/'
 
   devise_for :users


### PR DESCRIPTION
1. Adds download dropdown widget to blacklight `catalog` controller , partial redirect user to download action
2. Adds `catalog_export` route
3. Adds `export` method to `catalog` controller
4. Fixes advance search by adding `:add_advanced_search_to_solr` to `AMS::SearchBuilder`
5. Fixes css for search bar

![screen shot 2018-10-05 at 6 23 10 pm](https://user-images.githubusercontent.com/230291/46537850-c55e2d80-c8cb-11e8-8aba-0f0441f75563.png)
