### PR TITLE
Saves EssenceTracks in batch PBCore XML ingest

### DIFF
--- a/app/actors/hyrax/actors/digital_instantiation_actor.rb
+++ b/app/actors/hyrax/actors/digital_instantiation_actor.rb
@@ -95,7 +95,7 @@ module Hyrax
               e[:bit_depth] = track.bit_depth.value if track.bit_depth
               e[:frame_height] = parse_frame_height(track.frame_size.value) if track.frame_size
               e[:frame_width] = parse_frame_width(track.frame_size.value) if track.frame_size
-              e[:aspect_ratio] = Array(track.aspect_ratio.value) if track.aspect_ratio
+              e[:aspect_ratio] = track.aspect_ratio.value if track.aspect_ratio
               e[:duration] = track.duration.value if track.duration
               e[:annotation] =  track.annotations.map(&:value) if track.annotations
               e[:admin_set_id] = env.curation_concern.admin_set_id

--- a/app/models/essence_track.rb
+++ b/app/models/essence_track.rb
@@ -65,7 +65,7 @@ class EssenceTrack < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :aspect_ratio, predicate: ::RDF::URI.new("http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#aspectRatio"), multiple: true do |index|
+  property :aspect_ratio, predicate: ::RDF::URI.new("http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#aspectRatio"), multiple: false do |index|
     index.as :stored_searchable
   end
 

--- a/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
@@ -9,15 +9,14 @@ module AAPB
         if batch_item_is_asset?
           batch_item_object = ingest_asset!
 
-          if has_digital_instantiations?
-            xml_for_digital_instantiations.each do |xml_for_digital_instantiation|
-              ingest_digital_instantiation!(parent_asset: batch_item_object, xml: xml_for_digital_instantiation)
-            end
+          pbcore_digital_instantiations.each do |pbcore_digital_instantiation|
+            ingest_digital_instantiation!(parent: batch_item_object, xml: pbcore_digital_instantiation.to_xml)
           end
 
-          if has_physical_instantiations?
-            xml_for_physical_instantiations.each do |xml_for_physical_instantiation|
-              ingest_physical_instantiation!(parent_asset: batch_item_object, xml: xml_for_physical_instantiation)
+          pbcore_physical_instantiations.each do |pbcore_physical_instantiation|
+            physical_instantiation = ingest_physical_instantiation!(parent: batch_item_object, xml: pbcore_physical_instantiation.to_xml)
+            pbcore_physical_instantiation.essence_tracks.each do |pbcore_essence_track|
+              ingest_essence_track!(parent: physical_instantiation, xml: pbcore_essence_track.to_xml)
             end
           end
         elsif batch_item_is_digital_instantiation?
@@ -33,14 +32,6 @@ module AAPB
 
       private
 
-        def has_digital_instantiations?
-          pbcore.instantiations.any? { |inst| inst.digital }
-        end
-
-        def has_physical_instantiations?
-          pbcore.instantiations.any? { |inst| inst.physical }
-        end
-
         def batch_item_is_asset?
           pbcore_xml =~ /pbcoreDescriptionDocument/
         end
@@ -49,12 +40,12 @@ module AAPB
           pbcore_xml =~ /pbcoreInstantiationDocument/
         end
 
-        def xml_for_digital_instantiations
-          pbcore.instantiations.select { |inst| inst.digital }.map(&:to_xml)
+        def pbcore_digital_instantiations
+          pbcore.instantiations.select { |inst| inst.digital }
         end
 
-        def xml_for_physical_instantiations
-          pbcore.instantiations.select { |inst| inst.physical }.map(&:to_xml)
+        def pbcore_physical_instantiations
+          pbcore.instantiations.select { |inst| inst.physical }
         end
 
         def ingest_asset!
@@ -66,33 +57,44 @@ module AAPB
           asset
         end
 
-        def ingest_digital_instantiation!(parent_asset:, xml:)
+        def ingest_digital_instantiation!(parent:, xml:)
           digital_instantiation = DigitalInstantiation.new
           digital_instantiation.skip_file_upload_validation = true
           actor = Hyrax::CurationConcern.actor
           attrs = {
             pbcore_xml: xml,
-            in_works_ids: [parent_asset.id]
+            in_works_ids: [parent.id]
           }
           env = Hyrax::Actors::Environment.new(digital_instantiation, current_ability, attrs)
           actor.create(env)
           # reload the parent so that the children show up in the .members
           # accessor
-          parent_asset.reload
+          parent.reload
           digital_instantiation
         end
 
