### PR TITLE
Don't raise error on cascade delete

### DIFF
--- a/app/models/ams/cascade_destroy_members.rb
+++ b/app/models/ams/cascade_destroy_members.rb
@@ -6,6 +6,8 @@ module AMS
       after_destroy do
         members.each do |member|
           member.destroy!
+        rescue Ldp::Gone
+          nil
         end
       end
     end


### PR DESCRIPTION
The 'cascade delete' is an after_destory hook that calls #destroy! on an ActiveFedora
record's #members. If one of those members had already been deleted for some reason,
an LDP::Gone error was getting raised. We want to quietly rescue from that instead.