### PR TITLE
Use mailers' queue for export records jobs so that jobs run sooner

### DIFF
--- a/app/jobs/export_records_job.rb
+++ b/app/jobs/export_records_job.rb
@@ -1,6 +1,6 @@
 class ExportRecordsJob < ApplicationJob
-  # Sepcify queue name
-  queue_as :mailers
+  # special queue, so it jumps the ingest-queue line
+  queue_as :exports
 
   # Include Blacklight modules that provide methods for configurating and
   # performing searches.

--- a/app/jobs/export_records_job.rb
+++ b/app/jobs/export_records_job.rb
@@ -1,6 +1,6 @@
 class ExportRecordsJob < ApplicationJob
   # Sepcify queue name
-  queue_as :default
+  queue_as :mailers
 
   # Include Blacklight modules that provide methods for configurating and
   # performing searches.

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,3 +11,4 @@
   - [default, 3]
   - [ingest, 1]
   - [mailers, 10]
+  - [exports, 10]


### PR DESCRIPTION
use mailers queue for export records jobs so that jobs run at some point before the heat death of the universe when an ingest is running