### PR TITLE
Adds tests for mapping, ingestion of admin data

### DIFF
--- a/spec/factories/pbcore_xml/instantiation.rb
+++ b/spec/factories/pbcore_xml/instantiation.rb
@@ -30,8 +30,28 @@ FactoryBot.define do
       physical { build(:pbcore_instantiation_physical) }
     end
 
-    trait :aapb_holding do
-      annotations { [ build(:pbcore_instantiation_annotation, type: "Organization", value: "American Archive of Public Broadcasting") ] }
+    transient do
+      aapb_holding { true }
+      on_lto { true }
+      on_disk { true }
+    end
+
+    after(:build) do |pbcore_identifier, evaluator|
+      if evaluator.aapb_holding
+        pbcore_identifier.annotations << build(:pbcore_instantiation_annotation, type: "Organization", value: "American Archive of Public Broadcasting")
+      end
+
+      if evaluator.on_lto
+        # If the value is simply TRUE (the default), then convert it to a random string.
+        val = evaluator.on_lto == true ? SecureRandom.hex[0..10] : evaluator.on_lto.to_s
+        pbcore_identifier.annotations << build(:pbcore_instantiation_annotation, type: "AAPB Preservation LTO", value: val)
+      end
+
+      if evaluator.on_disk
+        # If the value is simply TRUE (the default), then convert it to a random string.
+        val = evaluator.on_disk == true ? SecureRandom.hex[0..10] : evaluator.on_disk.to_s
+        pbcore_identifier.annotations << build(:pbcore_instantiation_annotation, type: "AAPB Preservation Disk", value: val)
+      end
     end
   end
 end

--- a/spec/factories/pbcore_xml/pbcore_description_document.rb
+++ b/spec/factories/pbcore_xml/pbcore_description_document.rb
@@ -11,8 +11,29 @@ FactoryBot.define do
       audience_levels   { build_list(:pbcore_audience_level, rand(1..3)) }
       audience_ratings  { build_list(:pbcore_audience_rating, rand(1..3)) }
       asset_types       { build_list(:pbcore_asset_type, rand(1..3)) }
-      annotations       { build_list(:pbcore_annotation, rand(1..3)) }
       subjects          { build_list(:pbcore_subject, rand(1..3)) }
+
+      annotations do
+        # AAPB-specific admin data annotations
+        admin_data_annotations = [
+
+          # The incoming PBCore XML values for "Level of User Access" and
+          # "Transcript Status" match our controlled vocabulary, so we can take
+          # a random sampling from there.
+          build(:pbcore_annotation, type: "Level of User Access", value: LevelOfUserAccessService.new.select_all_options.to_h.values.sample),
+          build(:pbcore_annotation, type: "Transcript Status", value: TranscriptStatusService.new.select_all_options.to_h.values.sample),
+          build(:pbcore_annotation, type: "cataloging status", value: "Minimally Cataloged"),
+          build(:pbcore_annotation, type: "Outside URL", value: Faker::Internet.url),
+          build(:pbcore_annotation, type: "special_collections" , value: Faker::TvShows::Simpsons.character),
+          build(:pbcore_annotation, type: "Licensing Info" , value: Faker::Lorem.paragraph),
+          build(:pbcore_annotation, type: "Playlist Group" , value: Faker::Lorem.word),
+          build(:pbcore_annotation, type: "Playlist Order" , value: rand(1..5))
+        ]
+
+        # In addition to the admin data annotations, throw in some arbitrary
+        # annotations that are not admin data to show they can also be handled.
+        admin_data_annotations + build_list(:pbcore_annotation, rand(1..3))
+      end
 
       titles do
         [
@@ -77,7 +98,7 @@ FactoryBot.define do
 
       instantiations do
         [
-          build(:pbcore_instantiation, :digital, :aapb_holding)
+          build(:pbcore_instantiation, :digital, aapb_holding: true, on_lto: true, on_disk: true)
         ]
       end
 

--- a/spec/features/batch_ingest/aapb_pbcore_zipped_spec.rb
+++ b/spec/features/batch_ingest/aapb_pbcore_zipped_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Ingest: AAPB PBCore - Zipped" do
       expect(@ingested_objects.count).to eq expected_batch_item_count
     end
 
-    it 'creates additional BatchItem reocrds with inherited values for child objects' do
+    it 'creates additional BatchItem records that all share the same `id_within_batch` value' do
       batch_items_by_repo_object_id = @batch.batch_items.index_by(&:repo_object_id)
       ingested_objects_by_id = @ingested_objects.index_by(&:id)
       batch_items_by_repo_object_id.each do |repo_object_id, batch_item|

--- a/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
+++ b/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLMapper, :pbcore_xpath_helper do
       :date, :broadcast_date, :copyright_date, :created_date, :subject]
     end
 
