### PR TITLE
Installs gems without deployment or test groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ group :development, :test do
   gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry-rails'
   gem 'capybara-screenshot'
-  gem 'database_cleaner'
   gem 'rspec', "~> 3.7"
   gem 'rspec-rails', "~> 3.7"
   gem 'rspec-activemodel-mocks'
@@ -94,3 +93,4 @@ gem 'hyrax-iiif_av', '>= 0.2.0'
 gem 'webpacker'
 gem 'react-rails'
 gem 'faker'
+gem 'database_cleaner'

--- a/bin/deploy/install.sh
+++ b/bin/deploy/install.sh
@@ -6,7 +6,7 @@ echo "Running Deployment for ID: $DEPLOYMENT_ID"
 export APP_HOME=/var/www/ams
 sudo chown -R ec2-user:ec2-user $APP_HOME
 cd $APP_HOME
-bundle install --deployment
+bundle install --deployment --without development test
 echo "ruby version:`ruby -v`"
 echo "rails versions:`bundle exec rails -v`"
 echo "node version:`node -v`"


### PR DESCRIPTION
This is generally a good idea, but necessary because Spring was running in
prodution and causing a weird multi-inclusion error.

Also adds database_cleaner to the production bundle so we can use the
ams:reset_data rake task in production environments, i.e. on Edge server.