### PR TITLE
Fix bug with cascade delete

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,15 @@ module ApplicationHelper
     # woo!
     params
   end
+
+  def display_date(date_time, format: '%Y-%m-%d', from_format: nil)
+    parsed_time = if from_format
+      Date.strptime(date_time, from_format)
+    else
+      Date.strptime(date_time)
+    end
+    parsed_time.strftime(format)
+  rescue => e
+    nil
+  end
 end

--- a/app/models/ams/cascade_destroy_members.rb
+++ b/app/models/ams/cascade_destroy_members.rb
@@ -1,0 +1,13 @@
+module AMS
+  module CascadeDestroyMembers
+    extend ActiveSupport::Concern
+
+    included do
+      after_destroy do
+        members.each do |member|
+          member.destroy!
+        end
+      end
+    end
+  end
+end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -2,6 +2,7 @@ class Asset < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::AMS::CreateMemberMethods
   include ::AMS::IdentifierService
+  include ::AMS::CascadeDestroyMembers
 
   self.indexer = AssetIndexer
   before_save :save_admin_data
@@ -15,9 +16,6 @@ class Asset < ActiveFedora::Base
   end
 
   after_destroy do
-    ordered_members.to_a.each do |ordered_member|
-      ordered_member.destroy if ordered_member.class.in? [ PhysicalInstantiation, DigitalInstantiation, Contribution ]
-    end
     admin_data.destroy if admin_data_gid
   end
 

--- a/app/models/digital_instantiation.rb
+++ b/app/models/digital_instantiation.rb
@@ -7,6 +7,7 @@ class DigitalInstantiation < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::AMS::CreateMemberMethods
   include ::AMS::IdentifierService
+  include ::AMS::CascadeDestroyMembers
 
   extend CarrierWave::Mount
   before_save :save_instantiation_admin_data
@@ -29,12 +30,6 @@ class DigitalInstantiation < ActiveFedora::Base
   validates :media_type, presence: { message: 'Your work must have a Media Type.' }
   validates :duration, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for duration. Use HH:MM:SS, H:MM:SS, MM:SS, or M:SS" }
   validates :time_start, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for time start. Use HH:MM:SS, H:MM:SS, MM:SS, or M:SS" }
-
-  after_destroy do
-    ordered_members.to_a.each do |ordered_member|
-      ordered_member.destroy if ordered_member.class.in? [ EssenceTrack, Contribution ]
-    end
-  end
 
   def pbcore_validate_instantiation_xsd
     if digital_instantiation_pbcore_xml.file

--- a/app/models/physical_instantiation.rb
+++ b/app/models/physical_instantiation.rb
@@ -4,6 +4,7 @@ class PhysicalInstantiation < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::AMS::CreateMemberMethods
   include ::AMS::IdentifierService
+  include ::AMS::CascadeDestroyMembers
 
   self.indexer = PhysicalInstantiationIndexer
   # Change this to restrict which works can be added as a child.
@@ -23,14 +24,6 @@ class PhysicalInstantiation < ActiveFedora::Base
       end
     end
   end
-
-  after_destroy do
-    ordered_members.to_a.each do |ordered_member|
-      ordered_member.destroy if ordered_member.class.in? [ EssenceTrack, Contribution ]
-    end
-  end
-
-
 
   property :date, predicate: ::RDF::URI.new("http://purl.org/dc/terms/date"), multiple: true, index_to_parent: true do |index|
     index.as :stored_searchable, :facetable

--- a/lib/ams/aapb_pbcore_zipped_batch_ingest_fixer.rb
+++ b/lib/ams/aapb_pbcore_zipped_batch_ingest_fixer.rb
@@ -1,0 +1,49 @@
+module AMS
+  class AAPBPBCoreZippedBatchIngestFixer
+    attr_reader :batch
+
+    def initialize(batch_id)
+      @batch = Hyrax::BatchIngest::Batch.find(batch_id)
+      raise ArgumentError, 'batch must be of type "aapb_pbcore_zipped"' unless @batch.ingest_type == 'aapb_pbcore_zipped'
+    end
+
+    def delete_parent_assets_of_failed_children
+      parent_assets_of_failed_children.each { |asset| asset.destroy! }
+    end
+
+    delegate :batch_items, to: :batch
+
+    private
+
+      # For the AAPB PBCore Zipped XML batch ingest, the :id_within_batch for
+      # each batch item is the unzipped PBCore XML file. This PBCore XML
+      # contains one Asset and possible several children of that asset.
+      # This method checks for failures among the child batch items, and if any
+      # are found, it then fetches the parent Asset, which we want to delete,
+      # because it has been only 'partially' ingested.
+      def parent_assets_of_failed_children
+        @parent_assets_of_failed_children ||= parent_asset_ids_for_failed_children.map { |asset_id| Asset.find asset_id }
+      end
+
+      def parent_asset_ids_for_failed_children
+
+        @parent_asset_ids_for_failed_children ||= failed_batch_items_for_assets.map { |batch_item| batch_item.repo_object_id }
+      end
+
+      def failed_batch_items_for_assets
+        @failed_batch_items_for_assets ||= failed_batch_item_groups.map do |failed_batch_item_group|
+          failed_batch_item_group.select { |batch_item| batch_item.repo_object_class_name == 'Asset' }
+        end.flatten.compact
+      end
+
+      def failed_batch_item_groups
+        @failed_batch_item_groups ||= batch_item_groups.select do |batch_item_group|
+          batch_item_group.any? { |batch_item| batch_item.status == 'failed' }
+        end
+      end
+
+      def batch_item_groups
+        @batch_item_groups ||= batch_items.group_by(&:id_within_batch).values
+      end
+  end
+end

