### PR TITLE
Remove rescue clause that doesn't work

### DIFF
--- a/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
@@ -68,8 +68,6 @@ module AAPB
           env = Hyrax::Actors::Environment.new(asset, current_ability, attrs)
           raise_ingest_errors(asset) unless actor.create(env)
           asset
-        rescue => e
-          raise_ingest_failure()
         end
 
         def ingest_digital_instiation_and_manifest!


### PR DESCRIPTION
this is just leftover cruft from an implementation that never happened.