### PR TITLE
Adds #solr_doc and #asset methods to AdminData

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -19,7 +19,7 @@ module Hyrax
         save_aapb_admin_data(env) && super && create_or_update_contributions(env, contributions)
       end
 
-      def destory(env)
+      def destroy(env)
         super && destroy_admin_data(env)
       end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20200611175611) do
 
-  create_table "admin_data", force: :cascade do |t|
+  create_table "admin_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "level_of_user_access"
     t.string "minimally_cataloged"
     t.string "outside_url"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.datetime "updated_at", null: false
     t.string "playlist_group"
     t.integer "playlist_order"
-    t.integer "hyrax_batch_ingest_batch_id"
+    t.bigint "hyrax_batch_ingest_batch_id"
     t.integer "last_pushed"
     t.integer "last_updated"
     t.boolean "needs_update"
@@ -34,20 +34,20 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["hyrax_batch_ingest_batch_id"], name: "index_admin_data_on_hyrax_batch_ingest_batch_id"
   end
 
-  create_table "annotations", force: :cascade do |t|
+  create_table "annotations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "annotation_type"
     t.string "ref"
     t.string "source"
     t.string "annotation"
     t.string "version"
     t.string "value"
-    t.integer "admin_data_id"
+    t.bigint "admin_data_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["admin_data_id"], name: "index_annotations_on_admin_data_id"
   end
 
-  create_table "bookmarks", force: :cascade do |t|
+  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "checksum_audit_logs", force: :cascade do |t|
+  create_table "checksum_audit_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "file_set_id"
     t.string "file_id"
     t.string "checked_uri"
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id"
   end
 
-  create_table "collection_branding_infos", force: :cascade do |t|
+  create_table "collection_branding_infos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "collection_id"
     t.string "role"
     t.string "local_path"
@@ -84,8 +84,8 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "collection_type_participants", force: :cascade do |t|
-    t.integer "hyrax_collection_type_id"
+  create_table "collection_type_participants", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+    t.bigint "hyrax_collection_type_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -94,7 +94,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["hyrax_collection_type_id"], name: "hyrax_collection_type_id"
   end
 
-  create_table "content_blocks", force: :cascade do |t|
+  create_table "content_blocks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "name"
     t.text "value"
     t.datetime "created_at", null: false
@@ -102,14 +102,14 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.string "external_key"
   end
 
-  create_table "curation_concerns_operations", force: :cascade do |t|
+  create_table "curation_concerns_operations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "status"
     t.string "operation_type"
     t.string "job_class"
     t.string "job_id"
     t.string "type"
     t.text "message"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.integer "parent_id"
     t.integer "lft", null: false
     t.integer "rgt", null: false
@@ -123,7 +123,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
   end
 
-  create_table "featured_works", force: :cascade do |t|
+  create_table "featured_works", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "order", default: 5
     t.string "work_id"
     t.datetime "created_at", null: false
@@ -132,7 +132,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["work_id"], name: "index_featured_works_on_work_id"
   end
 
-  create_table "file_download_stats", force: :cascade do |t|
+  create_table "file_download_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.datetime "date"
     t.integer "downloads"
     t.string "file_id"
@@ -143,7 +143,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["user_id"], name: "index_file_download_stats_on_user_id"
   end
 
-  create_table "file_view_stats", force: :cascade do |t|
+  create_table "file_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.datetime "date"
     t.integer "views"
     t.string "file_id"
@@ -154,8 +154,8 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
   end
 
-  create_table "hyrax_batch_ingest_batch_items", force: :cascade do |t|
-    t.integer "batch_id"
+  create_table "hyrax_batch_ingest_batch_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+    t.bigint "batch_id"
     t.string "id_within_batch"
     t.text "source_data"
     t.string "source_location"
@@ -168,7 +168,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["batch_id"], name: "index_hyrax_batch_ingest_batch_items_on_batch_id"
   end
 
-  create_table "hyrax_batch_ingest_batches", force: :cascade do |t|
+  create_table "hyrax_batch_ingest_batches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "status"
     t.string "submitter_email"
     t.string "source_location"
@@ -182,7 +182,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.datetime "end_time"
   end
 
