### PR TITLE
Refactors permission configuration

### DIFF
--- a/spec/features/admin/admin_sets/add_multiple_userrole_as_manager_spec.rb
+++ b/spec/features/admin/admin_sets/add_multiple_userrole_as_manager_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'AssignMultipleRolesAsManager.', js: true do
     context 'Add Manager permissions to user (Role)' do
       let(:admin_user) { create :admin_user }
       let!(:user) { create :user }
-      let!(:user_with_role) { create :user, role_names: ['user'] }
+      let!(:user_with_role) { create :user, role_names: ['test-group'] }
       let!(:admin_set_1) { create :admin_set }
       let!(:admin_set_2) { create :admin_set }
 

--- a/spec/features/admin/admin_sets/add_multiple_userrole_as_viewer_spec.rb
+++ b/spec/features/admin/admin_sets/add_multiple_userrole_as_viewer_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'AssignMultipleRolesAsViewer.', js: true do
   context 'Add Viewer permissions to user (Role)' do
     let(:admin_user) { create :admin_user }
     let!(:user) { create :user }
-    let!(:user_with_role) { create :user, role_names: ['user'] }
+    let!(:user_with_role) { create :user, role_names: ['test-role'] }
     let!(:admin_set_1) { create :admin_set }
     let!(:asset_1) { create :asset, :public, user: user, admin_set_id: admin_set_1.id}
     let!(:admin_set_2) { create :admin_set }

--- a/spec/features/admin_add_userrole_as_adminset_manager_spec.rb
+++ b/spec/features/admin_add_userrole_as_adminset_manager_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.feature 'AdminAddUserroleAsAdminserManager.', js: true do
+RSpec.feature 'AdminAddUserroleAsAdminsetManager.', js: true do
 
   context 'As Admin add a UserRole as Adminset Manager' do
     let(:admin_user) { create :admin_user }
     let!(:user) { create :user }
-    let!(:user_with_role) { create :user, role_names: ['user'] }
+    let!(:user_with_role) { create :user, role_names: ['test_role'] }
     let!(:admin_set) { create :admin_set }
 
     before do

--- a/spec/features/create_asset_spec.rb
+++ b/spec/features/create_asset_spec.rb
@@ -6,7 +6,7 @@ require_relative '../../app/services/date_types_service'
 RSpec.feature 'Create and Validate Asset', js: true, asset_form_helpers: true, clean:true do
   context 'Create adminset, create asset' do
     let(:admin_user) { create :admin_user }
-    let!(:user_with_role) { create :user, role_names: ['user'] }
+    let!(:user_with_role) { create :user, role_names: ['ingester'] }
     let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
     let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
     let!(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
@@ -69,7 +69,7 @@ RSpec.feature 'Create and Validate Asset', js: true, asset_form_helpers: true, c
       Hyrax::PermissionTemplateAccess.create!(
         permission_template_id: permission_template.id,
         agent_type: 'group',
-        agent_id: 'user',
+        agent_id: 'ingester',
         access: 'deposit'
       )
       # Login role user to create asset
@@ -77,6 +77,7 @@ RSpec.feature 'Create and Validate Asset', js: true, asset_form_helpers: true, c
 
       # create asset
       visit new_hyrax_asset_path
+
       expect(page).to have_content "Add New Asset"
 
       click_link "Files" # switch tab

--- a/spec/features/create_asset_with_asset_types_vocabulary_spec.rb
+++ b/spec/features/create_asset_with_asset_types_vocabulary_spec.rb
@@ -4,7 +4,7 @@ include Warden::Test::Helpers
 RSpec.feature 'Create Asset with Asset Type', js: true, asset_form_helpers: true, clean:true do
   context 'Create adminset, create asset' do
     let(:admin_user) { create :admin_user }
-    let!(:user_with_role) { create :user, role_names: ['user'] }
+    let!(:user_with_role) { create :user, role_names: ['ingester'] }
 
     let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
     let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }

