### PR TITLE
Updates Role Views to Use Role Manager Translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 4.0'
 gem 'sidekiq'
-gem 'hydra-role-management'
+gem 'hydra-role-management', '~> 1.0'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -893,7 +893,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.0)
   faker
   fcrepo_wrapper
-  hydra-role-management
+  hydra-role-management (~> 1.0)
   hyrax (= 2.5.1)
   hyrax-batch_ingest!
   hyrax-iiif_av (>= 0.2.0)

--- a/app/views/roles/_add_user_modal.html.erb
+++ b/app/views/roles/_add_user_modal.html.erb
@@ -12,13 +12,13 @@
             <div class="form-Role">
               <%= f.select :user_key,
                            options_from_collection_for_select(@users, 'email', lambda { |user| "#{user.email} (#{user.deleted == false ? t('admin.users.index.active') : t('admin.users.index.not_active')})"}),
-                           { prompt: "#{t('hyrax.dashboard.manage_role.select_user')}" },
+                           { prompt: "#{t('hyrax.admin.dashboard.manage_role.select_user')}" },
                            class: 'form-control' %>
             </div>
           </div>
           <div class="modal-footer">
-            <%= f.submit t('hyrax.dashboard.manage_role.add'), class: "btn btn-primary" %>
-            <%= link_to t('hyrax.dashboard.manage_role.cancel'), "#", class: "btn", data: {dismiss: "modal"} %>
+            <%= f.submit t('role-management.edit.add'), class: "btn btn-primary" %>
+            <%= link_to t('role-management.edit.cancel'), "#", class: "btn", data: {dismiss: "modal"} %>
           </div>
         </div>
       <% end %>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -3,7 +3,7 @@
   <%if can? :create, Role %>
     <div class="pull-right">
       <% if can? :create, Role %>
-        <%= button_to t('hyrax.dashboard.manage_role.create_role'), role_management.new_role_path, method: :get, class: 'btn btn-primary' %>
+        <%= link_to t('hyrax.dashboard.manage_role.create_role'), role_management.new_role_path, method: :get, class: 'btn btn-primary' %>
       <% end %>
   <% end %>
   </div>
@@ -37,7 +37,7 @@
         </table>
       </div>
     <% else %>
-      <p><%= t('hyrax.dashboard.manage_role.role_not_avilable')%></p>
+      <p><%= t('hyrax.dashboard.manage_role.role_not_available')%></p>
     <% end %>
   </div>
 </div>

--- a/app/views/roles/new.html.erb
+++ b/app/views/roles/new.html.erb
@@ -8,12 +8,12 @@
     <div class="panel panel-default labels">
       <%= bootstrap_form_for @role, :url=>role_management.roles_path do |f| %>
         <div class="panel-body">
-          <%= f.text_field :name, :label=> t('hyrax.dashboard.manage_role.role_name') %>
+          <%= f.text_field :name, :label=> t('role-management.edit.field_name') %>
         </div>
 
         <div class="panel-footer">
-          <%= link_to t('hyrax.dashboard.manage_role.cancel'), role_management.roles_path, class: 'btn btn-default pull-right' %>
-          <%= f.submit t('hyrax.dashboard.manage_role.add'), class: 'btn btn-primary pull-right' %>
+          <%= link_to t('role-management.edit.cancel'), role_management.roles_path, class: 'btn btn-default pull-right' %>
+          <%= f.submit t('role-management.new.add'), class: 'btn btn-primary pull-right' %>
         </div>
       <% end %>
     </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -352,12 +352,12 @@ en:
           select_user: 'Select a user...'
           cancel: 'Cancel'
           confirm: 'Are you sure you want to delete?'
-          role_not_avilable: 'No roles have been created.'
+          role_not_available: 'No roles have been created.'
         admin_sets:
           title_unique_validation: 'already exist try another one'
           title_cant_blank_validation: 'You must provide a title'
       sidebar:
-        manage_roles:        'Manage Roles'
+        manage_roles: 'Manage Roles'
         activity: Activity
         appearance: Appearance
         collection_types: Collection Types


### PR DESCRIPTION
In looking at the history, I'm not sure why we were using our own translations for the Role Manager views. I reverted to using the gem's translations where applicable and pinning our gem version.