### PR TITLE
Fixes broken Travis builds

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 --require spec_helper
+--format documentation
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: true
-dist: trusty
+dist: xenial
 language: ruby
 services:
 - redis-server
+- xvfb
 jdk:
-- oraclejdk8
+- openjdk11
 rvm:
 - 2.5.3
 addons:
@@ -24,8 +25,6 @@ before_install:
 - gem install bundler
 before_script:
 - export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
-- sleep 3
 - RAILS_ENV=test bundle exec rake db:environment:set db:create db:migrate --trace
 - RAILS_ENV=test npm install yarn
 - RAILS_ENV=test yarn --ignore-engines install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
-    childprocess (1.0.1)
+    childprocess (2.0.0)
       rake (< 13.0)
     clipboard-rails (1.7.1)
     coderay (1.1.2)
@@ -542,7 +542,7 @@ GEM
     noid-rails (3.0.1)
       actionpack (>= 5.0.0, < 6)
       noid (~> 0.9)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
@@ -747,7 +747,7 @@ GEM
       oauth2
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    rubyzip (1.2.3)
+    rubyzip (1.2.4)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.7.4)
@@ -767,8 +767,8 @@ GEM
     sax-machine (1.3.2)
     select2-rails (3.5.10)
       thor (~> 0.14)
-    selenium-webdriver (3.142.3)
-      childprocess (>= 0.5, < 2.0)
+    selenium-webdriver (3.142.4)
+      childprocess (>= 0.5, < 3.0)
       rubyzip (~> 1.2, >= 1.2.2)
     shex (0.5.2)
       ebnf (~> 1.1)
@@ -855,7 +855,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (4.0.1)
+    webdrivers (4.1.2)
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
       selenium-webdriver (>= 3.0, < 4.0)
@@ -937,4 +937,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,4 +92,15 @@ RSpec.configure do |config|
   config.extend ControllerMacros, :type => :controller
 end
 
-Webdrivers::Chromedriver.required_version = '72.0.3626.69'
+# Uncomment this to specify a version of ChromeDriver, a list of which can be
+# found at https://chromedriver.storage.googleapis.com/index.html.
+# NOTE: The ChromeDriver version must be compatible with the version of Chrome,
+# being used to run tests, whether it's in development or on Travis CI.
+# NOTE: The 'webdrivers' gem is supposed to automatically select the correct
+# version of ChromeDriver, so you should only need to use this if WebDrivers is
+# failing to do so.
+# Webdrivers::Chromedriver.required_version = ''
+
+# Uncomment this to help debug ChromeDriver (or other web driver) issues on
+# Travis or development.
+# Webdrivers.logger.level = :DEBUG


### PR DESCRIPTION
We were getting errors that the version of ChromeDriver was incompatible with
the version of Chrome that Travis was running.

After much debugging, we found that a recently released version of Chrome was
not compatible with the 'trusty' Linux distribution that our Travis CI config
was specifying.

We upgraded our Linux distribution from `trusty` to `xenial`, but in so doing,
our Travis configuration for JDK `oraclejdk8` became incompatible.

Upgrading the distribution from `trusty` to `xenial` then caused an issue with
running `oraclejdk8` (required by Fedora and Solr), because `xenial` is
incompatible with `oraclejdk8`.

We changed our JDK config to use `openjdk11` and changed how we start xvfb, from
calling an init.d script, to using Travis config `services` option. This seems
to have caused a lot of Java errors as Travis was booting up the test suite, but
the tests ran to completion and passed.

The Java errors should be investigated further, but should not block this PR as
we need to get builds passing again quicly.

We also added `--fail-fast` and `format --docuemntation` options to `.rspec`.
Going to leave these in for now, but may want to remove them later if they
prove to be more annoying than useful.