### PR TITLE
Fixes date formatting for 'Last pushed to AAPB'

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,16 +20,24 @@ module ApplicationHelper
     params
   end
 
-  def display_date(date_time, format: '%Y-%m-%d', from_format: nil)
+  # Module method for displaying dates consistently.
+  # Usage: ApplicationHelper.display_date
+  def self.display_date(date_time, format: '%Y-%m-%d', from_format: nil, time_zone: 'US/Eastern')
     parsed_time = if from_format
-      Date.strptime(date_time, from_format)
+      Date.strptime(date_time.to_s, from_format)
     else
-      Date.strptime(date_time)
+      Date.strptime(date_time.to_s)
     end
+
+    parsed_time = parsed_time.in_time_zone(time_zone) if time_zone
     parsed_time.strftime(format)
-  rescue => e
+  rescue => error
+    Rails.logger.warn "Caught exception #{error.class}: #{error.message}\n#{error.backtrace.join("\n")}"
     nil
   end
+
+  # Instance method delegates to ApplicationHelper.display_date.
+  def display_date(*args); ApplicationHelper.display_date(*args); end
 
   def render_thumbnail(document, options)
     # send(blacklight_config.view_config(document_index_view_type).thumbnail_method, document, image_options)

--- a/app/presenters/hyrax/asset_presenter.rb
+++ b/app/presenters/hyrax/asset_presenter.rb
@@ -36,11 +36,11 @@ module Hyrax
     end
 
     def last_pushed
-      DateTime.new(solr_document['last_pushed']).strftime('%m-%e-%y %H:%M') if solr_document['last_pushed']
+      timestamp_to_display_date solr_document['last_pushed']
     end
 
     def last_updated
-      DateTime.new(solr_document['last_updated']).strftime('%m-%e-%y %H:%M') if solr_document['last_updated']
+      timestamp_to_display_date solr_document['last_updated']
     end
 
     def needs_update
@@ -155,6 +155,10 @@ module Hyrax
 
       def instantiation_have_holding_organization_aapb(instantiation)
         (instantiation.holding_organization && instantiation.holding_organization.include?("American Archive of Public Broadcasting"))
+      end
+
+      def timestamp_to_display_date(timestamp)
+        ApplicationHelper.display_date(timestamp, format: '%m-%e-%y %H:%M %Z', from_format: '%s', time_zone: 'US/Eastern')
       end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -14,5 +14,18 @@ RSpec.describe ApplicationHelper do
     it 'eats bad dates, returns nil' do
       expect(helper.display_date('bad date')).to eq nil
     end
+
+    it 'can convert a timestamp to a readable EDT date time' do
+      # Create an arbitrary date (during daylight savings) and make it a timestamp.
+      timestamp = Time.new(2020, 9, 15, 5, 00, 00, "+00:00").strftime('%s')
+      # Format a pretty date from the timestamp AND change the timezone.
+      display_date = helper.display_date(timestamp, format: '%Y-%m-%d %H:%M:%S %Z',
+                                                    from_format: '%s',
+                                                    time_zone: 'US/Eastern')
+
+      # Expect the EDT time to be 4 hours earlier (i.e. Eastern time during
+      # daylight savings).
+      expect(display_date).to eq '2020-09-15 00:00:00 EDT'
+    end
   end
 end

--- a/spec/presenters/hyrax/asset_presenter_spec.rb
+++ b/spec/presenters/hyrax/asset_presenter_spec.rb
@@ -116,60 +116,38 @@ RSpec.describe Hyrax::AssetPresenter do
     end
   end
 
-  context "delegate_methods" do
-    subject { presenter }
-    let(:asset) { create(:asset) }
+  context "delegation" do
+    let(:solr_doc) { instance_double(SolrDocument) }
+    subject { described_class.new(solr_doc, nil) }
 
-    let(:presenter) do
-      described_class.new(SolrDocument.new(asset.to_solr), nil)
+    let(:expected_delegated_methods) { [ :title, :genre, :asset_types,
+      :broadcast_date, :created_date, :episode_number, :description,
+      :spatial_coverage, :temporal_coverage, :audience_level, :audience_rating,
+      :annotation, :rights_summary, :rights_link, :date, :local_identifier,
+      :pbs_nola_code, :eidr_id, :topics, :subject, :program_title,
+      :episode_title, :segment_title, :raw_footage_title, :promo_title,
+      :clip_title, :program_description, :episode_description,
+      :segment_description, :raw_footage_description, :promo_description,
+      :clip_description, :copyright_date, :level_of_user_access, :outside_url,
+      :special_collections, :transcript_status, :sonyci_id, :licensing_info,
+      :cataloging_status, :canonical_meta_tag, :special_collection_category,
+      :playlist_group, :playlist_order, :organization
+    ] }
+
+    it 'delegates methods to :solr_document' do
+      expected_delegated_methods.each do |expected_delegated_method|
+        expect(subject).to delegate_method(expected_delegated_method).to :solr_document
+      end
     end
+  end
 
