### PR TITLE
Check for errors

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -86,6 +86,7 @@ module Hyrax
                 if param_contributor[:id].blank?
                   param_contributor.delete(:id)
                   contributor = ::Contribution.new
+
                   if actor.create(Actors::Environment.new(contributor, env.current_ability, param_contributor))
                     env.curation_concern.ordered_members << contributor
                     env.curation_concern.save

--- a/db/schema.test.rb
+++ b/db/schema.test.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190417205747) do
+ActiveRecord::Schema.define(version: 20190506173217) do
 
   create_table "admin_data", force: :cascade do |t|
     t.string "level_of_user_access"
@@ -145,6 +145,7 @@ ActiveRecord::Schema.define(version: 20190417205747) do
     t.string "repo_object_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "repo_object_class_name"
     t.index ["batch_id"], name: "index_hyrax_batch_ingest_batch_items_on_batch_id"
   end
 

--- a/spec/services/aapb/batch_ingest/pbcore_xml_item_ingester_spec.rb
+++ b/spec/services/aapb/batch_ingest/pbcore_xml_item_ingester_spec.rb
@@ -87,13 +87,15 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLItemIngester, reset_data: false do
       before :all do
         # Build the PBCore XML
         pbcore_xml = FactoryBot.build(:pbcore_instantiation_document, :media_info).to_xml
-
-        asset = create(:asset, id: "123456")
+        submitter = create(:user)
+        asset = build(:asset, id: "123456")
+        asset.apply_depositor_metadata(submitter)
+        asset.save!
 
         # Use the PBCore XML as the source data for a BatchItem.
         batch_item = build(
           :batch_item,
-          batch: build(:batch, submitter_email: create(:user).email),
+          batch: build(:batch, submitter_email: submitter.email),
           id_within_batch: "sample_digital_instantiation.xml",
           source_location: File.join(fixture_path, "batch_ingest", "sample_pbcore_digital_instantiation", "digital_instantiation_manifest.xlsx"),
           source_data: pbcore_xml


### PR DESCRIPTION
#292

Adds method (`check_for_errors`) for each AMS model to surface validation errors and raise an exception.