### PR TITLE
Fix rows and split query

### DIFF
--- a/app/controllers/pushes_controller.rb
+++ b/app/controllers/pushes_controller.rb
@@ -70,7 +70,7 @@ class PushesController < ApplicationController
 
   def new
     if params[:transfer] == 'true'
-      ze_params = params
+      ze_params = params.dup
       query_params = delete_extra_params(ze_params)
       query_params[:fl] = 'id'
       query_params[:rows] = 2147483647

--- a/app/controllers/pushes_controller.rb
+++ b/app/controllers/pushes_controller.rb
@@ -3,6 +3,14 @@ class PushesController < ApplicationController
   include Blacklight::SearchHelper
   before_action :authenticate_user!
 
+  include Blacklight::Configurable
+  configure_blacklight do |config|
+    # This is necessary to prevent Blacklight's default value of 100 for
+    # config.max_per_page from capping the number of results.
+    config.max_per_page = 2147483647
+    # config.rows = 2147483647
+  end
+
   def index
     # show all previous pushes
     @pushes = Push.all
@@ -32,6 +40,7 @@ class PushesController < ApplicationController
     
     query_params[:format] = 'zip-pbcore'
     query_params = delete_extra_params(query_params)
+    query_params.delete :controller
 
     ExportRecordsJob.perform_later(query_params, current_user)
     push = Push.create(user_id: current_user.id, pushed_id_csv: ids.join(',') )
@@ -43,21 +52,11 @@ class PushesController < ApplicationController
     # bad input
     return render json: {error: "There was a problem parsing your IDs. Please check your input and try again."} unless requested_ids && requested_ids.count > 0
 
