### PR TITLE
Fixes sidekiq restart

### DIFF
--- a/bin/deploy/install.sh
+++ b/bin/deploy/install.sh
@@ -22,7 +22,7 @@ bin/rails assets:precompile
 bin/rails g deployment_info_page --deployment_id $DEPLOYMENT_ID
 sudo service httpd restart
 sleep 2
-RESTART=true bundle exec ruby bin/scripts/ensure_sidekiq_running.rb
+SIDEKIQ_RESET=true bundle exec ruby bin/scripts/ensure_sidekiq_running.rb
 sleep 2
 echo "End of install.sh"
 exit 0;


### PR DESCRIPTION
Sidekiq was not properly restarting after deployment because I was using the
wrong env var.