### PR TITLE
Completes Validate and Clean for PBCore

### DIFF
--- a/app/models/concerns/ams2_pbcore.rb
+++ b/app/models/concerns/ams2_pbcore.rb
@@ -1,0 +1,15 @@
+class AMS2PBcore
+  # This class is used to wrap the PBCore::DescriptionDocument from
+  # the PBCore gem: https://github.com/WGBH-MLA/pbcore.
+  # It allows us to use ActiveModel::Validations and a custom validator.
+  include ActiveModel::Validations
+  validates_with AMS2PBCoreValidator
+
+  attr_reader :pbcore
+
+  def initialize(pbcore:)
+    raise 'AMS2PBcore must be initialized with a PBCore::DescriptionDocument' unless pbcore.class == PBCore::DescriptionDocument
+    @pbcore = pbcore
+  end
+
+end

--- a/app/models/concerns/ams2_pbcore_validator.rb
+++ b/app/models/concerns/ams2_pbcore_validator.rb
@@ -1,0 +1,48 @@
+class AMS2PBCoreValidator < ActiveModel::Validator
+
+  def validate(record)
+    @record = record
+    @pbcore = record.pbcore
+    validate_asset_type
+    validate_date_type
+    validate_date_format
+    validate_title_presence
+    validate_title_value_presence
+  end
+
+  private
+
+  def validate_asset_type
+    @pbcore.asset_types.each do |type|
+      @record.errors.add(:base, "Invalid PBCore::AssetType value: #{type.value}") unless valid_asset_type_values.include?(type.value)
+    end
+  end
+
+  def valid_asset_type_values
+    @valid_asset_type_values ||= AMS::Cleaner::VocabMap.for_pbcore_class(PBCore::AssetType)["values"].values.uniq
+  end
+
+  def validate_date_type
+    @pbcore.asset_dates.each do |date|
+      @record.errors.add(:base, "Invalid PBCore::AssetDate type: #{date.type}") unless valid_asset_date_types.include?(date.type)
+    end
+  end
+
+  def valid_asset_date_types
+    @valid_asset_date_types ||= AMS::Cleaner::VocabMap.for_pbcore_class(PBCore::AssetDate)["types"].values.uniq
+  end
+
+  def validate_date_format
+    @pbcore.asset_dates.each do |date|
+      @record.errors.add(:base, "Invalid PBCore::AssetDate value: #{date.value}") if AMS::NonExactDateService.invalid?(date.value)
+    end
+  end
+
+  def validate_title_presence
+    @record.errors.add(:base, "No PBCore::Title found") if @pbcore.titles.empty?
+  end
+
+  def validate_title_value_presence
+    @record.errors.add(:base, "Invalid PBCore::Title, value attribute is missing") if @pbcore.titles.map(&:value).map(&:present?).include?(false)
+  end
+end

--- a/app/services/ams/cleaner/pbcore_cleaner.rb
+++ b/app/services/ams/cleaner/pbcore_cleaner.rb
@@ -1,0 +1,31 @@
+module AMS
+  module Cleaner
+    class PBCoreCleaner
+
+      def initialize(pbcore)
+        raise 'PBCoreCleaner must be initialized with a PBCore::DescriptionDocument' unless pbcore.class == PBCore::DescriptionDocument
+        @pbcore = pbcore
+      end
+
+      def clean!
+        pipeline.process(@pbcore)
+      end
+
+      private
+
+      def pipeline
+        Pipeline.new(pipeline_steps)
+      end
+
+      def pipeline_steps
+        [
+          Steps::CleanAssetTypes,
+          Steps::CleanDateTypes,
+          Steps::CleanAssetDescriptionTypes,
+          Steps::DeleteEmptyTitles,
+          Steps::AddUnknownTitleIfMissing
+        ]
+      end
+    end
+  end
+end

