### PR TITLE
Split AAPB pushes into per-environment jobs

### DIFF
--- a/app/mailers/ams2_mailer.rb
+++ b/app/mailers/ams2_mailer.rb
@@ -2,14 +2,14 @@ class Ams2Mailer < ApplicationMailer
 
   def export_notification(user, export_url)
     @export_url = export_url
-    mail(to: user.email, subject: 'AMS2 Download Export File')
+    mail(to: user.email, subject: "AMS2 Download Export File")
   end
 
-  def scp_to_aapb_notification(user, output)
-    mail(to: user.email, subject: 'AMS2 to AAPB Copy Output', body: output)
+  def scp_to_aapb_notification(user, output, env_name)
+    mail(to: user.email, subject: "(#{env_name}) AMS2 to AAPB Copy Output", body: output)
   end
 
-  def export_job_failure(user)
-    mail(to: user, subject: 'AMS2 to AAPB Failed')
+  def export_job_failure(user, env_name)
+    mail(to: user, subject: "(#{env_name}) AMS2 to AAPB Failed")
   end
 end

--- a/app/views/pushes/index.html.erb
+++ b/app/views/pushes/index.html.erb
@@ -6,7 +6,7 @@
     
   <% @pushes.each do |push| %>
     <li>
-      <%= link_to %(Push ##{push.id}), push %>
+      <%= link_to %((#{push.destination}) Push ##{push.id}), push %>
     </li>  
   <% end %>
 

--- a/app/views/pushes/show.html.erb
+++ b/app/views/pushes/show.html.erb
@@ -1,4 +1,4 @@
-<h3>Push #<%= @push.id %></h3>
+<h3>(<%= @push.destination %>) Push #<%= @push.id %></h3>
 
 <h5>Initiated by <%= @push.user.email %> at <%= @push.created_at.strftime('%m-%e-%y %H:%M') %></h5>
 

--- a/db/migrate/20201120144958_add_destination_to_pushes.rb
+++ b/db/migrate/20201120144958_add_destination_to_pushes.rb
@@ -1,0 +1,5 @@
+class AddDestinationToPushes < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pushes, :destination, :string, default: "Both"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200803200219) do
+ActiveRecord::Schema.define(version: 20201120144958) do
 
-  create_table "admin_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "admin_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text "sonyci_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["hyrax_batch_ingest_batch_id"], name: "index_admin_data_on_hyrax_batch_ingest_batch_id"
   end
 
-  create_table "annotations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "annotations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "annotation_type"
     t.string "ref"
     t.string "source"
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["admin_data_id"], name: "index_annotations_on_admin_data_id"
   end
 
-  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "checksum_audit_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "checksum_audit_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "file_set_id"
     t.string "file_id"
     t.string "checked_uri"
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id"
   end
 
-  create_table "collection_branding_infos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "collection_branding_infos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "collection_id"
     t.string "role"
     t.string "local_path"
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "collection_type_participants", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "collection_type_participants", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "hyrax_collection_type_id"
     t.string "agent_type"
     t.string "agent_id"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["hyrax_collection_type_id"], name: "hyrax_collection_type_id"
   end
 
-  create_table "content_blocks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "content_blocks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
     t.text "value"
     t.datetime "created_at", null: false
@@ -91,7 +91,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.string "external_key"
   end
 
-  create_table "curation_concerns_operations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "curation_concerns_operations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "status"
     t.string "operation_type"
     t.string "job_class"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
   end
 
-  create_table "featured_works", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "featured_works", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "order", default: 5
     t.string "work_id"
     t.datetime "created_at", null: false
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["work_id"], name: "index_featured_works_on_work_id"
   end
 
-  create_table "file_download_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "file_download_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "date"
     t.integer "downloads"
     t.string "file_id"
@@ -132,7 +132,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["user_id"], name: "index_file_download_stats_on_user_id"
   end
 
-  create_table "file_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "file_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "date"
     t.integer "views"
     t.string "file_id"
@@ -143,7 +143,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
   end
 
-  create_table "hyrax_batch_ingest_batch_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "hyrax_batch_ingest_batch_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "batch_id"
     t.string "id_within_batch"
     t.text "source_data"
@@ -157,7 +157,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["batch_id"], name: "index_hyrax_batch_ingest_batch_items_on_batch_id"
   end
 
-  create_table "hyrax_batch_ingest_batches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "hyrax_batch_ingest_batches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "status"
     t.string "submitter_email"
     t.string "source_location"
@@ -171,7 +171,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.datetime "end_time"
   end
 
-  create_table "hyrax_collection_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "hyrax_collection_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
     t.text "description"
     t.string "machine_id"
@@ -188,14 +188,14 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
   end
 
-  create_table "hyrax_features", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "hyrax_features", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "instantiation_admin_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "instantiation_admin_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "aapb_preservation_lto"
     t.string "aapb_preservation_disk"
     t.datetime "created_at", null: false
@@ -203,7 +203,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.string "md5"
   end
 
-  create_table "job_io_wrappers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "job_io_wrappers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "user_id"
     t.bigint "uploaded_file_id"
     t.string "file_set_id"
@@ -217,7 +217,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "mailboxer_conversation_opt_outs", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -225,13 +225,13 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "mailboxer_conversations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "mailboxer_notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -254,7 +254,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "mailboxer_receipts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -271,7 +271,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "minter_states", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
@@ -282,7 +282,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
   end
 
-  create_table "permission_template_accesses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "permission_template_accesses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
@@ -293,7 +293,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["permission_template_id"], name: "index_permission_template_accesses_on_permission_template_id"
   end
 
-  create_table "permission_templates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "permission_templates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "source_id"
     t.string "visibility"
     t.datetime "created_at", null: false
@@ -303,7 +303,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["source_id"], name: "index_permission_templates_on_source_id", unique: true
   end
 
-  create_table "proxy_deposit_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "proxy_deposit_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "work_id", null: false
     t.bigint "sending_user_id", null: false
     t.bigint "receiving_user_id", null: false
@@ -317,7 +317,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id"
   end
 
-  create_table "proxy_deposit_rights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "proxy_deposit_rights", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "grantor_id"
     t.bigint "grantee_id"
     t.datetime "created_at", null: false
@@ -326,21 +326,22 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["grantor_id"], name: "index_proxy_deposit_rights_on_grantor_id"
   end
 
-  create_table "pushes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "pushes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text "pushed_id_csv"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.string "destination", default: "Both"
   end
 
-  create_table "qa_local_authorities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "qa_local_authorities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_qa_local_authorities_on_name", unique: true
   end
 
-  create_table "qa_local_authority_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "qa_local_authority_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "local_authority_id"
     t.string "label"
     t.string "uri"
@@ -350,11 +351,11 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
-  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
   end
 
-  create_table "roles_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "roles_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "role_id"
     t.integer "user_id"
     t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
@@ -363,7 +364,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["user_id"], name: "index_roles_users_on_user_id"
   end
 
-  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -372,7 +373,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "single_use_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "single_use_links", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "downloadKey"
     t.string "path"
     t.string "itemId"
@@ -381,7 +382,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "sipity_agents", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_agents", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "proxy_for_id", null: false
     t.string "proxy_for_type", null: false
     t.datetime "created_at", null: false
@@ -389,7 +390,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_agents_proxy_for", unique: true
   end
 
-  create_table "sipity_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "entity_id", null: false
     t.integer "agent_id", null: false
     t.text "comment"
@@ -400,7 +401,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["entity_id"], name: "index_sipity_comments_on_entity_id"
   end
 
-  create_table "sipity_entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_entities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "proxy_for_global_id", null: false
     t.integer "workflow_id", null: false
     t.integer "workflow_state_id"
@@ -411,7 +412,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["workflow_state_id"], name: "index_sipity_entities_on_workflow_state_id"
   end
 
-  create_table "sipity_entity_specific_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_entity_specific_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "workflow_role_id", null: false
     t.string "entity_id", null: false
     t.integer "agent_id", null: false
@@ -423,7 +424,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["workflow_role_id"], name: "sipity_entity_specific_responsibilities_role"
   end
 
-  create_table "sipity_notifiable_contexts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_notifiable_contexts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "scope_for_notification_id", null: false
     t.string "scope_for_notification_type", null: false
     t.string "reason_for_notification", null: false
@@ -436,7 +437,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "sipity_notifiable_contexts_concern"
   end
 
-  create_table "sipity_notification_recipients", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_notification_recipients", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "notification_id", null: false
     t.integer "role_id", null: false
     t.string "recipient_strategy", null: false
@@ -448,7 +449,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["role_id"], name: "sipity_notification_recipients_role"
   end
 
-  create_table "sipity_notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
     t.string "notification_type", null: false
     t.datetime "created_at", null: false
@@ -457,7 +458,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["notification_type"], name: "index_sipity_notifications_on_notification_type"
   end
 
-  create_table "sipity_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -465,7 +466,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
 
-  create_table "sipity_workflow_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "workflow_id", null: false
     t.integer "resulting_workflow_state_id"
     t.string "name", null: false
@@ -476,7 +477,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["workflow_id"], name: "sipity_workflow_actions_workflow"
   end
 
-  create_table "sipity_workflow_methods", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_methods", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "service_name", null: false
     t.integer "weight", null: false
     t.integer "workflow_action_id", null: false
@@ -485,7 +486,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["workflow_action_id"], name: "index_sipity_workflow_methods_on_workflow_action_id"
   end
 
-  create_table "sipity_workflow_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_responsibilities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "agent_id", null: false
     t.integer "workflow_role_id", null: false
     t.datetime "created_at", null: false
@@ -493,7 +494,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["agent_id", "workflow_role_id"], name: "sipity_workflow_responsibilities_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "workflow_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -501,7 +502,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["workflow_id", "role_id"], name: "sipity_workflow_roles_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_action_permissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_state_action_permissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "workflow_role_id", null: false
     t.integer "workflow_state_action_id", null: false
     t.datetime "created_at", null: false
@@ -509,7 +510,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["workflow_role_id", "workflow_state_action_id"], name: "sipity_workflow_state_action_permissions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_state_actions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "originating_workflow_state_id", null: false
     t.integer "workflow_action_id", null: false
     t.datetime "created_at", null: false
@@ -517,7 +518,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["originating_workflow_state_id", "workflow_action_id"], name: "sipity_workflow_state_actions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflow_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "workflow_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -526,7 +527,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["workflow_id", "name"], name: "sipity_type_state_aggregate", unique: true
   end
 
-  create_table "sipity_workflows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "sipity_workflows", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
     t.string "label"
     t.text "description"
@@ -538,20 +539,20 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
   end
 
-  create_table "tinymce_assets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "tinymce_assets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "file"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "trophies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "trophies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
     t.string "work_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "uploaded_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "uploaded_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "file"
     t.bigint "user_id"
     t.string "file_set_uri"
@@ -561,7 +562,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end
 
-  create_table "user_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "user_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
     t.datetime "date"
     t.integer "file_views"
@@ -572,7 +573,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["user_id"], name: "index_user_stats_on_user_id"
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -616,7 +617,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "version_committers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "version_committers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "obj_id"
     t.string "datastream_id"
     t.string "version_id"
@@ -625,7 +626,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "work_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" do |t|
+  create_table "work_view_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "date"
     t.integer "work_views"
     t.string "work_id"

--- a/db/schema.test.rb
+++ b/db/schema.test.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200803200219) do
+ActiveRecord::Schema.define(version: 20201120144958) do
 
   create_table "admin_data", force: :cascade do |t|
     t.text "sonyci_id"
@@ -331,6 +331,7 @@ ActiveRecord::Schema.define(version: 20200803200219) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.string "destination", default: "Both"
   end
 
   create_table "qa_local_authorities", force: :cascade do |t|

--- a/lib/ams/aapb.rb
+++ b/lib/ams/aapb.rb
@@ -22,6 +22,9 @@ module AMS
 
       def reachable?(host)
         !!head(host)
+      rescue OpenSSL::SSL::SSLError
+        # if destination host's ssl expired, thats fine
+        true
       rescue SocketError, Errno::ECONNREFUSED
         false
       end
@@ -29,7 +32,7 @@ module AMS
       private
         def make_url(host, *url_args)
           # HEAD check requires http://, while ssh requires it naught! joining them like this because URI#join messes up //
-          url_args.unshift('http://' + host)
+          url_args.unshift('https://' + host)
           URI.join(*url_args)
         end
     end

--- a/spec/controllers/pushes_controller_spec.rb
+++ b/spec/controllers/pushes_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Pushes", type: :controller, js: true do
 
       # this will have the output mail
       # output_mail = ActionMailer::Base.deliveries.last
-      expect(ExportRecordsJob).to have_received(:perform_later)
+      expect(ExportRecordsJob).to have_received(:perform_later).exactly(2).times
       push = Push.last
       expect(push.user_id).to eq(user.id)
       expect(push.pushed_id_csv).to eq(asset.id)

--- a/spec/jobs/export_records_job_spec.rb
+++ b/spec/jobs/export_records_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ExportRecordsJob, type: :job do
 
     it 'does not retry, and the error is logged' do
       perform_enqueued_jobs do
-        described_class.perform_later(search_params, user)
+        described_class.perform_later(search_params, user, 'demo.aapb.wgbh-mla.org')
       end
       assert_performed_jobs 1
       assert_emails delivery_count + 1

--- a/spec/jobs/export_records_job_spec.rb
+++ b/spec/jobs/export_records_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ExportRecordsJob, type: :job do
       assert_performed_jobs 1
       assert_emails delivery_count + 1
       expect(Rails.logger).to have_received(:error).with(/Foo/).exactly(1).times
-      expect(most_recent_mail.subject).to eq "AMS2 to AAPB Failed"
+      expect(most_recent_mail.subject).to eq "(demo.aapb.wgbh-mla.org) AMS2 to AAPB Failed"
     end
   end
 end


### PR DESCRIPTION
add destination field to Pushes, refactor ExportRecordsJob to only push to one AAPB environment, but trigger two jobs when creating a Push