### PR TITLE
Looking for Sound in Media Player

### DIFF
--- a/app/views/hyrax/assets/_representative_media.html.erb
+++ b/app/views/hyrax/assets/_representative_media.html.erb
@@ -1,5 +1,5 @@
 <% media_type = presenter.solr_document['media_type_ssim'].first if presenter.solr_document['media_type_ssim'] %>
-<% if ["Moving Image", "Audio"].include? media_type %>
+<% if ["Moving Image", "Sound"].include? media_type %>
   <% content_tag_type, source_type = media_type == "Moving Image" ? ["video", "video/mp4"] : ["audio", "audio/mp3"] %>
 
   <%= content_tag(content_tag_type,


### PR DESCRIPTION
There was a typo introduced to representative_media partial with the media player update. Should check for "Sound" not "Audio" from DigitalInstantiation.