--- a/app/services/ams/cleaner/pbcore_element_editor.rb
+++ b/app/services/ams/cleaner/pbcore_element_editor.rb
@@ -1,0 +1,57 @@
+module AMS
+  module Cleaner
+    class PBCoreElementEditor
+
+      attr_reader :element
+
+      def initialize(element:)
+        @element = element
+      end
+
+      def value
+        set_value
+      end
+
+      def type
+        set_type
+      end
+
+      def vocab_map
+        @vocab_map ||= VocabMap.for_pbcore_element(element)
+      end
+
+      private
+
+      def set_value
+        return element.value if ( vocab_map.nil? || map_values.nil? )
+        # Set to empty string to get default for an empty string in config file
+        element.value = '' if element.value.nil?
+        map_value
+      end
+
+      def set_type
+        return element.type if ( vocab_map.nil? || map_types.nil? )
+        # Set to empty string to get default for an empty string in config file
+        element.type = '' if element.type.nil?
+        map_type
+      end
+
+      def map_values
+        @map_values ||= vocab_map.fetch("values", nil)
+      end
+
+      def map_types
+        @map_types ||= vocab_map.fetch("types", nil)
+      end
+
+      def map_value
+        map_values.select{ |key| element.value.downcase.include? key.downcase }.values.first || raise("No match found for '#{element.value}' in VocabMap")
+      end
+
+      def map_type
+        map_types.select{ |key| element.type.downcase.include? key.downcase }.values.first || raise("No match found for '#{element.type}' in VocabMap")
+      end
+
+    end
+  end
+end

--- a/app/services/ams/cleaner/pipeline.rb
+++ b/app/services/ams/cleaner/pipeline.rb
@@ -1,0 +1,19 @@
+module AMS
+  module Cleaner
+    class Pipeline
+
+      attr_reader :steps
+
+      def initialize(steps = {})
+        @steps = steps
+      end
+
+      def process(pbcore)
+        steps.reduce(pbcore) do |pbc, step|
+           step.process(pbc)
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/ams/cleaner/steps.rb
+++ b/app/services/ams/cleaner/steps.rb
@@ -1,0 +1,37 @@
+module AMS
+  module Cleaner
+    module Steps
+
+      class CleanAssetTypes
+        def self.process(pbcore)
+          pbcore.asset_types.map{ |type| type.value = PBCoreElementEditor.new(element: type).value }
+        end
+      end
+
+      class CleanDateTypes
+        def self.process(pbcore)
+          pbcore.asset_dates.map{ |date| date.type = PBCoreElementEditor.new(element: date).type }
+        end
+      end
+
+      class CleanAssetDescriptionTypes
+        def self.process(pbcore)
+          pbcore.descriptions.map{ |desc| desc.type = PBCoreElementEditor.new(element: desc).type }
+        end
+      end
+
+      class DeleteEmptyTitles
+        def self.process(pbcore)
+          pbcore.titles.reject!{ |title| title.value.empty? }
+        end
+      end
+
+      class AddUnknownTitleIfMissing
+        def self.process(pbcore)
+          pbcore.titles << PBCore::Title.new(type: "unknown", value: "unknown") if pbcore.titles.empty?
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/ams/cleaner/vocab_map.rb
+++ b/app/services/ams/cleaner/vocab_map.rb
@@ -1,0 +1,29 @@
+require 'yaml'
+
+module AMS
+  module Cleaner
+    module VocabMap
+      class << self
+
+        def for_pbcore_element(pbcore_element)
+          YAML.load_file(Rails.root + "config/pbcore_cleaner_config.yml").fetch(pbcore_element_key(pbcore_element), nil)
+        end
+
+        def for_pbcore_class(pbcore_class)
+          YAML.load_file(Rails.root + "config/pbcore_cleaner_config.yml").fetch(pbcore_class_key(pbcore_class), nil)
+        end
+
+        private
+
+        def pbcore_element_key(pbcore_element)
+          pbcore_element.class.name.split('::').last.underscore
+        end
+
+        def pbcore_class_key(pbcore_class)
+          pbcore_class.to_s.split('::').last.underscore
+        end
+
+      end
+    end
+  end
+end

