### PR TITLE
Checks to see if Asset exists before ingesting

### DIFF
--- a/app/services/aapb/batch_ingest/errors.rb
+++ b/app/services/aapb/batch_ingest/errors.rb
@@ -1,0 +1,11 @@
+module AAPB
+  module BatchIngest
+    class Error < StandardError; end
+
+    class RecordExists < Error
+      def initialize(id)
+        super "A record with id '#{id}' already exists"
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  describe '#display_date' do
+
+    it 'can reformat mm/dd/yyyy to yyyy-mm-dd' do
+      expect(helper.display_date('01/16/2014', from_format: '%m/%d/%Y')).to eq '2014-01-16'
+    end
+
+    it 'can output a custom date format' do
+      expect(helper.display_date('2014-01-16', format: '%Y hello %m world %d')).to eq '2014 hello 01 world 16'
+    end
+
+    it 'eats bad dates, returns nil' do
+      expect(helper.display_date('bad date')).to eq nil
+    end
+  end
+end

--- a/spec/services/aapb/batch_ingest/pbcore_xml_item_ingester_spec.rb
+++ b/spec/services/aapb/batch_ingest/pbcore_xml_item_ingester_spec.rb
@@ -76,6 +76,18 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLItemIngester, reset_data: false do
         # Instnatiations.
         expect(@batch.batch_items.count).to eq 9
       end
+
+      context 'given a PBCore Description Document that alread exists' do
+        it 'raises an exception' do
+          duplicate_batch_item = create(
+            :batch_item,
+            batch: @batch,
+            source_location: nil,
+            source_data: @pbcore_xml
+          )
+          expect { described_class.new(duplicate_batch_item).ingest }.to raise_error AAPB::BatchIngest::RecordExists
+        end
+      end
     end
 
     context 'given a PBCore Instantiation Document with Essence Tracks' do
@@ -115,5 +127,7 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLItemIngester, reset_data: false do
       end
 
     end
+
+
   end
 end


### PR DESCRIPTION
If the Asset being ingested is already in Fedora, then it will raise an
exception that will be caught in the BatchItemProcessingJob's rescue_from block,
where the error msg it saved on the BatchItem instance.

Also,
* Creates a custom error class for AAPB::BatchIngest::RecordExists.
* Adds a spec for ApplicationHelper#display_date, which failed to get added a
  while ago for reasons unknown.

Closes #333.