### PR TITLE
Fixes producing_organization solr_document accessor + Cleanup

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -59,9 +59,9 @@ class CatalogController < ApplicationController
     config.add_facet_field "level_of_user_access_ssim", label: "Level of user access", limit: 5, collapse: true
     config.add_facet_field "transcript_status_ssim", label: "Transcript Status", limit: 5, collapse: true
 
-    config.add_facet_field 'minimally_cataloged_ssim', query: {
-        yes: { label: 'Yes', fq: 'minimally_cataloged_ssim:Yes' },
-        no: { label: 'No', fq: '-minimally_cataloged_ssim:[* TO *]' }
+    config.add_facet_field 'cataloging_status_ssim', query: {
+        yes: { label: 'Yes', fq: 'cataloging_status_ssim:Yes' },
+        no: { label: 'No', fq: '-cataloging_status_ssim:[* TO *]' }
      }, label:"Minimally Cataloged", collapse: true
 
     config.add_facet_field 'outside_url_ssim', query: {

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -65,11 +65,8 @@ class Ability
                               Annotation ]
 
     # Field-level permissions for Admin Data
-    can [:update_level_of_user_access, :update_minimally_cataloged,
-         :update_outside_url, :update_sonyci_id, :update_licensing_info,
-         :update_playlist_group, :update_playlist_order,
-         :update_hyrax_batch_ingest_batch_id, :update_last_pushed,
-         :update_last_updated, :update_needs_update, :update_special_collection_category], AdminData
+    can [ :update_sonyci_id, :update_hyrax_batch_ingest_batch_id, :update_last_pushed,
+         :update_last_updated, :update_needs_update ], AdminData
   end
 
   # Sets permissions for 'aapb-admin' users.

--- a/app/models/ams/csv_export_extension.rb
+++ b/app/models/ams/csv_export_extension.rb
@@ -1,7 +1,7 @@
 module AMS
   module CsvExportExtension
     CSV_FIELDS = {'asset' =>
-                    { :GUID=>:id,:local_identifier=>:local_identifier,:title=>:title,:dates=>:all_dates,:producing_organization=>:producing_organization, :description=>:description,:level_of_user_access=>:level_of_user_access,:minimally_cataloged=>:minimally_cataloged, :holding_organization =>:holding_organization_ssim}.freeze,
+                    { :GUID=>:id,:local_identifier=>:local_identifier,:title=>:title,:dates=>:all_dates,:producing_organization=>:producing_organization, :description=>:description,:level_of_user_access=>:level_of_user_access,:cataloging_status=>:cataloging_status, :holding_organization =>:holding_organization_ssim}.freeze,
                   'digital_instantiation' =>
                     { :asset_id=>:id,:digital_instantiation_id=>:id,:local_identifier=>:local_instantiation_identifier,:md5=>:md5, :media_type=>:media_type,:generations=>:generations,:duration=>:duration,:file_size=>:file_size }.freeze,
                   'physical_instantiation' =>

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -328,12 +328,12 @@ class SolrDocument
     self[Solrizer.solr_name('affiliation')]
   end
 
-  def level_of_user_access
-    self[Solrizer.solr_name('level_of_user_access', 'ssim')]
+  def producing_organization
+    self[Solrizer.solr_name('producing_organization')]
   end
 
-  def minimally_cataloged
-    self[Solrizer.solr_name('minimally_cataloged', 'ssim')]
+  def level_of_user_access
+    self[Solrizer.solr_name('level_of_user_access', 'ssim')]
   end
 
   def outside_url
@@ -359,10 +359,6 @@ class SolrDocument
   def licensing_info
     self[Solrizer.solr_name('licensing_info', 'ssim')]
     end
-
-  def producing_organization
-    self[Solrizer.solr_name('producing_organization', 'ssim')]
-  end
 
   def playlist_group
     self[Solrizer.solr_name('playlist_group', 'ssim')]
@@ -409,19 +405,15 @@ class SolrDocument
   end
 
   def special_collection_category
-    self[Solrizer.solr_name('special_collection_category')]
+    self[Solrizer.solr_name('special_collection_category', 'ssim')]
   end
 
   def canonical_meta_tag
-    self[Solrizer.solr_name('canonical_meta_tag')]
+    self[Solrizer.solr_name('canonical_meta_tag', 'ssim')]
   end
 
   def cataloging_status
     self[Solrizer.solr_name('cataloging_status', 'ssim')]
-  end
-
-  def captions_url
-    self[Solrizer.solr_name('captions_url', 'ssim')]
   end
 
   def captions_url

--- a/app/presenters/hyrax/asset_presenter.rb
+++ b/app/presenters/hyrax/asset_presenter.rb
@@ -9,7 +9,7 @@ module Hyrax
              :program_title, :episode_title, :segment_title, :raw_footage_title, :promo_title, :clip_title, :description,
              :program_description, :episode_description, :segment_description, :raw_footage_description,
              :promo_description, :clip_description, :copyright_date,
-             :level_of_user_access, :minimally_cataloged, :outside_url, :special_collections, :transcript_status, :organization,
+             :level_of_user_access, :outside_url, :special_collections, :transcript_status, :organization,
              :sonyci_id, :licensing_info, :producing_organization, :series_title, :series_description,
              :playlist_group, :playlist_order, :hyrax_batch_ingest_batch_id, :last_pushed, :last_update, :needs_update, :special_collection_category, :canonical_meta_tag, :cataloging_status,
              to: :solr_document

--- a/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
@@ -244,19 +244,11 @@ module AAPB
           # Otherwise, if use can update all these specific fiels, then return
           # true.
           [
-            :update_level_of_user_access,
-            :update_minimally_cataloged,
-            :update_outside_url,
             :update_sonyci_id,
-            :update_licensing_info,
-            :update_playlist_group,
-            :update_playlist_order,
             :update_hyrax_batch_ingest_batch_id,
             :update_last_pushed,
             :update_last_updated,
             :update_needs_update,
-            :update_special_collection_category,
-            :update_canonical_meta_tag
           ].all? do |action|
             ability.can? action, AdminData
           end

--- a/app/services/level_of_user_access_service.rb
+++ b/app/services/level_of_user_access_service.rb
@@ -1,5 +1,0 @@
-class LevelOfUserAccessService < Hyrax::QaSelectService
-  def initialize
-    super('level_of_user_access')
-  end
-end

--- a/app/services/minimally_cataloged_service.rb
+++ b/app/services/minimally_cataloged_service.rb
@@ -1,5 +1,0 @@
-class MinimallyCatalogedService < Hyrax::QaSelectService
-  def initialize
-    super('minimally_cataloged')
-  end
-end

--- a/app/services/transcript_status_service.rb
+++ b/app/services/transcript_status_service.rb
@@ -1,5 +1,0 @@
-class TranscriptStatusService < Hyrax::QaSelectService
-  def initialize
-    super('transcript_status')
-  end
-end

--- a/app/views/records/edit_fields/_level_of_user_access.html.erb
+++ b/app/views/records/edit_fields/_level_of_user_access.html.erb
@@ -1,7 +1,0 @@
-<% level_of_user_access =  LevelOfUserAccessService.new %>
-<%= f.input :level_of_user_access, as: :select,
-            collection: level_of_user_access.select_all_options,
-            include_blank: true,
-            disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key),
-            input_html: { class: 'form-control'}
-%>

--- a/app/views/records/edit_fields/_licensing_info.html.erb
+++ b/app/views/records/edit_fields/_licensing_info.html.erb
@@ -1,5 +1,0 @@
-<% if f.object.multiple? key %>
-  <%= f.input :licensing_info, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key), required: f.object.required?(key) %>
-<% else %>
-  <%= f.input :licensing_info, as: :text, input_html: { rows: '14' }, disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key), required: f.object.required?(key) %>
-<% end %>