--- a/config/pbcore_cleaner_config.yml
+++ b/config/pbcore_cleaner_config.yml
@@ -1,0 +1,84 @@
+asset_type:
+  values:
+    Album: Album
+    Clip: Clip
+    Compilation: Compilation
+    Element: Raw Footage
+    B-roll: Raw Footage
+    broll: Raw Footage
+    Field Tape: Raw Footage
+    News Conference: Raw Footage
+    NEWS RELEASE: Raw Footage
+    News Tape: Raw Footage
+    Original footage: Raw Footage
+    Original recording: Raw Footage
+    Outtake: Raw Footage
+    Raw Footage: Raw Footage
+    Stock Footage: Raw Footage
+    Stock shot: Raw Footage
+    unedited footage: Raw Footage
+    Episode: Episode
+    Program: Program
+    Porgram: Program
+    Television special: Program
+    Promo: Promo
+    Advertis: Promo
+    Commercial Spots: Promo
+    PSA: Promo
+    Public Announcement: Promo
+    Trailer: Promo
+    Segment: Segment
+    Segrment: Segment
+    Track: Track
+    epi: Episode
+    '': ''
+asset_date:
+  types:
+    broadcast: Broadcast
+    air: Broadcast
+    issue: Broadcast
+    published: Broadcast
+    release: Broadcast
+    created: Created
+    recorded: Created
+    performance: Created
+    revised: Revised
+    copyright: Copyright Date
+    '': Date
+asset_description:
+  types:
+    Raw Footage: Raw Footage
+    Element: Raw Footage
+    Clip: Clip
+    Promo: Promo
+    Episode: Episode
+    Program: Program
+    Description: Description
+    Abstract: Description
+    Log: Log
+    Rundown: Rundown
+    Shot List: Shot List
+    Transcript: Transcript
+    Series: Series
+    '': Description
+title:
+  types:
+    collection: Collection
+    series: Series
+    program: Program
+    number: Episode Number
+    epospde: Episode
+    episode: Episode
+    clip: Clip
+    advertis: Promo
+    trailer: Promo
+    promo: Promo
+    raw: Raw Footage
+    field tape: Raw Footage
+    element: Raw Footage
+    b-roll: Raw Footage
+    b roll: Raw Footage
+    album: Album
+    label: Label
+    segment: Segment
+    '': Title

--- a/spec/models/concerns/ams2_pbcore_validator_spec.rb
+++ b/spec/models/concerns/ams2_pbcore_validator_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+require 'concerns/ams2_pbcore_validator'
+require 'concerns/ams2_pbcore'
+require 'ams/cleaner/vocab_map'
+
+
+RSpec.describe AMS2PBCoreValidator do
+
+  subject { AMS2PBcore.new( pbcore: build(:pbcore_description_document,
+    :full_aapb, asset_types: [ build(:pbcore_asset_type, value: asset_type) ], asset_dates: asset_dates, titles: asset_titles,
+    instantiations: build_list(:pbcore_instantiation, rand(1..3), :digital) + build_list(:pbcore_instantiation, rand(1..3), :physical)))
+  }
+
+  let(:config) { {
+    "asset_type" => { "values" => { "Album" => "Album", "Clip" => "Clip", "Compilation" => "Compilation", "Raw Footage" => "Raw Footage" } },
+    "asset_date" => { "types" => { "broadcast" => "Broadcast", "air" => "Broadcast", "issue" => "Broadcast", "created" => "Created" } }
+  } }
+
+
+  before(:each) do
+    allow(YAML).to receive(:load_file).and_return(config)
+    subject.validate
+  end
+
+  context '.validate' do
+    describe 'PBCore with invalid data' do
+      let(:asset_dates) { [ build(:pbcore_asset_date, type: date_type, value: date_value) ] }
+      let(:asset_titles) { [ build(:pbcore_title, type: asset_title_type, value: asset_title_value), build(:pbcore_title) ] }
+      let(:asset_type) { SecureRandom.hex.slice(0..7) }
+      let(:date_type) { SecureRandom.hex.slice(0..7) }
+      let(:date_value) { SecureRandom.hex.slice(0..7) }
+      let(:asset_title_type) { SecureRandom.hex.slice(0..7) }
+      let(:asset_title_value) { nil }
+
+      it 'is processed as invalid' do
+        expect(subject).not_to be_valid
+      end
+
+      it 'Invalid AssetType adds a controlled vocabulary error' do
+        expect(subject.errors.messages[:base]).to include("Invalid PBCore::AssetType value: #{asset_type}")
+      end
+
+      it 'Invalid DateType adds a controlled vocabulary error' do
+        expect(subject.errors.messages[:base]).to include("Invalid PBCore::AssetDate type: #{date_type}")
+      end
+
+      it 'Invalid Date value adds an error' do
+        expect(subject.errors.messages[:base]).to include("Invalid PBCore::AssetDate value: #{date_value}")
+      end
+
+      context 'with no Titles' do
+        let(:asset_titles) { [] }
+
+        it 'adds an error' do
+          expect(subject.errors.messages[:base]).to include("No PBCore::Title found")
+        end
+      end
+
+      it 'Missing Title value adds an error' do
+        expect(subject.errors.messages[:base]).to include("Invalid PBCore::Title, value attribute is missing")
+      end
+    end
+
+    describe 'PBCore with valid data' do
+      let(:asset_type) { "Raw Footage" }
+      let(:asset_dates) { [ build(:pbcore_asset_date, type: "Broadcast"), build(:pbcore_asset_date, type: "Created") ] }
+      let(:asset_titles) { [ build(:pbcore_title) ] }
+
+      it 'is processed as valid' do
+        expect(subject).to be_valid
+      end
+    end
+  end
+end

