### PR TITLE
Graceful failure for deployment info page

### DIFF
--- a/bin/deploy/install.sh
+++ b/bin/deploy/install.sh
@@ -12,13 +12,12 @@ echo "ruby version:`ruby -v`"
 echo "rails versions:`bundle exec rails -v`"
 echo "node version:`node -v`"
 echo "yarn version:`yarn -v`"
-export SECRET_KEY_BASE=`bin/rails secret`
-# if [ -z $SECRET_KEY_BASE ]; then
-#   sudo echo "export SECRET_KEY_BASE=`bundle exec rails secret`" >> /etc/profile
-#   source /etc/profile
-# fi
-bundle exec rails db:migrate
-bundle exec rails assets:precompile
+if [ -z $SECRET_KEY_BASE ]; then
+  sudo echo "export SECRET_KEY_BASE=`bin/rails secret`" >> ~/.bashrc
+  source ~/.bashrc
+fi
+bin/rails db:migrate
+bin/rails assets:precompile
 
 bin/rails g deployment_info_page --deployment_id $DEPLOYMENT_ID
 sudo service httpd restart

--- a/config/initializers/deployment_info_page_generator.rb
+++ b/config/initializers/deployment_info_page_generator.rb
@@ -43,6 +43,12 @@ class DeploymentInfoPageGenerator < Rails::Generators::Base
 
     def deployment_info_html
       ERB.new(template).result(binding)
+    rescue => e
+      STDERR.puts "#{e.class}: #{e.message}"
+      STDERR.puts "\n\t#{e.backtrace.join("\n\t")}"
+      "An error occurred when attempting to generate this page: #{e.class}\n" \
+      "See /opt/codedeploy-agent/deployment-root/deployment-logs/codedeploy-agent-deployments.log " \
+      "on deployment destination host for full backtrace."
     end
 
     def template; File.read(template_path); end

--- a/lib/ams/sidekiq_process_manager.rb
+++ b/lib/ams/sidekiq_process_manager.rb
@@ -92,7 +92,7 @@ module AMS
       # Starts `count` sidekiq processes in the background.
       def start_sidekiq_processes(count: 1)
         Dir.chdir project_dir do
-          count.times { run_command start_sidekiq_cmd, spawn_new_process: true }
+          count.times { run_command start_sidekiq_cmd }
         end
       end
 
@@ -134,15 +134,14 @@ module AMS
         Sidekiq::Workers.new.map { |pid, thread_id, work| pid.split(':')[1] }
       end
 
-      # Log the command, then run it. If spawn_new_process is TRUE, then call
-      # it with `spawn`, otherwise with backticks.
-      def run_command(command, spawn_new_process: false)
+      # Log the command, then run it with backticks.
+      def run_command(command)
         logger.info "Running: #{command}"
-        spawn_new_process ? spawn(command) : `#{command}`
+        `#{command}`
       end
 
       def start_sidekiq_cmd
-        "bundle exec sidekiq -e #{env} >> #{sidekiq_log_file} 2>&1"
+        "bundle exec sidekiq -e #{env} >> #{sidekiq_log_file} 2>&1 &"
       end
 
       def sidekiq_log_file

--- a/lib/tasks/verify_service.rake
+++ b/lib/tasks/verify_service.rake
@@ -13,9 +13,8 @@ namespace :verify_service do
   end
 
   task :homepage do
-    host = ENV.fetch('PRODUCTION_HOST')
-    result = `curl -s -o /dev/null -I -w "%{http_code}" #{host}`
-    msg = "Request to #{host} returned: #{result}"
+    result = `curl -s -o /dev/null -I -w "%{http_code}" 127.0.0.1`
+    msg = "Request to 127.0.0.1 returned: #{result}"
     raise msg unless result == '200'
     puts msg
   end


### PR DESCRIPTION
There is some issue with the deployment IAM role not having access to one
of the CodeDeploy api methods. I hope to figure that out soon, but in the
meantime, I don't want the deployment info page failure to fail the whole
deployment. Instead log the message to STDERR, replace the deployment info page
with a readable error, and continue without failing.