### PR TITLE
Fixes some ingest formatting and error reporting

### DIFF
--- a/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
@@ -55,8 +55,12 @@ module AAPB
         end
 
         def raise_ingest_errors(object)
-          msg = object.errors.values.join('; ')
-          msg = "An unknown error occurred during ingest of #{object.class}" if msg.empty?
+          msg = "Error on #{object.class.model_name.human}: "
+          unless object.errors.empty?
+            msg += object.errors.messages.map { |field, msg| "#{field} #{msg.join(', ')}"}.join('; ')
+          else
+            msg += 'unknown error'
+          end
           raise msg
         end
 

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -103,7 +103,7 @@ module AAPB
 
           attrs[:subject]                     = pbcore.subjects.map(&:value)
 
-          creator_orgs, creator_people        = pbcore.creators.partition { |pbcreator| pbcreator.role.value == 'Producing Organization' }
+          creator_orgs, creator_people        = pbcore.creators.partition { |pbcreator| pbcreator.role&.value == 'Producing Organization' }
           all_people = pbcore.contributors + pbcore.publishers + creator_people
           attrs[:contributors]                = people_attributes(all_people)
           attrs[:producing_organization]      = creator_orgs.map {|co| co.creator.value}
@@ -118,12 +118,13 @@ module AAPB
       end
 
       def aapb_id
-        @aapb_id ||= pbcore.identifiers.select { |id|
-            id.source == "http://americanarchiveinventory.org"}.map(&:value).first
+        @aapb_id ||= pbcore.identifiers.select do |id|
+          id.source == "http://americanarchiveinventory.org"
+        end.map(&:value).first
       end
 
       def normalized_aapb_id(id)
-        id.gsub('cpb-aacip/', 'cpb-aacip_') if id
+        id.gsub('cpb-aacip/', 'cpb-aacip-') if id
       end
 
       def people_attributes(people)
@@ -177,6 +178,7 @@ module AAPB
           attrs[:generations]                     = pbcore.generations.map(&:value)
           attrs[:time_start]                      = pbcore.time_starts.map(&:value)
           attrs[:duration]                        = pbcore.duration&.value
+          attrs[:duration].gsub!('?', '')
           attrs[:colors]                          = pbcore.colors&.value
           attrs[:rights_summary]                  = pbcore.rights.map(&:rights_summary).map(&:value)
           attrs[:rights_link]                     = pbcore.rights.map(&:rights_link).map(&:value)
@@ -209,7 +211,7 @@ module AAPB
           attrs[:frame_height] = frame_height
           attrs[:aspect_ratio] = pbcore.aspect_ratio.value if pbcore.aspect_ratio
           attrs[:time_start] = pbcore.time_start.value if pbcore.time_start
-          attrs[:duration] = pbcore.duration.value if pbcore.duration
+          attrs[:duration] = pbcore.duration.value.gsub('?', '') if pbcore.duration
           attrs[:annotation] = pbcore.annotations.map(&:value) if pbcore.annotations
         end
       end


### PR DESCRIPTION
* Ensures that tranlated AAPB IDs will be prefixed with cpb-aacip- rather than
  cpb-aacip_ (i.e dash rather than underscore) which is consistent with newly
  generated AAPB-style IDs.
* Cleans out errant trailing question mark in duration values; relic from AMS1.
* Outputs object and field names when raising validation errors.