### PR TITLE
Use stateless ID minter for new AAPB ID

### DIFF
--- a/app/models/ams/identifier_service.rb
+++ b/app/models/ams/identifier_service.rb
@@ -1,0 +1,27 @@
+require 'securerandom'
+
+module AMS
+  module IdentifierService
+    ID_PREFIX = "cpb-aacip-"
+
+    def self.mint
+      begin
+        new_id = ID_PREFIX + SecureRandom.uuid.tr('-', '').slice(0, 11)
+      end until usable_id? new_id
+      new_id
+    end
+
+    def self.usable_id?(id)
+      return false unless id
+      !!!ActiveFedora::SolrService.query("id:#{id}", rows: 1).first
+    end
+
+    private
+
+      ## This overrides the default behavior, which is to ask Fedora for an id
+      # @see ActiveFedora::Persistence.assign_id
+      def assign_id
+        AMS::IdentifierService.mint
+      end
+  end
+end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,9 +1,7 @@
-# Generated via
-#  `rails generate hyrax:work Asset`
 class Asset < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::AMS::CreateMemberMethods
-
+  include ::AMS::IdentifierService
 
   self.indexer = AssetIndexer
   before_save :save_admin_data

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -2,6 +2,7 @@
 #  `rails generate hyrax:work Contribution`
 class Contribution < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include ::AMS::IdentifierService
 
   self.indexer = ContributionIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/digital_instantiation.rb
+++ b/app/models/digital_instantiation.rb
@@ -6,6 +6,7 @@ class DigitalInstantiation < ActiveFedora::Base
 
   include ::Hyrax::WorkBehavior
   include ::AMS::CreateMemberMethods
+  include ::AMS::IdentifierService
 
   extend CarrierWave::Mount
   before_save :save_instantiation_admin_data

--- a/app/models/essence_track.rb
+++ b/app/models/essence_track.rb
@@ -2,6 +2,7 @@
 #  `rails generate hyrax:work EssenceTrack`
 class EssenceTrack < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include ::AMS::IdentifierService
 
   self.indexer = EssenceTrackIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/physical_instantiation.rb
+++ b/app/models/physical_instantiation.rb
@@ -3,6 +3,7 @@
 class PhysicalInstantiation < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::AMS::CreateMemberMethods
+  include ::AMS::IdentifierService
 
   self.indexer = PhysicalInstantiationIndexer
   # Change this to restrict which works can be added as a child.

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -74,10 +74,10 @@ Hyrax.config do |config|
 
   # Hyrax uses NOIDs for files and collections instead of Fedora UUIDs
   # where NOID = 10-character string and UUID = 32-character string w/ hyphens
-  config.enable_noids = true
+  config.enable_noids = false
 
   # Template for your repository's NOID IDs
-  config.noid_template = "cpb-aacip_600-.reedeedeedk"
+  # config.noid_template = "cpb-aacip_600-.reedeedeedk"
 
   # Use the database-backed minter class
   # config.noid_minter_class = ActiveFedora::Noid::Minter::Db

--- a/lib/ams.rb
+++ b/lib/ams.rb
@@ -29,7 +29,9 @@ module AMS
       logger.info "Data reset complete in #{time.round(3)} seconds"
     end
 
-    private
+    def seeds; Seed; end
+
+    # private
 
       def fedora_status
         response = ActiveFedora.fedora.connection.head(ActiveFedora.fedora.base_uri)

--- a/spec/support/guid.rb
+++ b/spec/support/guid.rb
@@ -1,6 +1,10 @@
 module GuidHelpers
   def guid_regex
-    /cpb-aacip_600-[0-9b-z][0-9b-z][0-9][0-9b-z][0-9b-z][0-9][0-9b-z][0-9b-z][0-9][0-9b-z]/i
+    # Regex for verifying valid ID format of...
+    # 1. "cpb-aacip-" prefix (required)
+    # 2. 1-3 digit number, followed by dash (optional)
+    # 3. 6+ digit number (required)
+    /cpb-aacip-(\d{1,3}\-)?[0-9a-z]{6,}/i
   end
 end
 


### PR DESCRIPTION
We were running into issues in deployed environments with our stateful minter,
which requires providing concurrent access to a single persistence layer where
the minter state is stored. Our IDs are random, and we don't have a use case for
"replaying" the minting of them, so we can switch to a stateless minter and
avoid the persistence layer requirement, and associated headaches.

Our stateless minter replaces NOID, and is just the first 12 chars of a UUID
with the constant prefix "cpb-aacip-" prepended to it.

For every ID minted, we do a lookup in Solr to see if the ID exists yet, and if
it does, we regenerate a new random ID.

Also...
* Provides an accessor to AMS.seeds, for manually creating seed data. This has
  proen useful more than once in development, so added it in.