--- a/app/views/records/edit_fields/_minimally_cataloged.html.erb
+++ b/app/views/records/edit_fields/_minimally_cataloged.html.erb
@@ -1,7 +1,0 @@
-<% minimally_cataloged =  MinimallyCatalogedService.new %>
-<%= f.input :minimally_cataloged, as: :select,
-            collection: minimally_cataloged.select_all_options,
-            include_blank: true,
-            disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key),
-            input_html: { class: 'form-control'}
-%>

--- a/app/views/records/edit_fields/_organization.html.erb
+++ b/app/views/records/edit_fields/_organization.html.erb
@@ -1,7 +1,0 @@
-<% organization =  OrganizationService.new %>
-<%= f.input :organization, as: :select,
-            collection: organization.select_all_options,
-            include_blank: true,
-            disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key),
-            input_html: { class: 'form-control'}
-%>

--- a/app/views/records/edit_fields/_playlist_order.html.erb
+++ b/app/views/records/edit_fields/_playlist_order.html.erb
@@ -1,1 +1,0 @@
-<%= f.input :playlist_order, as: :integer, required: f.object.required?(key), disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key) %>

--- a/app/views/records/edit_fields/_transcript_status.html.erb
+++ b/app/views/records/edit_fields/_transcript_status.html.erb
@@ -1,7 +1,0 @@
-<% transcript_status =  TranscriptStatusService.new %>
-<%= f.input :transcript_status, as: :select,
-            collection: transcript_status.select_all_options,
-            include_blank: true,
-            disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key),
-            input_html: { class: 'form-control'}
-%>

