### PR TITLE
Adds PBCore XML endpoint

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,6 +1,5 @@
 class CatalogController < ApplicationController
   include Hydra::Catalog
-  include Hydra::Controller::ControllerBehavior
   include BlacklightAdvancedSearch::Controller
 
   # This filter applies the hydra access controls

--- a/app/controllers/hyrax/assets_controller.rb
+++ b/app/controllers/hyrax/assets_controller.rb
@@ -38,8 +38,16 @@ module Hyrax
 
     private
 
-    def solr_document
-      ::SolrDocument.find(presenter.id)
-    end
+      def solr_document
+        ::SolrDocument.find(presenter.id)
+      end
+
+      # This extends functionality from
+      # Hyrax::WorksControllerBehavior#additional_response_formats, adding a
+      # response for a ".xml" extension, returning the PBCore XML.
+      def additional_response_formats(format)
+        format.xml { render(plain: presenter.solr_document.export_as_pbcore) }
+        super
+      end
   end
 end

--- a/app/controllers/hyrax/contributions_controller.rb
+++ b/app/controllers/hyrax/contributions_controller.rb
@@ -16,7 +16,7 @@ module Hyrax
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::ContributionPresenter
   end
-  
+
   def destroy
     if current_user.can? :destroy, Contribution
       super

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -37,6 +37,7 @@ class SolrDocument
   def is_asset?; has_model == "Asset"; end
   def is_physical_instantiation?; has_model == "PhysicalInstantiation"; end
   def is_digital_instantiation?; has_model == "DigitalInstantiation"; end
+  def is_instantiation?; is_digital_instantiations || is_physical_instantiation; end
 
   # Specific ID accessors based on record type.
   def asset_id; id if is_asset?; end
@@ -522,15 +523,28 @@ class SolrDocument
   end
 
   def admin_data_gid
+    return unless is_asset?
     self['admin_data_gid_ssim'].first
   end
 
   def admin_data
+    return unless is_asset?
     @admin_data ||= AdminData.find_by_gid(admin_data_gid)
   end
 
   def annotations
+    return unless is_asset?
     @annotations ||= admin_data&.annotations
+  end
+
+  def instantiation_admin_data_gid
+    return unless is_instantiation?
+    @instantiation_admin_data_gid ||= self['admin_data_gid_ssim'].first
+  end
+
+  def instantiation_admin_data
+    return unless is_instantiation?
+    @instiation_admin_data ||= InstantiationAdminData.find_by_gid(instantiation_admin_data_gid)
   end
 
   ###

--- a/spec/features/pbcore_xml_endpoints_spec.rb
+++ b/spec/features/pbcore_xml_endpoints_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'PBCore XML endpoints' do
+
+  before { login_as(create(:user)) }
+
+  context 'for an Asset record' do
+    let(:asset) { create(:asset) }
+    let(:expected_pbcore_xml) { SolrDocument.new(asset.to_solr).export_as_pbcore }
+
+    describe '/concerns/assets/[id].xml' do
+      before do
+        visit "#{url_for(asset)}.xml"
+      end
+
+      it 'returns the PBCore XML' do
+        expect(page.html).to eq expected_pbcore_xml
+      end
+    end
+  end
+end


### PR DESCRIPTION
When on an Asset page, add .xml to the GUID and get the PBCore XML back.

Also,
* Removes redundant inclusion of Hydra::Controller::ControllerBehavior in CatalogController