### PR TITLE
Adds Organization to AAPBAdminData

### DIFF
--- a/app/forms/hyrax/asset_form.rb
+++ b/app/forms/hyrax/asset_form.rb
@@ -194,6 +194,14 @@ module Hyrax
       end
     end
 
+    def organization
+      if model.admin_data
+        model.admin_data.organization
+      else
+        ""
+      end
+    end
+
     # Augment the list of permmitted params to accept our fields that have
     # types associated with them, e.g. title + title type
     # NOTE: `super` in this case is HyraxEditor::Form.permitted_params

--- a/app/indexers/asset_indexer.rb
+++ b/app/indexers/asset_indexer.rb
@@ -30,6 +30,7 @@ class AssetIndexer < AMS::WorkIndexer
         solr_doc['licensing_info_ssim'] = solr_doc['licensing_info_tesim'] = object.admin_data.licensing_info if !object.admin_data.licensing_info.blank?
         solr_doc['playlist_group_tesim']  = object.admin_data.playlist_group if !object.admin_data.playlist_group.blank?
         solr_doc['playlist_order_tesim']  = object.admin_data.playlist_order if !object.admin_data.playlist_order.blank?
+        solr_doc['organization_ssim']  = object.admin_data.organization if !object.admin_data.organization.blank?
 
         #Indexing for Facets
         solr_doc['level_of_user_access_ssim'] =  object.admin_data.level_of_user_access if !object.admin_data.level_of_user_access.blank?

--- a/app/models/ams/pbcore_xml_export_extension.rb
+++ b/app/models/ams/pbcore_xml_export_extension.rb
@@ -156,6 +156,7 @@ module AMS::PbcoreXmlExportExtension
     playlist_order.to_a.each { |annotation| xml.pbcoreAnnotation(annotationType: 'Playlist Order') { xml.cdata(annotation) } }
     special_collection.to_a.each { |annotation| xml.pbcoreAnnotation(annotationType: 'special_collections') { xml.cdata(annotation) } }
     self.sonyci_id.to_a.each { |annotation| xml.pbcoreAnnotation(annotationType: 'Sony Ci') { xml.cdata(annotation) } }
+    organization.to_a.each { |annotation| xml.pbcoreAnnotation(annotationType: 'organization') { xml.cdata(annotation) } }
   end
 
   def prepare_instantiations(xml)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -348,6 +348,10 @@ class SolrDocument
     self[Solrizer.solr_name('transcript_status')]
   end
 
+  def organization
+    self[Solrizer.solr_name('organization','ssim')]
+  end
+
   def sonyci_id
     self[Solrizer.solr_name('sonyci_id')]
   end

--- a/app/presenters/hyrax/asset_presenter.rb
+++ b/app/presenters/hyrax/asset_presenter.rb
@@ -9,7 +9,7 @@ module Hyrax
              :program_title, :episode_title, :segment_title, :raw_footage_title, :promo_title, :clip_title, :description,
              :program_description, :episode_description, :segment_description, :raw_footage_description,
              :promo_description, :clip_description, :copyright_date,
-             :level_of_user_access, :minimally_cataloged, :outside_url, :special_collection, :transcript_status,
+             :level_of_user_access, :minimally_cataloged, :outside_url, :special_collection, :transcript_status, :organization,
              :sonyci_id, :licensing_info, :producing_organization, :series_title, :series_description,
              :playlist_group, :playlist_order, :hyrax_batch_ingest_batch_id, :last_pushed, :last_update, :needs_update,
              to: :solr_document
@@ -75,7 +75,8 @@ module Hyrax
           hyrax_batch_ingest_batch_id.blank? &&
           last_updated.blank? &&
           last_pushed.blank? &&
-          needs_update.blank?
+          needs_update.blank? &&
+          organization.blank?
         )
     end
 

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -37,7 +37,8 @@ module AAPB
           "transcript status" => :transcript_status,
           "licensing info" => :licensing_info,
           "playlist group" => :playlist_group,