-        def ingest_physical_instantiation!(parent_asset:, xml:)
+        def ingest_physical_instantiation!(parent:, xml:)
           physical_instantiation = PhysicalInstantiation.new
           actor = Hyrax::CurationConcern.actor
           attrs = AAPB::BatchIngest::PBCoreXMLMapper.new(xml).physical_instantiation_attributes
-          attrs[:in_works_ids] = [parent_asset.id]
+          attrs[:in_works_ids] = [parent.id]
           env = Hyrax::Actors::Environment.new(physical_instantiation, current_ability, attrs)
           actor.create(env)
           # reload the parent so that the children show up in the .members
           # accessor
-          parent_asset.reload
+          parent.reload
           physical_instantiation
+        end
+
+        def ingest_essence_track!(parent:, xml:)
+          essence_track = EssenceTrack.new
+          actor = Hyrax::CurationConcern.actor
+          attrs = AAPB::BatchIngest::PBCoreXMLMapper.new(xml).essence_track_attributes
+          attrs[:in_works_ids] = [parent.id]
+          env = Hyrax::Actors::Environment.new(essence_track, current_ability, attrs)
+          actor.create(env)
+          parent.reload
+          essence_track
         end
 
         def current_ability

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -111,7 +111,7 @@ module AAPB
           attrs[:aspect_ratio] = pbcore.aspect_ratio.value if pbcore.aspect_ratio
           attrs[:time_start] = pbcore.time_start.value if pbcore.time_start
           attrs[:duration] = pbcore.duration.value if pbcore.duration
-          attrs[:annotations] = pbcore.annotations.map(&:value) if pbcore.annotations
+          attrs[:annotation] = pbcore.annotations.map(&:value) if pbcore.annotations
         end
       end
 

--- a/spec/factories/pbcore_xml/instantiation/essence_track/time_start.rb
+++ b/spec/factories/pbcore_xml/instantiation/essence_track/time_start.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :pbcore_instantiation_essence_track_time_start, class: PBCore::Instantiation::EssenceTrack::TimeStart, parent: :pbcore_element do
     skip_create
 
-    value { Time.now.strftime( "%H:%M:%S") + ":00" }
+    value { Time.now.strftime( "%H:%M:%S") + '.' + rand(1..999).to_s }
 
     initialize_with { new(attributes) }
   end

--- a/spec/models/essence_track_spec.rb
+++ b/spec/models/essence_track_spec.rb
@@ -3,158 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe EssenceTrack do
+  subject { build(:essence_track) }
 