--- a/spec/lib/ams/aapb_pbcore_zipped_batch_ingest_fixer_spec.rb
+++ b/spec/lib/ams/aapb_pbcore_zipped_batch_ingest_fixer_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+require 'ams/aapb_pbcore_zipped_batch_ingest_fixer'
+
+RSpec.describe AMS::AAPBPBCoreZippedBatchIngestFixer do
+  describe '.new' do
+    context 'with the wrong kind of batch' do
+      let(:wrong_kind_of_batch) { create(:batch, ingest_type: 'wrong') }
+      it 'throws an ArgumentError' do
+        expect { described_class.new(wrong_kind_of_batch.id) }.to raise_error ArgumentError, 'batch must be of type "aapb_pbcore_zipped"'
+      end
+    end
+  end
+
+  describe '#delete_parent_assets_of_failed_children' do
+    # Create a batch for testing.
+    let(:batch) { create(:batch, ingest_type: 'aapb_pbcore_zipped') }
+    # Create a random list of assets.
+    let(:assets) do
+      rand(1..4).times.map { create(:asset, id: rand(999999)) }
+    end
+    # Pick one unlucky asset to have a child that failed to ingest.
+    let(:asset_with_failed_child) { assets.sample }
+    let(:asset_with_no_failing_children) { assets - [asset_with_failed_child] }
+
+    before do
+      # Setup a mock ingest. For each of the assets...
+      assets.each do |asset|
+        id_within_batch = "#{asset.id}.xml"
+        # Create successful batch items for the assets.
+        create(:batch_item, batch: batch, repo_object_class_name: 'Asset', repo_object_id: asset.id, status: 'completed', id_within_batch: id_within_batch)
+        # Create a random number of successful batch items that share the
+        # :id_within_batch for the asset.
+        create_list(:batch_item, rand(4), batch: batch, repo_object_class_name: 'ChildObject', status: 'completed', id_within_batch: id_within_batch)
+        # If this is the unlucky asset...
+        if asset == asset_with_failed_child
+          # Create a failed batch item that shares the same :id_within_batch
+          # with the asset.
+          create(:batch_item, batch: batch, repo_object_class_name: 'ChildObject', status: 'failed', id_within_batch: id_within_batch)
+        end
+
+        allow(Asset).to receive(:find).with(asset.id).and_return(asset)
+        allow(asset).to receive(:destroy!).and_return(nil)
+      end
+
+      # Run the method under test.
+      described_class.new(batch.id).delete_parent_assets_of_failed_children
+    end
+
+    it 'deletes parent Assets of failed batch items' do
+      expect(asset_with_failed_child).to have_received(:destroy!)
+    end
+
+    it 'does not delete parent Asset where all children were successfully ingested' do
+      asset_with_no_failing_children.each do |asset|
+        expect(asset).to_not have_received(:destroy!)
+      end
+    end
+  end
+end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Asset do
       # get the AdminData record to verify its destruction
       @admin_data = @asset.admin_data
 
-      # Now destroy the Asset
+      # Run the method under test, and assert expectations in the examples.
       @asset.destroy!
     end
 


### PR DESCRIPTION
The previous attempt didn't work for models created with actors because deleting
the Asset made it impossible to access the Asset#ordered_members (although for
reasons unknown, this wasn't a problem in the Asset model spec).

This change deletes objects from Asset#members rather than Asset#ordered_members
which seems to work.

The point of adding cascade delete, was so that we can identify Assets that were
ingested via the 'AAPB PBCore XML Zipped' batch ingest, but which had child
objects that failed ingest. In this case, we want to delete the Asset and all
it's ingested children, so that we can re-ingest it with the same IDs.

This PR also adds a utility, AMS::AAPBPBCoreZippedBatchIngestFixer, which does
just that, when given a batch id.