### PR TITLE
Sets eager_load to true for Production env

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,7 +17,7 @@ config.webpacker.check_yarn_integrity = false
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
   # Rake tasks automatically ignore this option for performance.
-  config.eager_load = false
+  config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false


### PR DESCRIPTION
This is to avoid an issue of the hyrax-batch_ingest gem calling const_get from within
a job that is being executed in parallel; for some reason, it hangs indefinitely in
a Sidekiq 'busy' state.