### PR TITLE
Do not add empty Contributions

### DIFF
--- a/app/services/aapb/batch_ingest/csv_reader.rb
+++ b/app/services/aapb/batch_ingest/csv_reader.rb
@@ -25,7 +25,7 @@ module AAPB
       end
 
       def validate_options
-        @options_structure = AAPB::BatchIngest::CSVConfigParser.validate_config(@options)
+        @options_structure = AAPB::BatchIngest::CSVConfigParser.validate_config(options)
       end
 
       def validate_csv_header
@@ -76,7 +76,6 @@ module AAPB
             else
               model_hash[model][attribute] = value unless value.empty?
             end
-
           else
 
             # initialize array of contributions or instantiations etc
@@ -93,11 +92,9 @@ module AAPB
               last_hash = model_hash[model].last
 
               if multi_value_attr?(attribute, model)
-
                 last_hash[attribute] ||= []
-                last_hash[attribute] << value.first
+                last_hash[attribute] << value.first unless value.empty?
               else
-
                 last_hash[attribute] = value unless value.empty?
               end
             end

--- a/spec/factories/csv.rb
+++ b/spec/factories/csv.rb
@@ -1,0 +1,10 @@
+require_relative '../support/csv_builder'
+
+FactoryBot.define do
+  factory :csv, class: CsvBuilder do
+    sequence(:path) { |n| "#{Dir.tmpdir}/test_data_#{n}.csv" }
+    rows { [] }
+    headers { nil }
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/services/aapb/batch_ingest/csv_reader_spec.rb
+++ b/spec/services/aapb/batch_ingest/csv_reader_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe AAPB::BatchIngest::CSVReader do
+  let(:reader_options) { Hyrax::BatchIngest.config.ingest_types[ingest_type].reader_options }
+  subject { described_class.new(csv.path, reader_options) }
+
+  context 'for ingest type aapb_csv_reader_1' do
+    let(:ingest_type) { :aapb_csv_reader_1 }
+
+    describe '#batch_items' do
+      let(:batch_items) { subject.batch_items }
+
+      context 'when input CSV contains rows with emtpy cells for Contributor' do
+
+        let(:csv) {
+          create( :csv,
+                  headers: ["Contribution", "Contribution.contributor" , "Contribution.contributor_role" , "Contribution.contributor" , "Contribution.contributor_role"],
+                  rows: [
+                    ["", "Patti Smith", "Everything", "Art Vandelay", "Exporter"],
+                    ["", "Steve", "Key grip", "", ""],
+                    ["", "", "", "", ""]
+                  ]
+          )
+        }
+
+        let(:contribution_data) { subject.batch_items.map { |batch_item|
+          JSON.parse(batch_item.source_data)['Contribution']
+        }}
+
+        it 'does not contain data for empty Contributions' do
+          expect(contribution_data[0]).to eq( [ { "contributor" => [ "Patti Smith", "Art Vandelay"], "contributor_role"=>"Exporter" } ] )
+          expect(contribution_data[1]).to eq( [ { "contributor" => [ "Steve" ], "contributor_role" => "Key grip" } ] )
+          expect(contribution_data[2]).to eq( [ { "contributor" => [] } ] )
+        end
+      end
+    end
+  end
+end

--- a/spec/support/csv_builder.rb
+++ b/spec/support/csv_builder.rb
@@ -1,0 +1,20 @@
+class CsvBuilder
+  ROW_SEPARATOR = "\n"
+  COLUMN_SEPARATOR = ','
+
+  attr_reader :path, :rows, :headers
+
+  def initialize(path:, rows: [], headers: [])
+    @path, @rows, @headers = path, rows, headers
+  end
+
+  def save!
+    File.write(path, csv)
+  end
+
+  def csv
+    @csv ||= CSV.generate(headers: headers, col_sep: COLUMN_SEPARATOR, row_sep: ROW_SEPARATOR, write_headers: true) do |csv|
+      rows.each { |row| csv << row }
+    end
+  end
+end


### PR DESCRIPTION
* Fixes CsvReader to filter out empty values when mapping to BatchItem#source_data JSON.
* Adds a CSV factory following this example: https://id-in-it.com/factorybot-for-csv-file-fixtures
  * CsvBuilder is a thin wrapper around CSV ruby lib that simplifies the interface and adds a
    #save method that FactoryBot needs for `create`

Fixes #579.