--- a/spec/features/create_asset_with_digitalinstantiation_spec.rb
+++ b/spec/features/create_asset_with_digitalinstantiation_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Create and Validate Asset,Digital Instantiation, EssenseTrack', j
               disable_animation:true, expand_fieldgroup: true  do
   context 'Create adminset, create asset, import pbcore xml for digital instantiation and essensetrack' do
     let(:admin_user) { create :admin_user }
-    let!(:user_with_role) { create :user, role_names: ['user'] }
+    let!(:user_with_role) { create :user, role_names: ['ingester'] }
     # let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
     let(:admin_set_id) { create(:admin_set).id }
     let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
@@ -64,9 +64,9 @@ RSpec.feature 'Create and Validate Asset,Digital Instantiation, EssenseTrack', j
       Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
       Hyrax::PermissionTemplateAccess.create!(
         permission_template_id: permission_template.id,
-        agent_type: 'group',
-        agent_id: 'user',
-        access: 'manage'
+        agent_type: 'user',
+        agent_id: user_with_role.email,
+        access: 'deposit'
       )
       # Login role user to create asset
       login_as(user_with_role)
@@ -102,6 +102,7 @@ RSpec.feature 'Create and Validate Asset,Digital Instantiation, EssenseTrack', j
       fill_in('Rights summary', with: asset_attributes[:rights_summary])
 
       click_link "Relationships" # define adminset relation
+
       find("#asset_admin_set_id option[value='#{admin_set_id}']").select_option
 
       # set it public

--- a/spec/features/create_asset_with_genre_vocabulary_spec.rb
+++ b/spec/features/create_asset_with_genre_vocabulary_spec.rb
@@ -4,7 +4,7 @@ include Warden::Test::Helpers
 RSpec.feature 'Create Asset with Asset Type', js: true, asset_form_helpers: true, clean:true do
   context 'Create adminset, create asset' do
     let(:admin_user) { create :admin_user }
-    let!(:user_with_role) { create :user, role_names: ['user'] }
+    let!(:user_with_role) { create :user, role_names: ['ingester'] }
 
     let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
     let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }

--- a/spec/features/redirect_new_action_spec.rb
+++ b/spec/features/redirect_new_action_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Redirect controller#new actions', js: true do
   context 'a logged in User' do
     let(:admin_user) { create :admin_user }