--- a/spec/services/ams/cleaner/pbcore_cleaner_spec.rb
+++ b/spec/services/ams/cleaner/pbcore_cleaner_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+require 'pbcore'
+require 'ams/cleaner/pbcore_cleaner'
+
+RSpec.describe AMS::Cleaner::PBCoreCleaner do
+
+  subject { described_class.new(pbcore) }
+  let(:pbcore) { create(:pbcore_description_document, :full_aapb) }
+  let(:fake_pipeline) { instance_double(AMS::Cleaner::Pipeline) }
+
+  before do
+    allow(fake_pipeline).to receive(:process).and_return(pbcore)
+  end
+
+  context 'with a pbcore document' do
+    describe '.clean!' do
+
+      it 'initiates an AMS::Cleaner::Pipeline and calls process' do
+        expect(AMS::Cleaner::Pipeline).to receive(:new).and_return(fake_pipeline)
+        expect(fake_pipeline).to receive(:process).with(pbcore)
+        subject.clean!
+      end
+
+    end
+  end
+end

--- a/spec/services/ams/cleaner/pbcore_element_editor_spec.rb
+++ b/spec/services/ams/cleaner/pbcore_element_editor_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+require 'pbcore'
+require 'ams/cleaner/pbcore_element_editor'
+
+RSpec.describe AMS::Cleaner::PBCoreElementEditor do
+
+  let(:pbcore_editor) { described_class.new(element: element) }
+
+  let(:config) { {
+    "title" => { "values" => { "test value" => "Test Value" }, "types" => { "test type" => "Test Type" } },
+    "asset_date" => { "types" => { "" => "Date" } }
+  } }
+
+  before do
+    allow(YAML).to receive(:load_file).and_return(config)
+  end
+
+  context 'with a PBCore element that has a VocabMap for both value and type' do
+    let(:element) { build(:pbcore_title, value: 'test value', type: 'test type') }
+
+    describe '.value' do
+      it 'returns a mapped element value' do
+        expect(pbcore_editor.value).to eq('Test Value')
+      end
+    end
+
+    describe '.type' do
+      it 'returns a mapped element type' do
+        expect(pbcore_editor.type).to eq('Test Type')
+      end
+    end
+  end
+
+  context 'with a PBCore element with a nil type and a VocabMap for an empty string' do
+    let(:element) { build(:pbcore_asset_date, type: nil)  }
+
+    describe '.type' do
+      it 'returns a mapped element type' do
+        expect(pbcore_editor.type).to eq('Date')
+      end
+    end
+  end
+
+  context 'with a PBCore element with no VocabMap' do
+    let(:element) { build(:pbcore_description, type: type, value: value) }
+    let(:type) { SecureRandom.hex.slice(0..7) }
+    let(:value) { SecureRandom.hex.slice(0..7) }
+
+    describe '.type' do
+      it 'returns the original type' do
+        expect(pbcore_editor.type).to eq(type)
+      end
+    end
+
+    describe '.value' do
+      it 'returns the original value' do
+        expect(pbcore_editor.value).to eq(value)
+      end
+    end
+  end
+end