-    query = ""
-    query += requested_ids.map { |id| %(id:#{id}) }.join(' OR ')
-    query = "(#{query})"
-
-    # use this builder so default one doesnt add fq to break our query!!
-    response, response_documents = search_results({}) do |builder|
-      # must pass in with .with here, search_results({q: ...}) is discarded
-      AMS::PushSearchBuilder.new(self).with({q: query, rows: 2147483647})
+    missing_ids = []
+    requested_ids.each_slice(100).each do |segment|
+      query = build_query(requested_ids)
+      missing_ids += verify_ids(query)
     end
-
-    found_ids_set = Set.new( response_documents.map(&:id) )
-    requested_ids_set = Set.new(requested_ids)
-
-    # get exclusive items, remove those exclusive to found_ids
-    missing_ids = (requested_ids_set ^ found_ids_set).subtract(found_ids_set)
 
     all_valid = missing_ids.count == 0 ? true : false
     id_response = {all_valid: all_valid}
@@ -66,21 +65,28 @@ class PushesController < ApplicationController
     render json: id_response
   end
 
-  def transfer_query
-    query_params = delete_extra_params(params)
-    query_params[:fl] = 'id'
+  def new
+    if params[:transfer] == 'true'
+      ze_params = params
+      query_params = delete_extra_params(ze_params)
+      query_params[:fl] = 'id'
+      query_params[:rows] = 2147483647
 
-    # regular query
-    response, response_documents = search_results(query_params)
-    ids = response_documents.map(&:id).join("\n")
-    redirect_to action: 'new', id_field: ids
+      # regular query
+      response, response_documents = search_results(query_params) do |builder|
+        builder = AMS::SearchBuilder.new(self).with(query_params)
+      end
+      params[:id_field] = response_documents.map(&:id).join("\n")
+    end
+
+    render 'new'
   end
 
   def needs_updating
     # Pass a block in to override default search builder's monkeying around
     # Pushbuilder forces correct query params, which are otherwise wiped out
     response, docs = search_results({}) do |builder|
-      AMS::PushSearchBuilder.new(self).with({q: 'needs_update:true', rows: 2147483647})
+      AMS::PushSearchBuilder.new(self).with({q: 'needs_update:true'})
     end
 
     if docs.count > 0
@@ -91,4 +97,26 @@ class PushesController < ApplicationController
       redirect_to new_push_path
     end
   end
+
+  private
+    def build_query(ids)
+      query = ""
+      query += ids.map { |id| %(id:#{id}) }.join(' OR ')
+      query = "(#{query})"
+    end
+
+    def verify_ids(query)
+
+      response, response_documents = search_results({}) do |builder|
+        # must pass in with .with here, search_results({q: ...}) is discarded
+        AMS::PushSearchBuilder.new(self).with({q: query})
+      end
+
+      found_ids_set = Set.new( response_documents.map(&:id) )
+      requested_ids_set = Set.new(requested_ids)
+
+      # get exclusive items, remove those exclusive to found_ids
+      (requested_ids_set ^ found_ids_set).subtract(found_ids_set)
+    end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,8 +13,9 @@ module ApplicationHelper
     params.delete :page
     params.delete :per_page
     params.delete :action
-    params.delete :controller
+    # params.delete :controller
     params.delete :locale
+    params.delete :transfer
     # woo!
     params
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,4 +40,32 @@ module ApplicationHelper
   def user_can_delete?(user)
     user.roles.any? {|r| r.name == 'aapb-admin'}
   end
+
+  def build_query(ids)
+    query = ""
+    query += ids.map { |id| %(id:#{id}) }.join(' OR ')
+    query = "(#{query})"
+  end
+
+  def query_docs(query)
+
+    response, response_documents = search_results({}) do |builder|
+      # must pass in with .with here, search_results({q: ...}) is discarded
+      AMS::PushSearchBuilder.new(self).with({q: query, rows: 2147483647})
+    end
+
+    response_documents
+  end
+
+  def query_ids(query)
+    query_docs(query).map(&:id)
+  end
+
+  def verify_id_set(requested_ids, found_ids)
+    found_ids_set = Set.new( found_ids )
+    requested_ids_set = Set.new( requested_ids )
+
+    # get exclusive items, remove those exclusive to found_ids
+    (requested_ids_set ^ found_ids_set).subtract(found_ids_set)
+  end
 end

--- a/app/jobs/export_records_job.rb
+++ b/app/jobs/export_records_job.rb
@@ -23,7 +23,6 @@ class ExportRecordsJob < ApplicationJob
     self.current_ability = Ability.new(user)
 
     format = search_params.delete :format
-    search_params[:rows] = 2147483647
     response, response_documents = search_results({}) do |builder|
       AMS::PushSearchBuilder.new(self).with(search_params)
     end

--- a/app/jobs/export_records_job.rb
+++ b/app/jobs/export_records_job.rb
@@ -6,11 +6,12 @@ class ExportRecordsJob < ApplicationJob
   # performing searches.
   include Blacklight::Configurable
   include Blacklight::SearchHelper
+  include ApplicationHelper
 
   class_attribute :current_ability
-
+  
+  # this v is required - advanced_search will crash without it
   copy_blacklight_config_from(CatalogController)
-
   configure_blacklight do |config|
     # This is necessary to prevent Blacklight's default value of 100 for
     # config.max_per_page from capping the number of results.
@@ -21,10 +22,27 @@ class ExportRecordsJob < ApplicationJob
   # @param [User] user
   def perform(search_params, user)
     self.current_ability = Ability.new(user)
-
     format = search_params.delete :format
-    response, response_documents = search_results({}) do |builder|
-      AMS::PushSearchBuilder.new(self).with(search_params)
+    
+    # these push queries can be huge (500+), so slice up id queries to kid-size pieces
+    if format == 'zip-pbcore' 
+
+      ids = search_params[:q].gsub('id:', '').split(' OR ')
+      response_documents = [] 
+      docs = nil
+
+      ids.each_slice(100).each do |segment|
+        query = build_query(segment)
+        docs = query_docs(query)
+        response_documents += docs
+      end
+
+    else
+
+      # nothing to see here, folks!
+      response, response_documents = search_results({}) do |builder|
+        AMS::PushSearchBuilder.new(self).with(search_params)
+      end
     end
 
     if format == "csv"

--- a/app/views/catalog/_export_search_results.html.erb
+++ b/app/views/catalog/_export_search_results.html.erb
@@ -12,5 +12,5 @@
 </div>
 
 <% if can? :push_to_aapb, nil && request.env['QUERY_STRING'] && request.env['QUERY_STRING'].present? %>
-  <a class="aapb-push-button" href="/pushes/transfer_query?<%= request.env['QUERY_STRING'] %>">Push To AAPB</a>
+  <a class="aapb-push-button" href="/pushes/new?transfer=true&<%= request.env['QUERY_STRING'] %>">Push To AAPB</a>
 <% end %>

--- a/lib/ams/aapb.rb
+++ b/lib/ams/aapb.rb
@@ -4,26 +4,30 @@ module AMS
   # Module for communicating with the AAPB website.
   module AAPB
     class << self
-      def host
-        ENV.fetch('AAPB_HOST', 'americanarchive.org')
+      def production
+        'americanarchive.org'
       end
 
-      def get(*url_args)
-        HTTParty.get(make_url(*url_args))
+      def demoduction
+        'demo.aapb.wgbh-mla.org'
       end
 
-      def head(*url_args)
-        HTTParty.head make_url(*url_args)
+      def get(host, *url_args)
+        HTTParty.get make_url(host, *url_args)
       end
 
-      def reachable?
-        !!head
+      def head(host, *url_args)
+        HTTParty.head make_url(host, *url_args)
+      end
+
+      def reachable?(host)
+        !!head(host)
       rescue SocketError, Errno::ECONNREFUSED
         false
       end
 
       private
-        def make_url(*url_args)
+        def make_url(host, *url_args)
           # HEAD check requires http://, while ssh requires it naught! joining them like this because URI#join messes up //
           url_args.unshift('http://' + host)
           URI.join(*url_args)


### PR DESCRIPTION
-Split push queries into 100-record batches so solr uri doesnt get too long and cause 414 error
-Move push query functions into ApplicationHelper
-Eliminate superfluous `transfer_query` route to avoid too-big query string on redirect
-Other refactoring