### PR TITLE
Fix 'Find media in Sony Ci...' button

### DIFF
--- a/app/assets/javascripts/sony_ci/find_media.coffee
+++ b/app/assets/javascripts/sony_ci/find_media.coffee
@@ -85,9 +85,12 @@ class FindSonyCiMediaBehavior
     $(@sonyCiIdInputSelector).change @fetchFilenameHandler
 
 # When the page loads...
-$(document).on 'turbolinks:load', ->
+# NOTE: could not get $(document).on('turbolinks:load') to work on initial page
+# load; reverting to $(document).ready, which seems to work more consistently.
+$(document).ready ->
   # This regex matches the 3rd URL segment which should be the GUID.
   guid_query_str = window.location.href.match(/concern\/assets\/(.*)\//)[1]
+
   # Create the behavior object, passing in the GUID as the query string.
   # NOTE: Sony Ci API has a 20 character limit on it's search terms, so let's
   # just pass in the last 20 characters, which will be more unique than the 1st
@@ -95,5 +98,6 @@ $(document).on 'turbolinks:load', ->
   # from Sony Ci said that quoted search queries have no such limit, but I could
   # not get that to work, nor is it mentioned in the Ci API docs anywhere.
   behavior = new FindSonyCiMediaBehavior(guid_query_str.substr(-20))
+
   # apply the behavior
   behavior.apply()


### PR DESCRIPTION
This button (as a <a> tag currently) is rendered on the Asset Edit interface in the Admin Data
section of the form, and finds Sony Ci media whose filename matches an Asset's GUID. But it
wasn't working on initial page. The behavior was being added in the turbolinks:load event,
which should work (we're doing it elsewhere), but on this page it simply would not. So I
changed it to use the jQuery(document).ready() method, which typically does NOT work because
of turbolinks, but in this case, it works better. But still not sure why.

Closes #608.