--- a/config/authorities/level_of_user_access.yml
+++ b/config/authorities/level_of_user_access.yml
@@ -1,7 +1,0 @@
-terms:
-  - id: Online Reading Room
-    term: Online Reading Room
-  - id: On Location
-    term: On Location
-  - id: Private
-    term: Private

--- a/config/authorities/minimally_cataloged.yml
+++ b/config/authorities/minimally_cataloged.yml
@@ -1,5 +1,0 @@
-terms:
-  - id: "Yes"
-    term: "Yes"
-  - id: "No"
-    term: "No"

--- a/config/authorities/transcript_status.yml
+++ b/config/authorities/transcript_status.yml
@@ -1,7 +1,0 @@
-terms:
-  - id: Uncorrected
-    term: Uncorrected
-  - id: Correcting
-    term: Correcting
-  - id: Correct
-    term: Correct

--- a/spec/factories/pbcore_xml/pbcore_description_document.rb
+++ b/spec/factories/pbcore_xml/pbcore_description_document.rb
@@ -20,8 +20,8 @@ FactoryBot.define do
           # The incoming PBCore XML values for "Level of User Access" and
           # "Transcript Status" match our controlled vocabulary, so we can take
           # a random sampling from there.
-          build(:pbcore_annotation, type: "Level of User Access", value: LevelOfUserAccessService.new.select_all_options.to_h.values.sample),
-          build(:pbcore_annotation, type: "Transcript Status", value: TranscriptStatusService.new.select_all_options.to_h.values.sample),
+          build(:pbcore_annotation, type: "Level of User Access", value: [ "Online Reading Room", "On Location", "Private" ].sample),
+          build(:pbcore_annotation, type: "Transcript Status", value: [ "Uncorrected", "Correcting", "Correct" ].sample),
           build(:pbcore_annotation, type: "cataloging status", value: "Minimally Cataloged"),
           build(:pbcore_annotation, type: "Outside URL", value: Faker::Internet.url),
           build(:pbcore_annotation, type: "special_collections" , value: Faker::TvShows::Simpsons.character),

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -42,13 +42,7 @@ RSpec.describe Ability do
     [ :create,
       :update,
       :destroy,
-      :update_level_of_user_access,
-      :update_minimally_cataloged,
-      :update_outside_url,
       :update_sonyci_id,
-      :update_licensing_info,
-      :update_playlist_group,
-      :update_playlist_order,
       :update_hyrax_batch_ingest_batch_id,
       :update_last_pushed,
       :update_last_updated,
@@ -74,13 +68,7 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:create, AdminData) }
 
     # An 'ingestser' user may update specific fields on AdminData objects.
-    it { is_expected.to be_able_to(:update_level_of_user_access, AdminData) }
-    it { is_expected.to be_able_to(:update_minimally_cataloged, AdminData) }
-    it { is_expected.to be_able_to(:update_outside_url, AdminData) }
     it { is_expected.to be_able_to(:update_sonyci_id, AdminData) }
-    it { is_expected.to be_able_to(:update_licensing_info, AdminData) }
-    it { is_expected.to be_able_to(:update_playlist_group, AdminData) }
-    it { is_expected.to be_able_to(:update_playlist_order, AdminData) }
     it { is_expected.to be_able_to(:update_hyrax_batch_ingest_batch_id, AdminData) }
     it { is_expected.to be_able_to(:update_last_pushed, AdminData) }
     it { is_expected.to be_able_to(:update_last_updated, AdminData) }

--- a/spec/presenters/hyrax/asset_presenter_spec.rb
+++ b/spec/presenters/hyrax/asset_presenter_spec.rb
@@ -160,7 +160,6 @@ RSpec.describe Hyrax::AssetPresenter do
     it { is_expected.to delegate_method(:clip_description).to(:solr_document) }
     it { is_expected.to delegate_method(:copyright_date).to(:solr_document) }
     it { is_expected.to delegate_method(:level_of_user_access).to(:solr_document) }
-    it { is_expected.to delegate_method(:minimally_cataloged).to(:solr_document) }
     it { is_expected.to delegate_method(:outside_url).to(:solr_document) }
     it { is_expected.to delegate_method(:special_collections).to(:solr_document) }
     it { is_expected.to delegate_method(:transcript_status).to(:solr_document) }


### PR DESCRIPTION
producing_organization suffix got changed with the annotations update because it had it's solr suffix mistakenly updated. This rolls back that update, deletes unused edit_field partials and authorities, and updates the minimally_cataloged facet to use cataloging_status as that's the actual name of the annotation.