-  create_table "hyrax_collection_types", force: :cascade do |t|
+  create_table "hyrax_collection_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "title"
     t.text "description"
     t.string "machine_id"
@@ -199,14 +199,14 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
   end
 
-  create_table "hyrax_features", force: :cascade do |t|
+  create_table "hyrax_features", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "instantiation_admin_data", force: :cascade do |t|
+  create_table "instantiation_admin_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "aapb_preservation_lto"
     t.string "aapb_preservation_disk"
     t.datetime "created_at", null: false
@@ -214,9 +214,9 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.string "md5"
   end
 
-  create_table "job_io_wrappers", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "uploaded_file_id"
+  create_table "job_io_wrappers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+    t.bigint "user_id"
+    t.bigint "uploaded_file_id"
     t.string "file_set_id"
     t.string "mime_type"
     t.string "original_name"
@@ -228,7 +228,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", force: :cascade do |t|
+  create_table "mailboxer_conversation_opt_outs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -236,13 +236,13 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", force: :cascade do |t|
+  create_table "mailboxer_conversations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", force: :cascade do |t|
+  create_table "mailboxer_notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", force: :cascade do |t|
+  create_table "mailboxer_receipts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -282,19 +282,19 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", force: :cascade do |t|
+  create_table "minter_states", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
-    t.integer "seq", limit: 8, default: 0
+    t.bigint "seq", default: 0
     t.binary "rand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
   end
 
-  create_table "permission_template_accesses", force: :cascade do |t|
-    t.integer "permission_template_id"
+  create_table "permission_template_accesses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+    t.bigint "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
     t.string "access"
@@ -304,7 +304,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["permission_template_id"], name: "index_permission_template_accesses_on_permission_template_id"
   end
 
-  create_table "permission_templates", force: :cascade do |t|
+  create_table "permission_templates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "source_id"
     t.string "visibility"
     t.datetime "created_at", null: false
@@ -314,10 +314,10 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["source_id"], name: "index_permission_templates_on_source_id", unique: true
   end
 
-  create_table "proxy_deposit_requests", force: :cascade do |t|
+  create_table "proxy_deposit_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "work_id", null: false
-    t.integer "sending_user_id", null: false
-    t.integer "receiving_user_id", null: false
+    t.bigint "sending_user_id", null: false
+    t.bigint "receiving_user_id", null: false
     t.datetime "fulfillment_date"
     t.string "status", default: "pending", null: false
     t.text "sender_comment"
@@ -328,31 +328,31 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id"
   end
 
-  create_table "proxy_deposit_rights", force: :cascade do |t|
-    t.integer "grantor_id"
-    t.integer "grantee_id"
+  create_table "proxy_deposit_rights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+    t.bigint "grantor_id"
+    t.bigint "grantee_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["grantee_id"], name: "index_proxy_deposit_rights_on_grantee_id"
     t.index ["grantor_id"], name: "index_proxy_deposit_rights_on_grantor_id"
   end
 
-  create_table "pushes", force: :cascade do |t|
+  create_table "pushes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.text "pushed_id_csv"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
   end
 
-  create_table "qa_local_authorities", force: :cascade do |t|
+  create_table "qa_local_authorities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_qa_local_authorities_on_name", unique: true
   end
 
-  create_table "qa_local_authority_entries", force: :cascade do |t|
-    t.integer "local_authority_id"
+  create_table "qa_local_authority_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+    t.bigint "local_authority_id"
     t.string "label"
     t.string "uri"
     t.datetime "created_at", null: false
@@ -361,11 +361,11 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
-  create_table "roles", force: :cascade do |t|
+  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "name"
   end
 
-  create_table "roles_users", id: false, force: :cascade do |t|
+  create_table "roles_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "role_id"
     t.integer "user_id"
     t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
@@ -374,7 +374,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["user_id"], name: "index_roles_users_on_user_id"
   end
 
-  create_table "searches", force: :cascade do |t|
+  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -383,7 +383,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "single_use_links", force: :cascade do |t|
+  create_table "single_use_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "downloadKey"
     t.string "path"
     t.string "itemId"
@@ -392,7 +392,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "sipity_agents", force: :cascade do |t|
+  create_table "sipity_agents", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "proxy_for_id", null: false
     t.string "proxy_for_type", null: false
     t.datetime "created_at", null: false
