### PR TITLE
Change prod log level from :debug to :warn

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ config.webpacker.check_yarn_integrity = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
Debug logging is extremely noisy, and I need to track down ingestion errors, so
switching to Warning level for now (shows warnings and errors).