### PR TITLE
Fixes SolrDocumet#members

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -50,7 +50,7 @@ class SolrDocument
   def members(only: [], except: [])
     return [] if member_ids.empty?
 
-    @members ||= self.class.repository.search("q" => "+id:(#{member_ids.join(' OR ')})")['response']['docs'].map do |doc|
+    @members ||= self.class.repository.search(q: "+id:(#{member_ids.join(' OR ')})", rows: 99999)['response']['docs'].map do |doc|
       SolrDocument.new(doc)
     end
 
@@ -62,7 +62,7 @@ class SolrDocument
   end
 
   def member_of
-    self.class.repository.search("q" => "member_ids_ssim:#{id}")['response']['docs'].map do |doc|
+    self.class.repository.search(q: "member_ids_ssim:#{id}", rows: 99999)['response']['docs'].map do |doc|
       SolrDocument.new(doc)
     end
   end


### PR DESCRIPTION
The 'rows' parameter was defaulting to 10, which was limiting the number of children
returned, which was causing instantiations to not be returned for PBCore XML exports
and pushes to AAPB. This fixes that, by setting the 'param' to arbitrarily high
number. Also, sets rows param for #member_of query.