@@ -400,7 +400,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_agents_proxy_for", unique: true
   end
 
-  create_table "sipity_comments", force: :cascade do |t|
+  create_table "sipity_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "entity_id", null: false
     t.integer "agent_id", null: false
     t.text "comment"
@@ -411,7 +411,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["entity_id"], name: "index_sipity_comments_on_entity_id"
   end
 
-  create_table "sipity_entities", force: :cascade do |t|
+  create_table "sipity_entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "proxy_for_global_id", null: false
     t.integer "workflow_id", null: false
     t.integer "workflow_state_id"
@@ -422,7 +422,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["workflow_state_id"], name: "index_sipity_entities_on_workflow_state_id"
   end
 
-  create_table "sipity_entity_specific_responsibilities", force: :cascade do |t|
+  create_table "sipity_entity_specific_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "workflow_role_id", null: false
     t.string "entity_id", null: false
     t.integer "agent_id", null: false
@@ -434,7 +434,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["workflow_role_id"], name: "sipity_entity_specific_responsibilities_role"
   end
 
-  create_table "sipity_notifiable_contexts", force: :cascade do |t|
+  create_table "sipity_notifiable_contexts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "scope_for_notification_id", null: false
     t.string "scope_for_notification_type", null: false
     t.string "reason_for_notification", null: false
@@ -447,7 +447,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "sipity_notifiable_contexts_concern"
   end
 
-  create_table "sipity_notification_recipients", force: :cascade do |t|
+  create_table "sipity_notification_recipients", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "notification_id", null: false
     t.integer "role_id", null: false
     t.string "recipient_strategy", null: false
@@ -459,7 +459,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["role_id"], name: "sipity_notification_recipients_role"
   end
 
-  create_table "sipity_notifications", force: :cascade do |t|
+  create_table "sipity_notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "name", null: false
     t.string "notification_type", null: false
     t.datetime "created_at", null: false
@@ -468,7 +468,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["notification_type"], name: "index_sipity_notifications_on_notification_type"
   end
 
-  create_table "sipity_roles", force: :cascade do |t|
+  create_table "sipity_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -476,7 +476,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
 
-  create_table "sipity_workflow_actions", force: :cascade do |t|
+  create_table "sipity_workflow_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "workflow_id", null: false
     t.integer "resulting_workflow_state_id"
     t.string "name", null: false
@@ -487,7 +487,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["workflow_id"], name: "sipity_workflow_actions_workflow"
   end
 
-  create_table "sipity_workflow_methods", force: :cascade do |t|
+  create_table "sipity_workflow_methods", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "service_name", null: false
     t.integer "weight", null: false
     t.integer "workflow_action_id", null: false
@@ -496,7 +496,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["workflow_action_id"], name: "index_sipity_workflow_methods_on_workflow_action_id"
   end
 
-  create_table "sipity_workflow_responsibilities", force: :cascade do |t|
+  create_table "sipity_workflow_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "agent_id", null: false
     t.integer "workflow_role_id", null: false
     t.datetime "created_at", null: false
@@ -504,7 +504,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["agent_id", "workflow_role_id"], name: "sipity_workflow_responsibilities_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_roles", force: :cascade do |t|
+  create_table "sipity_workflow_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "workflow_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -512,7 +512,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["workflow_id", "role_id"], name: "sipity_workflow_roles_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_action_permissions", force: :cascade do |t|
+  create_table "sipity_workflow_state_action_permissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "workflow_role_id", null: false
     t.integer "workflow_state_action_id", null: false
     t.datetime "created_at", null: false
@@ -520,7 +520,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["workflow_role_id", "workflow_state_action_id"], name: "sipity_workflow_state_action_permissions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_actions", force: :cascade do |t|
+  create_table "sipity_workflow_state_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "originating_workflow_state_id", null: false
     t.integer "workflow_action_id", null: false
     t.datetime "created_at", null: false
@@ -528,7 +528,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["originating_workflow_state_id", "workflow_action_id"], name: "sipity_workflow_state_actions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_states", force: :cascade do |t|
+  create_table "sipity_workflow_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "workflow_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -537,7 +537,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["workflow_id", "name"], name: "sipity_type_state_aggregate", unique: true
   end
 
