### PR TITLE
Destroys child Works when Parent is deleted

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -14,6 +14,13 @@ class Asset < ActiveFedora::Base
     value.each { |val|  record.errors.add(attr, "invalid date format: #{val}") if AMS::NonExactDateService.invalid?(val) }
   end
 
+  after_destroy do
+    ordered_members.to_a.each do |ordered_member|
+      ordered_member.destroy if ordered_member.class.in? [ PhysicalInstantiation, DigitalInstantiation, Contribution ]
+    end
+    admin_data.destroy if admin_data_gid
+  end
+
   def at_least_one_title
     all_titles = title.to_a
     all_titles += program_title.to_a

--- a/app/models/digital_instantiation.rb
+++ b/app/models/digital_instantiation.rb
@@ -30,6 +30,12 @@ class DigitalInstantiation < ActiveFedora::Base
   validates :duration, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for duration. Use HH:MM:SS, H:MM:SS, MM:SS, or M:SS" }
   validates :time_start, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for time start. Use HH:MM:SS, H:MM:SS, MM:SS, or M:SS" }
 
+  after_destroy do
+    ordered_members.to_a.each do |ordered_member|
+      ordered_member.destroy if ordered_member.class.in? [ EssenceTrack, Contribution ]
+    end
+  end
+
   def pbcore_validate_instantiation_xsd
     if digital_instantiation_pbcore_xml.file
       schema = Nokogiri::XML::Schema(File.read(Rails.root.join('spec', 'fixtures', 'pbcore-2.1.xsd')))

--- a/app/models/physical_instantiation.rb
+++ b/app/models/physical_instantiation.rb
@@ -24,6 +24,12 @@ class PhysicalInstantiation < ActiveFedora::Base
     end
   end
 
+  after_destroy do
+    ordered_members.to_a.each do |ordered_member|
+      ordered_member.destroy if ordered_member.class.in? [ EssenceTrack, Contribution ]
+    end
+  end
+
 
 
   property :date, predicate: ::RDF::URI.new("http://purl.org/dc/terms/date"), multiple: true, index_to_parent: true do |index|

--- a/spec/factories/asset.rb
+++ b/spec/factories/asset.rb
@@ -43,6 +43,10 @@ FactoryBot.define do
       # Pass in an AdminSet instance, or an admin set id, for example
       # create(:asset, admin_set: create(:admin_set))
       admin_set { false }
+
+      # This is where you would set the Asset's PhysicalInstantiations,
+      # DigitalINstantiations, and/or Contributions
+      ordered_members { [] }
     end
 
     trait :public do
@@ -50,19 +54,19 @@ FactoryBot.define do
     end
 
     trait :with_physical_instantiation do
-      members { [create(:physical_instantiation)] }
+      ordered_members { [ create(:physical_instantiation) ] }
     end
 
     trait :with_digital_instantiation do
-      members { [create(:digital_instantiation)] }
+      ordered_members { [ create(:digital_instantiation) ] }
     end
 
     trait :with_digital_instantiation_and_essence_track do
-      members { [create(:digital_instantiation, :aapb_moving_image_with_essence_track)] }
+      ordered_members { [ create(:digital_instantiation, :aapb_moving_image_with_essence_track) ] }
     end
 
     trait :with_two_digital_instantiations_and_essence_tracks do