-    let!(:user_with_role) { create :user, role_names: ['user'] }
+    let!(:user_with_role) { create :user, role_names: ['ingester'] }
     let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
 
     let!(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
@@ -13,8 +13,8 @@ RSpec.feature 'Redirect controller#new actions', js: true do
       Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
       Hyrax::PermissionTemplateAccess.create!(
           permission_template_id: permission_template.id,
-          agent_type: 'group',
-          agent_id: 'user',
+          agent_type: 'user',
+          agent_id: user_with_role.email,
           access: 'deposit'
       )
       # Login role user to create DigitalInstantiation

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -89,37 +89,6 @@ RSpec.describe Ability do
 
   context ', given a user who is part of the "admin" group, ' do
     let(:user) { create(:admin_user) }
-
     it { is_expected.to be_able_to(:manage, :all) }
-
-    # it { is_expected.to be_able_to([:create, :update, :destroy], Asset) }
-    # it { is_expected.to be_able_to([:create, :update, :destroy], DigitalInstantiation) }
-    # it { is_expected.to be_able_to([:create, :update, :destroy], PhysicalInstantiation) }
-    # it { is_expected.to be_able_to([:create, :update, :destroy], Collection) }
-    # it { is_expected.to be_able_to([:create, :update, :destroy], EssenceTrack) }
-    # it { is_expected.to be_able_to([:create, :update, :destroy], Contribution) }
-    #
-    #
-    # it 'an create, update, and destroy a Role' do
-    #   [:create, :update, :destroy].each do |action|
-    #
-    #   end
-    #   expect(subject.can?(action, Role)).to eq true
-    # end
-    #
-    # it 'an create, update, and destroy a Contribution' do
-    #   expect(subject.can?([:create, :update, :destroy], Contribution)).to eq true
-    # end
-    #
-    # it 'an create, update, and destroy a AdminData' do
-    #   expect(subject.can?([:create, :update, :destroy], AdminData)).to eq true
-    # end
-    #
-    # it { is_expected.to be_able_to([:create, :update, :destroy], Role) }
-    # it { is_expected.to be_able_to(:create, Role) }
-    # it { is_expected.to be_able_to(:update, Role) }
-    # it { is_expected.to be_able_to(:destroy, Role) }
-    # it { is_expected.to be_able_to([:create, :update, :destroy], User) }
-    # it { is_expected.to be_able_to([:create, :update, :destroy], Push) }
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+require 'cancan/matchers'
+
+RSpec.describe Ability do
+  # User is defined
+  let(:subject) { Ability.new user }
+
+  context 'for any user (no group)' do
+    let(:user) { create(:user) }
+
+    it { is_expected.to be_able_to(:show, Asset) }
+    [:create, :update, :destroy].each do |action|
+      it { is_expected.not_to be_able_to(action, Asset) }
+    end
+
+    it { is_expected.to be_able_to(:show, DigitalInstantiation) }
+    [:create, :update, :destroy].each do |action|
+      it { is_expected.not_to be_able_to(action, DigitalInstantiation) }
+    end
+
+    it { is_expected.to be_able_to(:show, PhysicalInstantiation) }
+    [:create, :update, :destroy].each do |action|
+      it { is_expected.not_to be_able_to(action, PhysicalInstantiation) }
+    end
+
+    it { is_expected.to be_able_to(:show, EssenceTrack) }
+    [:create, :update, :destroy].each do |action|
+      it { is_expected.not_to be_able_to(action, EssenceTrack) }
+    end
+
+    it { is_expected.to be_able_to(:show, Contribution) }
+    [:create, :update, :destroy].each do |action|
+      it { is_expected.not_to be_able_to(action, Contribution) }
+    end
+
+    it { is_expected.to be_able_to(:show, Collection) }
+    [:create, :update, :destroy].each do |action|
+      it { is_expected.not_to be_able_to(action, Collection) }
+    end
+
+    it { is_expected.to be_able_to(:show, AdminData) }
+    [ :create,
+      :update,
+      :destroy,
+      :update_level_of_user_access,
+      :update_minimally_cataloged,
+      :update_outside_url,
+      :update_sonyci_id,
+      :update_licensing_info,
+      :update_playlist_group,
+      :update_playlist_order,
+      :update_hyrax_batch_ingest_batch_id,
+      :update_last_pushed,
+      :update_last_updated,
+      :update_needs_update ].each do |action|
+      it { is_expected.not_to be_able_to(action, AdminData) }
+    end
+  end
+
+  context ', given a user who is part of the "ingester" group, ' do
+    let(:user) { create(:user, role_names: [:ingester]) }
+
+    # An 'ingester' user may create and update the following object types.
+    [:create, :update].each do |action|
+      it { is_expected.to be_able_to(action, Asset) }
+      it { is_expected.to be_able_to(action, DigitalInstantiation) }
+      it { is_expected.to be_able_to(action, PhysicalInstantiation) }
+      it { is_expected.to be_able_to(action, Collection) }
+      it { is_expected.to be_able_to(action, EssenceTrack) }
+      it { is_expected.to be_able_to(action, Contribution) }
+    end
+
+    # An 'ingester' user may create AdminData, but not update all fields.
+    it { is_expected.to be_able_to(:create, AdminData) }
+
+    # An 'ingestser' user may update specific fields on AdminData objects.
+    it { is_expected.to be_able_to(:update_level_of_user_access, AdminData) }
+    it { is_expected.to be_able_to(:update_minimally_cataloged, AdminData) }
+    it { is_expected.to be_able_to(:update_outside_url, AdminData) }
+    it { is_expected.to be_able_to(:update_sonyci_id, AdminData) }
+    it { is_expected.to be_able_to(:update_licensing_info, AdminData) }
+    it { is_expected.to be_able_to(:update_playlist_group, AdminData) }
+    it { is_expected.to be_able_to(:update_playlist_order, AdminData) }
+    it { is_expected.to be_able_to(:update_hyrax_batch_ingest_batch_id, AdminData) }
+    it { is_expected.to be_able_to(:update_last_pushed, AdminData) }
+    it { is_expected.to be_able_to(:update_last_updated, AdminData) }
+    it { is_expected.to be_able_to(:update_needs_update, AdminData) }
+  end
+
+  context ', given a user who is part of the "admin" group, ' do
+    let(:user) { create(:admin_user) }
+
+    it { is_expected.to be_able_to(:manage, :all) }
+
+    # it { is_expected.to be_able_to([:create, :update, :destroy], Asset) }
+    # it { is_expected.to be_able_to([:create, :update, :destroy], DigitalInstantiation) }
+    # it { is_expected.to be_able_to([:create, :update, :destroy], PhysicalInstantiation) }
+    # it { is_expected.to be_able_to([:create, :update, :destroy], Collection) }
+    # it { is_expected.to be_able_to([:create, :update, :destroy], EssenceTrack) }
+    # it { is_expected.to be_able_to([:create, :update, :destroy], Contribution) }
+    #
+    #
+    # it 'an create, update, and destroy a Role' do
+    #   [:create, :update, :destroy].each do |action|
+    #
+    #   end
+    #   expect(subject.can?(action, Role)).to eq true
+    # end
+    #
+    # it 'an create, update, and destroy a Contribution' do
+    #   expect(subject.can?([:create, :update, :destroy], Contribution)).to eq true
+    # end
+    #
+    # it 'an create, update, and destroy a AdminData' do
+    #   expect(subject.can?([:create, :update, :destroy], AdminData)).to eq true
+    # end
+    #
+    # it { is_expected.to be_able_to([:create, :update, :destroy], Role) }
+    # it { is_expected.to be_able_to(:create, Role) }
+    # it { is_expected.to be_able_to(:update, Role) }
+    # it { is_expected.to be_able_to(:destroy, Role) }
+    # it { is_expected.to be_able_to([:create, :update, :destroy], User) }
+    # it { is_expected.to be_able_to([:create, :update, :destroy], Push) }
+  end
+end

--- a/spec/support/deposit_helpers.rb
+++ b/spec/support/deposit_helpers.rb
@@ -6,7 +6,7 @@ module DepositHelpers
     #  factory-generated User and AdminSet instances.
     def create_user_and_admin_set_for_deposit
       admin_set = FactoryBot.create(:admin_set)
-      user_role = "TestRole#{rand.to_s[2..5]}"
+      user_role = "ingester"
       user = FactoryBot.create(:user, role_names: [user_role])
       permission_template = FactoryBot.create(:permission_template, source_id: admin_set.id)
       permission_template_access = FactoryBot.create(


### PR DESCRIPTION
Hyrax's authorization system has a few moving parts.
1. The applications's `Ability` class, which includes `CanCan::Ability`.
2. `Hyrax::Ability` and `Hydra::Ability` mixings that are injected into the
    app's `Ability` class.
3. Application data stored in DB tables that inform permissions defined in
   the `Hyrax::Ability` and `Hydra::Ability` mixins.

Previously our permissions defaulted to be overly permissive, and we wanted
to switch that to be restrictive by default, and selectively permissive based
on group.

Also, some of our custom permissions in the app's `Ability` class were being
overwritten by logic within the `hyrax` and `hydra-access-controls` gem.

As a result, some of our tests were passing based on false positives due to the
overly permissive rules, or to rules we had specified that were not having an
effect.

* Adds new rules to `Ability` class and refactors how they are applied by not
  relying on the `custom_permission` method that is provided by the
  `Hydra::Ability` class from the `hydra-access-controls` gem.
* Adds helper methods to `PBCoreXMLItemIngester` class to help determine
  permissions related to ingest of PBCore XML.
* Renames role from "user" to "test-group" when creating `user_with_role`
  variables in some specs. This is a bit more clear that the role is arbitrary.