### PR TITLE
Downcase the Upcase

### DIFF
--- a/app/presenters/ams/asset_file_presenter.rb
+++ b/app/presenters/ams/asset_file_presenter.rb
@@ -14,13 +14,12 @@ module AMS
       media_content = []
       if @solr_doc['media']
         @solr_doc['media'].each_with_index do |media,index|
-          if media[:type] == "video"
+          if media[:type].downcase == "video"
             media_content << video_content(@solr_doc.media_src(index.to_s),
                                            width=media[:width].nil??400:media[:width], height=media[:height].nil??400:media[:height], duration=media[:duration])
-          elsif media[:type] == "audio"
+          elsif media[:type].downcase == "audio"
             media_content << audio_content(@solr_doc.media_src(index.to_s),
                                            duration=media[:duration])
-
           end
         end
       end


### PR DESCRIPTION
This was so apparent once I recreated locally. "Audio" was not matching "audio" and no display content was getting passed to iiif_manifest. 