-      members { [
+      ordered_members { [
         create(:digital_instantiation, :aapb_moving_image_with_essence_track),
         create(:digital_instantiation, :aapb_moving_image_with_essence_track)
       ] }
@@ -83,9 +87,16 @@ FactoryBot.define do
         admin_data = create(:admin_data)
         work.admin_data_gid = admin_data.gid
       end
+
+      if evaluator.ordered_members
+        evaluator.ordered_members.each do |ordered_member|
+          work.ordered_members << ordered_member
+        end
+      end
     end
 
     after(:create) do |work, evaluator|
+      # TODO: don't think this is needed, since it's happening in after(:build)
       work.apply_depositor_metadata(evaluator.user.user_key)
       work.save!
     end

--- a/spec/factories/contribution.rb
+++ b/spec/factories/contribution.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :contribution do
-    sequence(:title) { |n| ["Test Admin Set #{n}"] }
     contributor  { ["Test Contributor"] }
     contributor_role  { "Actor" }
     portrayal  { "Test portrayal" }

--- a/spec/factories/digital_instantiation.rb
+++ b/spec/factories/digital_instantiation.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     trait :aapb_moving_image_with_essence_track do
       holding_organization { "American Archive of Public Broadcasting" }
       media_type { "Moving Image" }
-      members { [ create(:essence_track)] }
+      ordered_members { [ create(:essence_track)] }
     end
     trait :aapb_sound do
       holding_organization { "American Archive of Public Broadcasting" }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -107,4 +107,33 @@ RSpec.describe Asset do
       expect(asset.valid?).to be false
     end
   end
+
+  describe '#destroy' do
+    before do
+      @ordered_members = [
+        create_list(:digital_instantiation, rand(1..3)),
+        create_list(:physical_instantiation, rand(1..3)),
+        create(:contribution)
+      ].flatten
+
+      @asset = create(
+        :asset,
+        ordered_members: @ordered_members
+      )
+
+      # get the AdminData record to verify its destruction
+      @admin_data = @asset.admin_data
+
+      # Now destroy the Asset
+      @asset.destroy!
+    end
+
+    it 'destroys child PhysicalInstantiations, DigitalInstantiations, and associated AdminData' do
+      @ordered_members.each do |child|
+        expect { child.reload }.to raise_error ActiveFedora::ObjectNotFoundError
+      end
+
+      expect { @admin_data.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
 end

--- a/spec/models/digital_instantiation_spec.rb
+++ b/spec/models/digital_instantiation_spec.rb
@@ -195,4 +195,28 @@ RSpec.describe DigitalInstantiation do
       expect { digital_instantiation.instantiation_admin_data_gid = gid }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find InstantiationAdminData matching GID #{gid}")
     end
   end
+
+  describe '#destroy' do
+    before do
+      @ordered_members = [
+        create_list(:essence_track, rand(1..3)),
+        create_list(:contribution, rand(1..3))
+      ].flatten
+
+      # Create, with children
+      digtial_instantiation = create(
+        :digital_instantiation,
+        ordered_members: @ordered_members
+      )
+
+      # Now destroy what we've just created
+      digtial_instantiation.destroy!
+    end
+
+    it 'destroys child EssenceTracks and Contributions' do
+      @ordered_members.each do |child|
+        expect { child.reload }.to raise_error ActiveFedora::ObjectNotFoundError
+      end
+    end
+  end
 end

--- a/spec/models/physical_instantiation_spec.rb
+++ b/spec/models/physical_instantiation_spec.rb
@@ -173,4 +173,28 @@ RSpec.describe PhysicalInstantiation do
       expect(physical_instantiation.holding_organization.include?("Test holding_organization")).to be true
     end
   end
+
+  describe '#destroy' do
+    before do
+      @ordered_members = [
+        create_list(:essence_track, rand(1..3)),
+        create_list(:contribution, rand(1..3))
+      ].flatten
+
+      # Create, with children
+      physical_instantiation = create(
+        :physical_instantiation,
+        ordered_members: @ordered_members
+      )
+
+      # Now destroy what we've just created
+      physical_instantiation.destroy!
+    end
+
+    it 'destroys child EssenceTracks and Contributions' do
+      @ordered_members.each do |child|
+        expect { child.reload }.to raise_error ActiveFedora::ObjectNotFoundError
+      end
+    end
+  end
 end


### PR DESCRIPTION
The after_destroy hook is used for ActiveFedora models to destroy child object
after parent is destroyed. This effectively is a 'cascade' delete.

* Asset#destroy deletes PhysicalInstantiations, DigitalInstantiations,
  Contributions, and AdminData
* PhysicalInstantiation#destroy and DigitalInstantiation#destroy deletes
  Contributions and EssenceTracks

Also, updates factories to use ordered_members to be consistent with how models
are associated in the app.