### PR TITLE
Appends to, rather than truncates, sidekiq log.

### DIFF
--- a/bin/deploy/install.sh
+++ b/bin/deploy/install.sh
@@ -21,7 +21,7 @@ fi
 bin/rails g deployment_info_page --deployment_id $DEPLOYMENT_ID
 sudo service httpd restart
 sleep 2
-RESTART=true ruby bin/scripts/ensure_sidekiq_running.rb
+RESTART=true bundle exec ruby bin/scripts/ensure_sidekiq_running.rb
 sleep 2
 echo "End of install.sh"
 exit 0;

--- a/bin/scripts/ensure_sidekiq_running.rb
+++ b/bin/scripts/ensure_sidekiq_running.rb
@@ -1,4 +1,4 @@
-require_relative '../../lib/ams/sidekiq_process_manager.rb'
+require_relative '../../lib/ams/sidekiq_process_manager'
 
 sidekiq = AMS::SidekiqProcessManager.new
 puts "#{sidekiq.active_pids.count} Sidekiq processes running."

--- a/lib/ams/sidekiq_process_manager.rb
+++ b/lib/ams/sidekiq_process_manager.rb
@@ -142,7 +142,7 @@ module AMS
       end
 
       def start_sidekiq_cmd
-        "bundle exec sidekiq -e #{env} > #{sidekiq_log_file} 2>&1"
+        "bundle exec sidekiq -e #{env} >> #{sidekiq_log_file} 2>&1"
       end
 
       def sidekiq_log_file


### PR DESCRIPTION
Also, uses bundle exec when calling bin/scripts/ensure_sidekiq_running.rb to within install.sh to fix error of not being able to load sidekiq/api.