### PR TITLE
Adds pry to all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,10 +42,6 @@ end
 group :development, :test do
   # Use sqlite3 as the database for Active Record
   gem 'sqlite3', '1.3.13'
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
-  gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'pry-rails'
   gem 'capybara-screenshot'
   gem 'rspec', "~> 3.7"
   gem 'rspec-rails', "~> 3.7"
@@ -102,3 +98,7 @@ gem 'faker'
 gem 'database_cleaner'
 gem 'redlock', '~> 1.0'
 gem 'httparty', '~> 0.18'
+
+# Adding pry to all environments, because it's very useful for debugging
+# production environments on demo instances.
+gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -605,8 +605,6 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     public_suffix (4.0.6)
     pul_uv_rails (2.0.1)
     puma (3.12.6)
@@ -937,7 +935,6 @@ DEPENDENCIES
   bixby
   blacklight_advanced_search (~> 6.4.0)
   bootstrap-multiselect-rails
-  byebug
   capybara (~> 3.0)
   capybara-screenshot
   carrierwave (~> 1.3)
@@ -962,7 +959,6 @@ DEPENDENCIES
   nokogiri
   pbcore (~> 0.3.0)
   pry-byebug
-  pry-rails
   puma (~> 3.12)
   rails (~> 5.1.5)
   rails-controller-testing


### PR DESCRIPTION
The error "Only referenceable nodes may be the value of reference properties" is a somewhat cryptic way to say that you're trying to save a new object with an ID that has a tombstone associated with it (i.e. it existed before in the repository, but has since been deleted, but not fully eradicated).

Eradicating the tombstone for these IDs allows us to move forward with the ingest. So that's good, but once again, I found myself really wanting a pry session on our demo machine, so I'm just adding it to the production environment here, for that reason. Debugging in prod env is not ideal, but sometimes you gotta do it to flush out issues specific to the prod environment, and I've had to do that several times now.

closes #586 