### PR TITLE
Better error message for invalid annotation type

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -21,7 +21,7 @@ class Annotation < ApplicationRecord
   end
 
   def self.find_annotation_type_id(type_name)
-    registered_annotation_types[type_name.downcase]
+    registered_annotation_types[type_name.to_s.downcase]
   end
 
   def self.ingestable_attributes


### PR DESCRIPTION
Ensures that a nil annotation type does not raise a NoMethodError #downcase for nil:Class
allowing the more informative error message to be used instead, which is thrown in pbcore_xm_mapper.rb.

NOTE: refactoring validation might make this moot, but for now, it's ok.

Closes #561