-  create_table "sipity_workflows", force: :cascade do |t|
+  create_table "sipity_workflows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "name", null: false
     t.string "label"
     t.text "description"
@@ -549,22 +549,22 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
   end
 
-  create_table "tinymce_assets", force: :cascade do |t|
+  create_table "tinymce_assets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "file"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "trophies", force: :cascade do |t|
+  create_table "trophies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "user_id"
     t.string "work_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "uploaded_files", force: :cascade do |t|
+  create_table "uploaded_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "file"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "file_set_uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -572,7 +572,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end
 
-  create_table "user_stats", force: :cascade do |t|
+  create_table "user_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.integer "user_id"
     t.datetime "date"
     t.integer "file_views"
@@ -583,7 +583,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["user_id"], name: "index_user_stats_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -627,7 +627,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "version_committers", force: :cascade do |t|
+  create_table "version_committers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.string "obj_id"
     t.string "datastream_id"
     t.string "version_id"
@@ -636,7 +636,7 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "work_view_stats", force: :cascade do |t|
+  create_table "work_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
     t.datetime "date"
     t.integer "work_views"
     t.string "work_id"
@@ -647,4 +647,15 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "admin_data", "hyrax_batch_ingest_batches"
+  add_foreign_key "annotations", "admin_data", column: "admin_data_id"
+  add_foreign_key "collection_type_participants", "hyrax_collection_types"
+  add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "hyrax_batch_ingest_batch_items", "hyrax_batch_ingest_batches", column: "batch_id"
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
+  add_foreign_key "permission_template_accesses", "permission_templates"
+  add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
+  add_foreign_key "uploaded_files", "users"
 end

--- a/db/schema.test.rb
+++ b/db/schema.test.rb
@@ -34,6 +34,19 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.index ["hyrax_batch_ingest_batch_id"], name: "index_admin_data_on_hyrax_batch_ingest_batch_id"
   end
 
+  create_table "annotations", force: :cascade do |t|
+    t.string "annotation_type"
+    t.string "ref"
+    t.string "source"
+    t.string "annotation"
+    t.string "version"
+    t.string "value"
+    t.integer "admin_data_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["admin_data_id"], name: "index_annotations_on_admin_data_id"
+  end
+
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"
@@ -534,15 +547,6 @@ ActiveRecord::Schema.define(version: 20200611175611) do
     t.boolean "active"
     t.boolean "allows_access_grant"
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
-  end
-
-  create_table "supplemental_materials", force: :cascade do |t|
-    t.string "href"
-    t.string "value"
-    t.integer "admin_data_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["admin_data_id"], name: "index_supplemental_materials_on_admin_data_id"
   end
 
   create_table "tinymce_assets", force: :cascade do |t|

--- a/spec/models/admin_data_spec.rb
+++ b/spec/models/admin_data_spec.rb
@@ -16,4 +16,25 @@ RSpec.describe AdminData, type: :model do
       expect(admin_data.gid).to eq(expected_admin_data_gid)
     end
   end
+
+  context 'when it has an associated Fedora object and Solr document (as it always should)' do
+    let!(:asset) { create(:asset) }
+    let(:admin_data) { AdminData.find_by_gid(asset.admin_data_gid) }
+
+    describe '#solr_doc' do
+      it 'returns the solr document' do
+        # Expect the Solr doc ID to be the same as the Asset ID
+        expect(admin_data.solr_doc.id).to eq asset.id
+        # Expect the AdminData gid to be teh same as what's in the returned
+        # solr doc.
+        expect(admin_data.solr_doc[:admin_data_gid_ssim].first).to eq admin_data.gid
+      end
+    end
+
+    describe '#asset' do
+      it 'returns the asset' do
+        expect(admin_data.asset).to eq asset
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Adds AdminData#solr_doc to lazily fetch associated Solr doc, if present, using
  the AdminData#gid value.
* Adds AdminData#asset to lazily fetch Asset instance, if present, using the
  Solr document's ID. If the Asset.find operation raises an error, it's
  rescued from, and assigned to AdminData#asset_error.

Also, incidentally updates DB schemas due to running migrations with MySQL.