### PR TITLE
Fix Bracket Issue For Admin Data Fields

### DIFF
--- a/app/assets/javascripts/global/datepicker.js
+++ b/app/assets/javascripts/global/datepicker.js
@@ -20,4 +20,3 @@ $( document ).on('turbolinks:load', function() {
         });
     }
 });
-

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -34,7 +34,12 @@ module AAPB
           admindata_field_names.each do |field_name|
             field_name = 'minimally_cataloged' if field_name == 'cataloging status'
             field_name = 'special_collection' if field_name == 'special_collections'
-            attrs[:"#{field_name.gsub(" ", '_')}"] = admindata[field_name] if admindata[field_name]
+
+            value = admindata[field_name]
+            # handle arrays for single-value fields
+            value = value.first if value && ['special_collections','sonyci_id'].exclude?(field_name)
+
+            attrs[:"#{field_name.gsub(" ", '_')}"] = value if value
           end
 
           # Saves Asset with AAPB ID if present

--- a/app/views/hyrax/assets/_aapb_admindata.html.erb
+++ b/app/views/hyrax/assets/_aapb_admindata.html.erb
@@ -6,7 +6,7 @@
     <div class="collapse" id="collapse-<%= t('.aapb_admin').parameterize.underscore %>">
       <div class="well">
         <dl>
-
+          
           <!-- TODO fix bracket issue for admindata -->
           <%= presenter.attribute_to_html(:level_of_user_access, html_dl: true) %>
           <%= presenter.attribute_to_html(:minimally_cataloged, html_dl: true) %>


### PR DESCRIPTION
Fixes bracket issue for admindata fields.

Admin data handling in `pbcore_xml_mapper` did not account for single- versus multi-value fields. Now, it do.