-    # If the fields require no addition logic for display, you can simply delegate
-    # them to the solr document
-    it { is_expected.to delegate_method(:title).to(:solr_document) }
-    it { is_expected.to delegate_method(:genre).to(:solr_document) }
-    it { is_expected.to delegate_method(:asset_types).to(:solr_document) }
-    it { is_expected.to delegate_method(:broadcast_date).to(:solr_document) }
-    it { is_expected.to delegate_method(:created_date).to(:solr_document) }
-    it { is_expected.to delegate_method(:episode_number).to(:solr_document) }
-    it { is_expected.to delegate_method(:description).to(:solr_document) }
-    it { is_expected.to delegate_method(:spatial_coverage).to(:solr_document) }
-    it { is_expected.to delegate_method(:temporal_coverage).to(:solr_document) }
-    it { is_expected.to delegate_method(:audience_level).to(:solr_document) }
-    it { is_expected.to delegate_method(:audience_rating).to(:solr_document) }
-    it { is_expected.to delegate_method(:annotation).to(:solr_document) }
-    it { is_expected.to delegate_method(:rights_summary).to(:solr_document) }
-    it { is_expected.to delegate_method(:rights_link).to(:solr_document) }
-    it { is_expected.to delegate_method(:date).to(:solr_document) }
-    it { is_expected.to delegate_method(:local_identifier).to(:solr_document) }
-    it { is_expected.to delegate_method(:pbs_nola_code).to(:solr_document) }
-    it { is_expected.to delegate_method(:eidr_id).to(:solr_document) }
-    it { is_expected.to delegate_method(:topics).to(:solr_document) }
-    it { is_expected.to delegate_method(:subject).to(:solr_document) }
-    it { is_expected.to delegate_method(:program_title).to(:solr_document) }
-    it { is_expected.to delegate_method(:episode_title).to(:solr_document) }
-    it { is_expected.to delegate_method(:segment_title).to(:solr_document) }
-    it { is_expected.to delegate_method(:raw_footage_title).to(:solr_document) }
-    it { is_expected.to delegate_method(:promo_title).to(:solr_document) }
-    it { is_expected.to delegate_method(:clip_title).to(:solr_document) }
-    it { is_expected.to delegate_method(:program_description).to(:solr_document) }
-    it { is_expected.to delegate_method(:episode_description).to(:solr_document) }
-    it { is_expected.to delegate_method(:segment_description).to(:solr_document) }
-    it { is_expected.to delegate_method(:raw_footage_description).to(:solr_document) }
-    it { is_expected.to delegate_method(:promo_description).to(:solr_document) }
-    it { is_expected.to delegate_method(:clip_description).to(:solr_document) }
-    it { is_expected.to delegate_method(:copyright_date).to(:solr_document) }
-    it { is_expected.to delegate_method(:level_of_user_access).to(:solr_document) }
-    it { is_expected.to delegate_method(:outside_url).to(:solr_document) }
-    it { is_expected.to delegate_method(:special_collections).to(:solr_document) }
-    it { is_expected.to delegate_method(:transcript_status).to(:solr_document) }
-    it { is_expected.to delegate_method(:sonyci_id).to(:solr_document) }
-    it { is_expected.to delegate_method(:licensing_info).to(:solr_document) }
-    it { is_expected.to delegate_method(:cataloging_status).to(:solr_document) }
-    it { is_expected.to delegate_method(:canonical_meta_tag).to(:solr_document) }
-    it { is_expected.to delegate_method(:special_collection_category).to(:solr_document) }
-    it { is_expected.to delegate_method(:playlist_group).to(:solr_document) }
-    it { is_expected.to delegate_method(:playlist_order).to(:solr_document) }
-    it { is_expected.to delegate_method(:organization).to(:solr_document) }
+  describe '#last_pushed' do
+    let(:solr_doc) { instance_double(SolrDocument) }
+    let(:timestamp) { Time.new(2020, 9, 15, 5, 00, 00, "+00:00").strftime('%s') }
+    subject { described_class.new(solr_doc, nil) }
+    before { allow(solr_doc).to receive(:[]).with('last_pushed').and_return(timestamp.to_i) }
+    it 'converts a Unix timestamp into a readable EDT date string with time zone' do
+      expect(subject.last_pushed).to eq '09-15-20 00:00 EDT'
+    end
   end
 end


### PR DESCRIPTION
* Changes #last_pushed and #last_updated methods of AssetPresenter to use
  ApplicationHelper.dispay_date.
* Modifies ApplicationHelper.display_date to:
  * allow input of a different timezone, default to US/Eastern.
  * allow input integer timestamp.
  * logs date formatting errors to Rails log as a WARN before returning nil.
* Change the date formats of #last_pushed and #last_updated to include the
  timezone.

Also,
* refactors specs for AssetPresenter that test for delegated methods; instead of
  calling FactoryBot.create(:asset) 45 times, just leave the Asset out of it and
  use instance_double(SolrDocument) for the one and only dependency into
  AssetPresenter.

Fixes #469.