-          "playlist order" => :playlist_order
+          "playlist order" => :playlist_order,
+          "organization" => :organization
         }
       end
 

--- a/app/views/hyrax/assets/_aapb_admindata.html.erb
+++ b/app/views/hyrax/assets/_aapb_admindata.html.erb
@@ -7,17 +7,17 @@
     <div class="collapse" id="collapse-<%= t('.aapb_admin').parameterize.underscore %>">
       <div class="well">
         <dl>
-          
+
           <%= presenter.attribute_to_html(:level_of_user_access, html_dl: true) %>
           <%= presenter.attribute_to_html(:minimally_cataloged, html_dl: true) %>
           <%= presenter.attribute_to_html(:outside_url, html_dl: true) %>
+          <%= presenter.attribute_to_html(:organization, html_dl: true) %>
           <%= presenter.attribute_to_html(:special_collection, html_dl: true) %>
           <%= presenter.attribute_to_html(:transcript_status, html_dl: true) %>
           <%= presenter.attribute_to_html(:sonyci_id, html_dl: true) %>
           <%= presenter.attribute_to_html(:licensing_info, html_dl: true) %>
           <%= presenter.attribute_to_html(:playlist_group, html_dl: true) %>
           <%= presenter.attribute_to_html(:playlist_order, html_dl: true) %>
-
           <%= presenter.attribute_to_html(:last_pushed, html_dl: true) %>
 
           <%= render 'batch', presenter: presenter %>

--- a/app/views/records/edit_fields/_organization.html.erb
+++ b/app/views/records/edit_fields/_organization.html.erb
@@ -1,0 +1,7 @@
+<% organization =  OrganizationService.new %>
+<%= f.input :organization, as: :select,
+            collection: organization.select_all_options,
+            include_blank: true,
+            disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key),
+            input_html: { class: 'form-control'}
+%>

--- a/db/migrate/20200513190614_add_organization_to_aapb_admin_data.rb
+++ b/db/migrate/20200513190614_add_organization_to_aapb_admin_data.rb
@@ -1,0 +1,5 @@
+class AddOrganizationToAapbAdminData < ActiveRecord::Migration[5.1]
+  def change
+    add_column :admin_data, :organization, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190923224725) do
+ActiveRecord::Schema.define(version: 20200513190614) do
 
-  create_table "admin_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "admin_data", force: :cascade do |t|
     t.string "level_of_user_access"
     t.string "minimally_cataloged"
     t.string "outside_url"
@@ -24,14 +24,15 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.datetime "updated_at", null: false
     t.string "playlist_group"
     t.integer "playlist_order"
-    t.bigint "hyrax_batch_ingest_batch_id"
+    t.integer "hyrax_batch_ingest_batch_id"
     t.integer "last_pushed"
     t.integer "last_updated"
     t.boolean "needs_update"
+    t.string "organization"
     t.index ["hyrax_batch_ingest_batch_id"], name: "index_admin_data_on_hyrax_batch_ingest_batch_id"
   end
 
-  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -43,7 +44,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "checksum_audit_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "checksum_audit_logs", force: :cascade do |t|
     t.string "file_set_id"
     t.string "file_id"
     t.string "checked_uri"
@@ -56,7 +57,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id"
   end
 
-  create_table "collection_branding_infos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "collection_branding_infos", force: :cascade do |t|
     t.string "collection_id"
     t.string "role"
     t.string "local_path"
@@ -68,8 +69,8 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "collection_type_participants", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
-    t.bigint "hyrax_collection_type_id"
+  create_table "collection_type_participants", force: :cascade do |t|
+    t.integer "hyrax_collection_type_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -78,7 +79,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["hyrax_collection_type_id"], name: "hyrax_collection_type_id"
   end
 
-  create_table "content_blocks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "content_blocks", force: :cascade do |t|
     t.string "name"
     t.text "value"
     t.datetime "created_at", null: false
@@ -86,14 +87,14 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.string "external_key"
   end
 
