### PR TITLE
Displays all children of Asset in #show view

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -226,6 +226,11 @@ Hyrax.config do |config|
   # mount point.
   #
   # config.whitelisted_ingest_dirs = []
+
+
+  # Increase the number of Asset members that are displayed on the Asset's
+  # #show page.
+  config.show_work_item_rows = 100
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"


### PR DESCRIPTION
The number of children was being cut off at 10 by default.

Closes #575.