-  context "title" do
-    let(:contribution) { FactoryBot.build(:contribution) }
-    it "has title" do
-      contribution.title = ["Test title 1","Test title 2"]
-      expect(contribution.resource.dump(:ttl)).to match(/terms\/title/)
-      expect(contribution.title.include?("Test title 1")).to be true
-    end
-  end
-
-  context "track_type" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has track_type" do
-      essence_track.track_type = "Test track_type"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#trackType/)
-      expect(essence_track.track_type.include?("Test track_type")).to be true
-    end
-  end
-
-  context "track_id" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has track_id" do
-      essence_track.track_id = ["Test track_id"]
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#trackName/)
-      expect(essence_track.track_id.include?("Test track_id")).to be true
-    end
-  end
-
-  context "standard" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has standard" do
-      essence_track.standard = "Test standard"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#hasStandard/)
-      expect(essence_track.standard.include?("Test standard")).to be true
-    end
-  end
-
-  context "encoding" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has encoding" do
-      essence_track.encoding = "Test encoding"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#hasEncodingFormat/)
-      expect(essence_track.encoding.include?("Test encoding")).to be true
-    end
-  end
-
-  context "data_rate" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has data_rate" do
-      essence_track.data_rate = "Test data_rate"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#bitRate/)
-      expect(essence_track.data_rate.include?("Test data_rate")).to be true
-    end
-  end
-
-  context "frame_rate" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has frame_rate" do
-      essence_track.frame_rate = "Test frame_rate"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#frameRate/)
-      expect(essence_track.frame_rate.include?("Test frame_rate")).to be true
-    end
-  end
-
-  context "playback_speed" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has playback_speed" do
-      essence_track.playback_speed = "24"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#playbackSpeed/)
-      expect(essence_track.playback_speed).to eq "24"
-    end
-  end
-
-  context "playback_speed_units" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has playback_speed_units" do
-      essence_track.playback_speed_units = "fps"
-      expect(essence_track.resource.dump(:ttl)).to match(/pbcore\.org#hasPlaybackSpeedUnits/)
-      expect(essence_track.playback_speed_units).to eq "fps"
-    end
-  end
-
-  context "sample_rate" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has sample_rate" do
-      essence_track.sample_rate = "Test sample_rate"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#sampleRate/)
-      expect(essence_track.sample_rate.include?("Test sample_rate")).to be true
-    end
-  end
-
-  context "bit_depth" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has bit_depth" do
-      essence_track.bit_depth = "Test bit_depth"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#bitDepth/)
-      expect(essence_track.bit_depth.include?("Test bit_depth")).to be true
-    end
-  end
-
-  context "frame_width" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has frame_width" do
-      essence_track.frame_width = "Test frame_width"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#frameWidth/)
-      expect(essence_track.frame_width.include?("Test frame_width")).to be true
-    end
-  end
-
-  context "frame_height" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has frame_height" do
-      essence_track.frame_height = "Test frame_height"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#frameHeight/)
-      expect(essence_track.frame_height.include?("Test frame_height")).to be true
-    end
-  end
-
-  context "aspect_ratio" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has aspect_ratio" do
-      essence_track.aspect_ratio = ["Test aspect_ratio"]
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#aspectRatio/)
-      expect(essence_track.aspect_ratio.include?("Test aspect_ratio")).to be true
-    end
-  end
-
-  context "time_start" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has time_start" do
-      essence_track.time_start = "Test time_start"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#start/)
-      expect(essence_track.time_start.include?("Test time_start")).to be true
-    end
-  end
-
-  context "duration" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has duration" do
-      essence_track.duration = "Test duration"
-      expect(essence_track.resource.dump(:ttl)).to match(/ebucore#duration/)
-      expect(essence_track.duration.include?("Test duration")).to be true
-    end
-  end
-
-  context "annotation" do
-    let(:essence_track) { FactoryBot.build(:essence_track) }
-    it "has annotation" do
-      essence_track.annotation = ["Test annotation"]
-      expect(essence_track.resource.dump(:ttl)).to match(/skos\/core#note/)
-      expect(essence_track.annotation.include?("Test annotation")).to be true
-    end
-  end
-
+  it { is_expected.to have_property(:track_type) }
+  it { is_expected.to have_property(:track_id) }
+  it { is_expected.to have_property(:standard) }
+  it { is_expected.to have_property(:encoding) }
+  it { is_expected.to have_property(:data_rate) }
+  it { is_expected.to have_property(:frame_rate) }
+  it { is_expected.to have_property(:playback_speed) }
+  it { is_expected.to have_property(:playback_speed_units) }
+  it { is_expected.to have_property(:sample_rate) }
+  it { is_expected.to have_property(:bit_depth) }
+  it { is_expected.to have_property(:frame_width) }
+  it { is_expected.to have_property(:frame_height) }
+  it { is_expected.to have_property(:aspect_ratio) }
+  it { is_expected.to have_property(:time_start) }
+  it { is_expected.to have_property(:duration) }
+  it { is_expected.to have_property(:annotation) }
 end

--- a/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
+++ b/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLMapper, :pbcore_xpath_helper do
       expect(essence_track_attributes[:aspect_ratio]).to eq pbcore_values_from_xpath(pbcore_xml, :ess_aspect_ratio).first
       expect(essence_track_attributes[:time_start]).to eq pbcore_values_from_xpath(pbcore_xml, :ess_time_start).first
       expect(essence_track_attributes[:duration]).to eq pbcore_values_from_xpath(pbcore_xml, :ess_duration).first
-      expect(essence_track_attributes[:annotations]).to eq pbcore_values_from_xpath(pbcore_xml, :ess_annotations)
+      expect(essence_track_attributes[:annotation]).to eq pbcore_values_from_xpath(pbcore_xml, :ess_annotations)
     end
   end
 end


### PR DESCRIPTION
Modifies PBCoreXMLItemIngester to save EssenceTrack records for
PhysicalInstantiations and DigitalInstantiations.

NOTE: EssenceTrack PBCore metadata for DigitalInstantiations is mapped within
the DigitalInstantiationActor, but for Physical Instantiations, it's mapped
using the PBCoreXMLMapper within the PBCoreXMLItemIngester, and each
Essence Tracks is added one at a time to it's parent.

Also,
* Includes slight refactor of PBCoreXMLItemIngester.
* Fixes cardinality issue with aspect ratio in Essence Track records; was
  multiple, should be single-valued.
* Fixes mapping of PBCore xml annotations; was mapping to 'annotations'
  but should map to 'annotation'
* Fixes bug in factories re: date formats; was generating hh::mm::ss:xyz but
  should be hh::mm::ss.xyz (seconds use decimal for fractions, not a colon).