### PR TITLE
Refactors how contributions are added to Asset

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -142,11 +142,7 @@ module Hyrax
                 if param_contributor[:id].blank?
                   param_contributor.delete(:id)
                   contributor = ::Contribution.new
-
-                  if actor.create(Actors::Environment.new(contributor, env.current_ability, param_contributor))
-                    env.curation_concern.ordered_members << contributor
-                    env.curation_concern.save
-                  end
+                  actor.create(Actors::Environment.new(contributor, env.current_ability, param_contributor)
                 elsif (contributor = Contribution.find(param_contributor[:id]))
                   param_contributor.delete(:id)
                   actor.update(Actors::Environment.new(contributor, env.current_ability, param_contributor))

--- a/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
@@ -82,6 +82,26 @@ module AAPB
           asset = Asset.new
           env = Hyrax::Actors::Environment.new(asset, current_ability, attrs)
 
+          digital_instantiation_attribute_sets.each do |dig_inst_attrs|
+            di = DigitalInstantiation.new
+            env = Hyrax::Actors::Environment.new(di, current_ability, dig_inst_attrs)
+
+            get_essence_track_attribute_sets(dig_inst_attrs).each do |ess_track_attrs|
+              et = EssenceTrack.new
+              env = Hyrax::Actors::Environment.new(et, current_ability, ess_track_attrs)
+            end
+          end
+
+          physical_instantiation_attribute_sets.each do |dig_inst_attrs|
+            di = DigitalInstantiation.new
+            env = Hyrax::Actors::Environment.new(di, current_ability, dig_inst_attrs)
+            
+            get_essence_track_attribute_sets(dig_inst_attrs).each do |ess_track_attrs|
+              et = EssenceTrack.new
+              env = Hyrax::Actors::Environment.new(et, current_ability, ess_track_attrs)
+            end
+          end
+
           # Get the actor and call #create with teh actor environment.
           # If #create fails, raise any exception that was set on the Asset
           # object.


### PR DESCRIPTION
Does not save Asset for every contribution added.
Relies on Hyrax default actor behavior to handle the parent_id, so no need to
explicitly add to ordered members.