-  create_table "curation_concerns_operations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "curation_concerns_operations", force: :cascade do |t|
     t.string "status"
     t.string "operation_type"
     t.string "job_class"
     t.string "job_id"
     t.string "type"
     t.text "message"
-    t.bigint "user_id"
+    t.integer "user_id"
     t.integer "parent_id"
     t.integer "lft", null: false
     t.integer "rgt", null: false
@@ -107,7 +108,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
   end
 
-  create_table "featured_works", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "featured_works", force: :cascade do |t|
     t.integer "order", default: 5
     t.string "work_id"
     t.datetime "created_at", null: false
@@ -116,7 +117,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["work_id"], name: "index_featured_works_on_work_id"
   end
 
-  create_table "file_download_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "file_download_stats", force: :cascade do |t|
     t.datetime "date"
     t.integer "downloads"
     t.string "file_id"
@@ -127,7 +128,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["user_id"], name: "index_file_download_stats_on_user_id"
   end
 
-  create_table "file_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "file_view_stats", force: :cascade do |t|
     t.datetime "date"
     t.integer "views"
     t.string "file_id"
@@ -138,8 +139,8 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
   end
 
-  create_table "hyrax_batch_ingest_batch_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
-    t.bigint "batch_id"
+  create_table "hyrax_batch_ingest_batch_items", force: :cascade do |t|
+    t.integer "batch_id"
     t.string "id_within_batch"
     t.text "source_data"
     t.string "source_location"
@@ -152,7 +153,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["batch_id"], name: "index_hyrax_batch_ingest_batch_items_on_batch_id"
   end
 
-  create_table "hyrax_batch_ingest_batches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "hyrax_batch_ingest_batches", force: :cascade do |t|
     t.string "status"
     t.string "submitter_email"
     t.string "source_location"
@@ -166,7 +167,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.datetime "end_time"
   end
 
-  create_table "hyrax_collection_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "hyrax_collection_types", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.string "machine_id"
@@ -183,14 +184,14 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
   end
 
-  create_table "hyrax_features", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "hyrax_features", force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "instantiation_admin_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "instantiation_admin_data", force: :cascade do |t|
     t.string "aapb_preservation_lto"
     t.string "aapb_preservation_disk"
     t.datetime "created_at", null: false
@@ -198,9 +199,9 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.string "md5"
   end
 
-  create_table "job_io_wrappers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
-    t.bigint "user_id"
-    t.bigint "uploaded_file_id"
+  create_table "job_io_wrappers", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "uploaded_file_id"
     t.string "file_set_id"
     t.string "mime_type"
     t.string "original_name"
@@ -212,7 +213,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "mailboxer_conversation_opt_outs", force: :cascade do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -220,13 +221,13 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "mailboxer_conversations", force: :cascade do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "mailboxer_notifications", force: :cascade do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -249,7 +250,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "mailboxer_receipts", force: :cascade do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -266,19 +267,19 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "minter_states", force: :cascade do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
-    t.bigint "seq", default: 0
+    t.integer "seq", limit: 8, default: 0
     t.binary "rand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
   end
 
-  create_table "permission_template_accesses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
-    t.bigint "permission_template_id"
+  create_table "permission_template_accesses", force: :cascade do |t|
+    t.integer "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -288,7 +289,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["permission_template_id"], name: "index_permission_template_accesses_on_permission_template_id"
   end
 
-  create_table "permission_templates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "permission_templates", force: :cascade do |t|
     t.string "source_id"
     t.string "visibility"
     t.datetime "created_at", null: false
@@ -298,10 +299,10 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["source_id"], name: "index_permission_templates_on_source_id", unique: true
   end
 
-  create_table "proxy_deposit_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "proxy_deposit_requests", force: :cascade do |t|
     t.string "work_id", null: false
-    t.bigint "sending_user_id", null: false
-    t.bigint "receiving_user_id", null: false
+    t.integer "sending_user_id", null: false
+    t.integer "receiving_user_id", null: false
     t.datetime "fulfillment_date"
     t.string "status", default: "pending", null: false
     t.text "sender_comment"
