### PR TITLE
Adds w+ to File.open in DocumentsToCsv#process_export

### DIFF
--- a/app/services/ams/export/documents_to_csv.rb
+++ b/app/services/ams/export/documents_to_csv.rb
@@ -14,7 +14,8 @@ module AMS
       end
 
       def process_export
-        temp_file = File.open(@temp_file_path)
+        temp_file = File.open(@temp_file_path, "w+")
+
         temp_file << AMS::CsvExportExtension.get_csv_header(object_type)
         @solr_documents.each do |doc|
           temp_file << doc.export_as_csv(object_type)

--- a/spec/services/ams/export/documents_to_csv_spec.rb
+++ b/spec/services/ams/export/documents_to_csv_spec.rb
@@ -7,16 +7,18 @@ RSpec.describe AMS::Export::DocumentsToCsv do
   let(:search_results) { [SolrDocument.new(asset.to_solr)] }
 
   describe "#process_export" do
+    # Adding back an explicit call to process export, because the test would have caught an IOError
+    let(:service) { described_class.new(search_results, object_type: 'asset', export_type: 'csv_download') }
+
     describe "with 'asset' set as the object_type" do
-      let(:service) do
-        expect{ described_class.new(search_results, object_type: 'asset', export_type: 'csv_download') }.to_not raise_error
+      it "does not raise an error" do
+        expect{ service.process_export }.to_not raise_error
       end
     end
 
     describe "with 'physical_instantiation' set as the object type" do
       let(:asset_with_physical_instantiation) { create(:asset, :with_physical_instantiation) }
       let(:service) do
-        # removed 'call #process_export test' because that now happens during initialize of service
         expect{ described_class.new(search_results, object_type: 'physical_instantiation', export_type: 'csv_download') }.to_not raise_error
       end
     end


### PR DESCRIPTION
Closes #470. The tmp file created in the DocumentsToCsv process_export method wasn't opened for writing. Adds w+ to the open and adds back an explicit test on the #process_export method because I think this would have caught it. 