### PR TITLE
Adds new migration from batch ingest gem

### DIFF
--- a/db/migrate/20190307145823_change_source_data_to_text.hyrax_batch_ingest.rb
+++ b/db/migrate/20190307145823_change_source_data_to_text.hyrax_batch_ingest.rb
@@ -1,0 +1,6 @@
+# This migration comes from hyrax_batch_ingest (originally 20190124222733)
+class ChangeSourceDataToText < ActiveRecord::Migration[5.1]
+  def change
+    change_column :hyrax_batch_ingest_batch_items, :source_data, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190129160128) do
+ActiveRecord::Schema.define(version: 20190307145823) do
 
   create_table "admin_data", force: :cascade do |t|
     t.string "level_of_user_access"
@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 20190129160128) do
   create_table "hyrax_batch_ingest_batch_items", force: :cascade do |t|
     t.integer "batch_id"
     t.string "id_within_batch"
-    t.string "source_data"
+    t.text "source_data"
     t.string "source_location"
     t.string "status"
     t.text "error"


### PR DESCRIPTION
New migration changes hyrax_batch_ingest_batch_items.source_data field from
varchar to text because it needs to be able to hold more data.