@@ -312,31 +313,31 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id"
   end
 
-  create_table "proxy_deposit_rights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
-    t.bigint "grantor_id"
-    t.bigint "grantee_id"
+  create_table "proxy_deposit_rights", force: :cascade do |t|
+    t.integer "grantor_id"
+    t.integer "grantee_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["grantee_id"], name: "index_proxy_deposit_rights_on_grantee_id"
     t.index ["grantor_id"], name: "index_proxy_deposit_rights_on_grantor_id"
   end
 
-  create_table "pushes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "pushes", force: :cascade do |t|
     t.text "pushed_id_csv"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
   end
 
-  create_table "qa_local_authorities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "qa_local_authorities", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_qa_local_authorities_on_name", unique: true
   end
 
-  create_table "qa_local_authority_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
-    t.bigint "local_authority_id"
+  create_table "qa_local_authority_entries", force: :cascade do |t|
+    t.integer "local_authority_id"
     t.string "label"
     t.string "uri"
     t.datetime "created_at", null: false
@@ -345,11 +346,11 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
-  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "roles", force: :cascade do |t|
     t.string "name"
   end
 
-  create_table "roles_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "roles_users", id: false, force: :cascade do |t|
     t.integer "role_id"
     t.integer "user_id"
     t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
@@ -358,7 +359,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["user_id"], name: "index_roles_users_on_user_id"
   end
 
-  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "searches", force: :cascade do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -367,7 +368,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "single_use_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "single_use_links", force: :cascade do |t|
     t.string "downloadKey"
     t.string "path"
     t.string "itemId"
@@ -376,7 +377,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "sipity_agents", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_agents", force: :cascade do |t|
     t.string "proxy_for_id", null: false
     t.string "proxy_for_type", null: false
     t.datetime "created_at", null: false
@@ -384,7 +385,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_agents_proxy_for", unique: true
   end
 
-  create_table "sipity_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_comments", force: :cascade do |t|
     t.integer "entity_id", null: false
     t.integer "agent_id", null: false
     t.text "comment"
@@ -395,7 +396,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["entity_id"], name: "index_sipity_comments_on_entity_id"
   end
 
-  create_table "sipity_entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_entities", force: :cascade do |t|
     t.string "proxy_for_global_id", null: false
     t.integer "workflow_id", null: false
     t.integer "workflow_state_id"
@@ -406,7 +407,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["workflow_state_id"], name: "index_sipity_entities_on_workflow_state_id"
   end
 
-  create_table "sipity_entity_specific_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_entity_specific_responsibilities", force: :cascade do |t|
     t.integer "workflow_role_id", null: false
     t.string "entity_id", null: false
     t.integer "agent_id", null: false
@@ -418,7 +419,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["workflow_role_id"], name: "sipity_entity_specific_responsibilities_role"
   end
 
-  create_table "sipity_notifiable_contexts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_notifiable_contexts", force: :cascade do |t|
     t.integer "scope_for_notification_id", null: false
     t.string "scope_for_notification_type", null: false
     t.string "reason_for_notification", null: false
@@ -431,7 +432,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "sipity_notifiable_contexts_concern"
   end
 
-  create_table "sipity_notification_recipients", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_notification_recipients", force: :cascade do |t|
     t.integer "notification_id", null: false
     t.integer "role_id", null: false
     t.string "recipient_strategy", null: false
@@ -443,7 +444,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["role_id"], name: "sipity_notification_recipients_role"
   end
 
-  create_table "sipity_notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_notifications", force: :cascade do |t|
     t.string "name", null: false
     t.string "notification_type", null: false
     t.datetime "created_at", null: false
@@ -452,7 +453,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["notification_type"], name: "index_sipity_notifications_on_notification_type"
   end
 
-  create_table "sipity_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_roles", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -460,7 +461,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
 
-  create_table "sipity_workflow_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_actions", force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.integer "resulting_workflow_state_id"
     t.string "name", null: false
