### PR TITLE
Add space to Asset Type id 

### DIFF
--- a/config/authorities/asset_types.yml
+++ b/config/authorities/asset_types.yml
@@ -11,7 +11,7 @@ terms:
     term: Program
   - id: Promo
     term: Promo
-  - id: RawFootage
+  - id: Raw Footage
     term: Raw Footage
   - id: Segment
     term: Segment

--- a/config/authorities/format.yml
+++ b/config/authorities/format.yml
@@ -39,10 +39,14 @@ terms:
     term: DVCPRO
   - id: DVD
     term: DVD
-  - id: "Film: 16mm"
-    term: "Film: 16mm"
-  - id: "Film: 35mm"
-    term: "Film: 35mm"
+  - id: >
+      Film: 16mm
+    term: >
+      Film: 16mm
+  - id: >
+      Film: 35mm
+    term: >
+      Film: 35mm
   - id: HDCAM
     term: HDCAM
   - id: Hi8


### PR DESCRIPTION
Some edit.s to controlled vocabularies, including avoiding quotation marks and adding spaces to ids, where we missed that before