### PR TITLE
Uses REDIS_SERVER for redis host

### DIFF
--- a/lib/ams.rb
+++ b/lib/ams.rb
@@ -62,7 +62,7 @@ module AMS
       end
 
       def flush_redis_cache!
-        Redis.new(port: '6379').flushall
+        Redis.new(host: ENV.fetch('REDIS_SERVER', 'localhost'), port: '6379').flushall
       end
 
 

--- a/spec/features/admin/admin_sets/add_userrole_as_viewer_spec.rb
+++ b/spec/features/admin/admin_sets/add_userrole_as_viewer_spec.rb
@@ -40,6 +40,7 @@ RSpec.feature 'AssignRoleViewer.', js: true do
 
       # Check other user viewer search permissions exist
       visit '/admin/admin_sets'
+      sleep 5
       expect(page).to have_content 'You are not authorized to access this page.'
     end
   end


### PR DESCRIPTION
In production environments, the Redis server is set in an env var. Use that first
and default to localhost if it's not there.