@@ -471,7 +472,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["workflow_id"], name: "sipity_workflow_actions_workflow"
   end
 
-  create_table "sipity_workflow_methods", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_methods", force: :cascade do |t|
     t.string "service_name", null: false
     t.integer "weight", null: false
     t.integer "workflow_action_id", null: false
@@ -480,7 +481,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["workflow_action_id"], name: "index_sipity_workflow_methods_on_workflow_action_id"
   end
 
-  create_table "sipity_workflow_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_responsibilities", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "workflow_role_id", null: false
     t.datetime "created_at", null: false
@@ -488,7 +489,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["agent_id", "workflow_role_id"], name: "sipity_workflow_responsibilities_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_roles", force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -496,7 +497,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["workflow_id", "role_id"], name: "sipity_workflow_roles_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_action_permissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_state_action_permissions", force: :cascade do |t|
     t.integer "workflow_role_id", null: false
     t.integer "workflow_state_action_id", null: false
     t.datetime "created_at", null: false
@@ -504,7 +505,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["workflow_role_id", "workflow_state_action_id"], name: "sipity_workflow_state_action_permissions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_state_actions", force: :cascade do |t|
     t.integer "originating_workflow_state_id", null: false
     t.integer "workflow_action_id", null: false
     t.datetime "created_at", null: false
@@ -512,7 +513,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["originating_workflow_state_id", "workflow_action_id"], name: "sipity_workflow_state_actions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_states", force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -521,7 +522,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["workflow_id", "name"], name: "sipity_type_state_aggregate", unique: true
   end
 
-  create_table "sipity_workflows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflows", force: :cascade do |t|
     t.string "name", null: false
     t.string "label"
     t.text "description"
@@ -533,22 +534,22 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
   end
 
-  create_table "tinymce_assets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "tinymce_assets", force: :cascade do |t|
     t.string "file"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "trophies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "trophies", force: :cascade do |t|
     t.integer "user_id"
     t.string "work_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "uploaded_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "uploaded_files", force: :cascade do |t|
     t.string "file"
-    t.bigint "user_id"
+    t.integer "user_id"
     t.string "file_set_uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -556,7 +557,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end
 
-  create_table "user_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "user_stats", force: :cascade do |t|
     t.integer "user_id"
     t.datetime "date"
     t.integer "file_views"
@@ -567,7 +568,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["user_id"], name: "index_user_stats_on_user_id"
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -611,7 +612,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "version_committers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "version_committers", force: :cascade do |t|
     t.string "obj_id"
     t.string "datastream_id"
     t.string "version_id"
@@ -620,7 +621,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "work_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "work_view_stats", force: :cascade do |t|
     t.datetime "date"
     t.integer "work_views"
     t.string "work_id"
@@ -631,14 +632,4 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
-  add_foreign_key "admin_data", "hyrax_batch_ingest_batches"
-  add_foreign_key "collection_type_participants", "hyrax_collection_types"
-  add_foreign_key "curation_concerns_operations", "users"
-  add_foreign_key "hyrax_batch_ingest_batch_items", "hyrax_batch_ingest_batches", column: "batch_id"
-  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
-  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
-  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
-  add_foreign_key "permission_template_accesses", "permission_templates"
-  add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
-  add_foreign_key "uploaded_files", "users"
 end

--- a/db/schema.test.rb
+++ b/db/schema.test.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190923224725) do
+ActiveRecord::Schema.define(version: 20200513190614) do
 
   create_table "admin_data", force: :cascade do |t|
     t.string "level_of_user_access"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20190923224725) do
     t.integer "last_pushed"
     t.integer "last_updated"
     t.boolean "needs_update"
+    t.string "organization"
     t.index ["hyrax_batch_ingest_batch_id"], name: "index_admin_data_on_hyrax_batch_ingest_batch_id"
   end
 


### PR DESCRIPTION
This PR adds the ability to add a Organization to the AAPBAdminData that is used to populate a PBCore Annotation on the Asset level that is used for ingesting transcripts in to Fix It +.