-    let(:attrs_with_xpath_shortcuts) { attr_names - [:title, :description, :date, :spatial_coverage, :temporal_coverage, :id, :holding_organization] }
+    let(:attrs_with_xpath_shortcuts) { attr_names - [:title, :description, :date, :spatial_coverage, :temporal_coverage, :id, :holding_organization, :annotation] }
     let(:attrs) { subject.asset_attributes }
 
     it 'maps all attributes from PBCore XML' do
@@ -40,10 +40,29 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLMapper, :pbcore_xpath_helper do
       expect(attrs[:description]).to  eq pbcore_xpath_helper(pbcore_xml).descriptions_without_type
       expect(attrs[:date]).to         eq pbcore_xpath_helper(pbcore_xml).dates_without_type
       expect(attrs[:id]).to           eq pbcore_xpath_helper(pbcore_xml).ams_id
+      expect(attrs[:annotation]).to   eq pbcore_xpath_helper(pbcore_xml).annotations_without_type
     end
 
     it 'maps Contribution data from PBCore XML' do
       expect(attrs[:contributors]).to eq pbcore_xpath_helper(pbcore_xml).contributors_attrs
+    end
+
+    it 'correctly maps admin data coming from annotations' do
+      admin_data_fields = [
+        :level_of_user_access,
+        :minimally_cataloged,
+        :outside_url,
+        :special_collection,
+        :transcript_status,
+        :licensing_info,
+        :playlist_group,
+        :playlist_order
+      ]
+
+      admin_data_fields.each do |admin_data_field|
+        expect(attrs).to have_key admin_data_field
+        expect(attrs[admin_data_field]).not_to be_nil
+      end
     end
 
     context 'when dates are of a known invalid type' do


### PR DESCRIPTION
Fields for AdminData db records, which are associated with Asset records in
Fedora, are taken from a series of typed <pbcoreAnnotation> elements. We did
not have a test in place to ensure this mapping, nor for ensuring the accurate
creation of the AdminData record, and we encountered bugs that showed the
AdminData was not getting populated correctly in production. This PR adds those
specs.

* Adds a spec for ensuring the propper mapping from PBCore XML to the interim
  Hash that is then sent along to the actor stack.
* Adds an integration spec for ensuring that a non-empty AdminData record gets
  created as part of the ingest of an Asset.
* Modifies pbcore_description_document factory to add typed annotation for admin
  data
* Adds factory params to pbcore_identifer for adding annotations for:
  * AAPB Preservation Disk barcode
  * AAPB Preservation LTO barcode
  * signifying an AAPB holding (this was a trait, but converted to a transient
    variable to allow appending mixing and matching annotations)

Also...
* Changes a spec description to be more accurate.
* Refactors PBCoreXMLMapper to use an explicit map of annotation types to field
  names. This is a little clearer than what was there previously.
* Treats <pbcoreAnnotation> elements as other typed elements (e.g. pbcoreTitle)
  in the PBCore xpath helpers.