### PR TITLE
All BatchItems have correct 'ID within batch'

### DIFF
--- a/app/jobs/cool_physical_job.rb
+++ b/app/jobs/cool_physical_job.rb
@@ -9,7 +9,7 @@ class CoolPhysicalJob < Hyrax::BatchIngest::BatchItemProcessingJob
     pbcore_physical = PBCore::Instantiation.parse(xml)
     # fire these off while we have em
     pbcore_physical.essence_tracks.each do |ess_track|
-      et_batch_item = Hyrax::BatchIngest::BatchItem.create!(batch: batch_item.batch, status: 'initialized')
+      et_batch_item = Hyrax::BatchIngest::BatchItem.create!(batch: batch_item.batch, status: 'initialized', id_within_batch: batch_item.id_within_batch)
       CoolEssenceJob.perform_later(parent_id: physical_inst.id, xml: ess_track.to_xml, batch_item: et_batch_item)
     end
     # Need to set @work to the ingested PhysicalInstantiation in order for

--- a/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
@@ -18,12 +18,12 @@ module AAPB
           raise "Batch item contained invalid data.\n\n#{batch_item_object.errors.to_a.join("\n")}" if batch_item_object.errors.count > 0
 
           pbcore_digital_instantiations.each do |pbcore_digital_instantiation|
-            di_batch_item = Hyrax::BatchIngest::BatchItem.create!(batch: batch_item.batch, status: 'initialized')
+            di_batch_item = Hyrax::BatchIngest::BatchItem.create!(batch: batch_item.batch, status: 'initialized', id_within_batch: batch_item.id_within_batch)
             CoolDigitalJob.perform_later(parent_id: batch_item_object.id, xml: pbcore_digital_instantiation.to_xml, batch_item: di_batch_item)
           end
 
           pbcore_physical_instantiations.each do |pbcore_physical_instantiation|
-            pi_batch_item = Hyrax::BatchIngest::BatchItem.create!(batch: batch_item.batch, status: 'initialized')
+            pi_batch_item = Hyrax::BatchIngest::BatchItem.create!(batch: batch_item.batch, status: 'initialized', id_within_batch: batch_item.id_within_batch)
             CoolPhysicalJob.perform_later(parent_id: batch_item_object.id, xml: pbcore_physical_instantiation.to_xml, batch_item: pi_batch_item)
           end
         elsif batch_item_is_digital_instantiation?

--- a/spec/support/deposit_helpers.rb
+++ b/spec/support/deposit_helpers.rb
@@ -1,0 +1,24 @@
+module DepositHelpers
+    # Creates the apparatus needed for depositing/ingesting things.
+    # This doesn't memoize anything, but it can be used within a :let if you
+    # want to memoize.
+    # @return [Array<User,AdminSet>] A 2-element array consisting of the
+    #  factory-generated User and AdminSet instances.
+    def create_user_and_admin_set_for_deposit
+      admin_set = FactoryBot.create(:admin_set)
+      user_role = "TestRole#{rand.to_s[2..5]}"
+      user = FactoryBot.create(:user, role_names: [user_role])
+      permission_template = FactoryBot.create(:permission_template, source_id: admin_set.id)
+      permission_template_access = FactoryBot.create(
+        :permission_template_access,
+        permission_template: permission_template,
+        agent_id: user_role,
+        agent_type: 'group',
+        access: 'deposit'
+      )
+      # Return the user and the admin set.
+      [user, admin_set]
+    end
+end
+
+RSpec.configure { |c| c.include DepositHelpers }


### PR DESCRIPTION
For 'AAPB PBCore Zipped' ingests, BatchItems created after the initial reading
of the batch were not receiving any value for 'ID within batch', which is the
filename within the zipped batch. This ensures those additonal batch items
have the right filename in that field.

Also,
  * Small refactor of test for AAPB PBCore Zipped ingest a bit for readability.