--- a/spec/services/ams/cleaner/steps_spec.rb
+++ b/spec/services/ams/cleaner/steps_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+require 'ams/cleaner/pbcore_element_editor'
+
+RSpec.describe AMS::Cleaner::Steps do
+
+  describe '.process' do
+
+    let(:pbcore) { build(:pbcore_description_document, :full_aapb) }
+
+    context 'CleanAssetTypes' do
+
+      subject { AMS::Cleaner::Steps::CleanAssetTypes.process(pbcore) }
+      let(:asset_types) { pbcore.asset_types }
+      let(:new_value) { SecureRandom.hex.slice(0..7) }
+
+      before do
+        allow_any_instance_of(AMS::Cleaner::PBCoreElementEditor).to receive(:value).and_return(new_value)
+      end
+
+      it 'sets pbcore.asset_type values' do
+        expect(subject.length).to eq(asset_types.length)
+        expect(subject.uniq).to eq([new_value])
+      end
+    end
+
+    context 'CleanDateTypes' do
+
+      subject { AMS::Cleaner::Steps::CleanDateTypes.process(pbcore) }
+      let(:asset_dates) { pbcore.asset_dates }
+      let(:new_type) { SecureRandom.hex.slice(0..7) }
+
+      before do
+        allow_any_instance_of(AMS::Cleaner::PBCoreElementEditor).to receive(:type).and_return(new_type)
+      end
+
+      it 'sets pbcore.asset_date types' do
+        expect(subject.length).to eq(asset_dates.length)
+        expect(subject.uniq).to eq([new_type])
+      end
+    end
+
+    context 'CleanAssetDescriptionTypes' do
+
+      subject { AMS::Cleaner::Steps::CleanAssetDescriptionTypes.process(pbcore) }
+      let(:descriptions) { pbcore.descriptions }
+      let(:new_type) { SecureRandom.hex.slice(0..7) }
+
+      before do
+        allow_any_instance_of(AMS::Cleaner::PBCoreElementEditor).to receive(:type).and_return(new_type)
+      end
+
+      it 'sets pbcore.descriptions types' do
+        expect(subject.length).to eq(descriptions.length)
+        expect(subject.uniq).to eq([new_type])
+      end
+    end
+
+    context 'DeleteEmptyTitles' do
+
+      subject { AMS::Cleaner::Steps::DeleteEmptyTitles.process(pbcore) }
+      let(:pbcore) { build(:pbcore_description_document, :full_aapb, titles: [ build(:pbcore_title, type: '', value: ''), build(:pbcore_title, value: test_title) ]) }
+      let(:test_title) { SecureRandom.hex.slice(0..7) }
+
+
+      it 'removes pbcore.titles with no values' do
+        expect(subject.map(&:value)).to eq([test_title])
+      end
+    end
+
+    context 'AddUnknownTitleIfMissing' do
+
+      subject { AMS::Cleaner::Steps::AddUnknownTitleIfMissing.process(pbcore) }
+      let(:pbcore) { build(:pbcore_description_document, :full_aapb, titles: []) }
+
+      it 'adds pbcore.title with unknown type and value if no titles are present' do
+        expect(subject.length).to eq(1)
+        expect(subject.map(&:type)).to eq(["unknown"])
+        expect(subject.map(&:value)).to eq(["unknown"])
+      end
+    end
+
+  end
+end

--- a/spec/services/ams/cleaner/vocab_map_spec.rb
+++ b/spec/services/ams/cleaner/vocab_map_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+require 'yaml'
+require 'ams/cleaner/vocab_map'
+
+RSpec.describe AMS::Cleaner::VocabMap do
+
+  let(:config) { {
+    "asset_type" => { "values" => { "Album" => "Album", "Clip" => "Clip", "Compilation" => "Compilation" } },
+    "asset_date" => { "types" => { "broadcast" => "Broadcast", "air" => "Broadcast", "issue" => "Broadcast" } }
+  } }
+
+  before do
+    allow(YAML).to receive(:load_file).and_return(config)
+  end
+
+  describe '.for_pbcore_element' do
+
+    subject { described_class.for_pbcore_element(element) }
+
+    context 'with an element that has a vocab map in the config' do
+      let(:element) { create(:pbcore_asset_type) }
+
+      it 'it maps a PBCoreElement to the correct config' do
+        expect(subject).to eq(config["asset_type"])
+      end
+    end
+
+    context 'with an element that does not have a vocab map in the config' do
+      let(:element) { create(:pbcore_audience_level) }
+
+      it 'returns nil' do
+        expect(subject).to eq(nil)
+      end
+    end
+  end
+
+  describe '.for_pbcore_class' do
+
+    subject { described_class.for_pbcore_class(pbcore_class) }
+
+    context 'with a class that has a vocab map in the config' do
+      let(:pbcore_class) { PBCore::AssetDate }
+
+      it 'it maps a PBCoreClass to the correct config' do
+        expect(subject).to eq(config["asset_date"])
+      end
+    end
+
+    context 'with an element that does not have a vocab map in the config' do
+      let(:pbcore_class) { PBCore::AudienceLevel }
+
+      it 'returns nil' do
+        expect(subject).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR includes a custom validation class for a PBCore Description Document (from the WGBH pbcore gem) that checks for certain types, values, and elements that (while they may be technically valid in PBCore) are not exactly what we want for OUR PBCore. The PR also includes a Cleaner that checks the PBCore for similar characteristics and edits the PBCore Description Document.