### PR TITLE
663 Unique PBCore Factory Data

### DIFF
--- a/spec/factories/pbcore_xml/instantiation/date.rb
+++ b/spec/factories/pbcore_xml/instantiation/date.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     skip_create
 
     type { Faker::Types.rb_string }
-    value { Faker::Date.backward(14) }
+    value { Faker::Date.unique.backward(14) }
 
     trait :digitized do
       type { "Digitized" }

--- a/spec/factories/pbcore_xml/instantiation/date.rb
+++ b/spec/factories/pbcore_xml/instantiation/date.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     skip_create
 
     type { Faker::Types.rb_string }
-    value { Faker::Date.unique.backward(14) }
+    value { Faker::Date.unique.backward(300) }
 
     trait :digitized do
       type { "Digitized" }

--- a/spec/factories/pbcore_xml/pbcore_description.rb
+++ b/spec/factories/pbcore_xml/pbcore_description.rb
@@ -4,7 +4,8 @@ FactoryBot.define do
   factory :pbcore_description, class: PBCore::Description, parent: :pbcore_element do
     skip_create
 
-    value { rand(10000).to_s + Faker::HitchhikersGuideToTheGalaxy.quote }
+    # Uses Digest to ensure the values are unique.
+    value { Digest::SHA1.hexdigest([Time.now, rand].join)[0..10] + Faker::HitchhikersGuideToTheGalaxy.quote }
 
     initialize_with { new(attributes) }
   end

--- a/spec/factories/pbcore_xml/pbcore_title.rb
+++ b/spec/factories/pbcore_xml/pbcore_title.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
   factory :pbcore_title, class: PBCore::Title, parent: :pbcore_element do
     skip_create
 
-    value { Faker::Book.title }
+    value { Faker::Book.unique.title }
 
     initialize_with { new(attributes) }
   end

--- a/spec/services/aapb/batch_ingest/zipped_pbcore_reader_spec.rb
+++ b/spec/services/aapb/batch_ingest/zipped_pbcore_reader_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 require 'zip'
 require 'hyrax/batch_ingest/spec/shared_specs'
+require 'aapb/batch_ingest/zipped_pbcore_reader'
 
 RSpec.describe AAPB::BatchIngest::ZippedPBCoreReader do
   let(:reader_class) { described_class }


### PR DESCRIPTION
I think this should keep the data unique to fix the intermittent errors from the xpath spec helper.