### PR TITLE
Fixes export cap of 100 results

### DIFF
--- a/app/jobs/export_records_job.rb
+++ b/app/jobs/export_records_job.rb
@@ -11,6 +11,12 @@ class ExportRecordsJob < ApplicationJob
 
   copy_blacklight_config_from(CatalogController)
 
+  configure_blacklight do |config|
+    # This is necessary to prevent Blacklight's default value of 100 for
+    # config.max_per_page from capping the number of results.
+    config.max_per_page = Rails.application.config.max_export_limit
+  end
+
   # @param [Hash] search params
   # @param [User] user
   def perform(search_params, user)


### PR DESCRIPTION
The Blacklight config required to prevent capping exports at 100 got erroneously
removed from the previous PR that was intended to fix it. My fault. This puts it
back in there.