### PR TITLE
Re-indexes Asset after webhook from Sony Ci

### DIFF
--- a/app/controllers/sony_ci/webhooks_controller.rb
+++ b/app/controllers/sony_ci/webhooks_controller.rb
@@ -16,14 +16,23 @@ module SonyCi
     end
 
     def save_sony_ci_id
-      asset_admin_data_from_sony_ci_filename.update!( sonyci_id: [ sony_ci_id ] )
-      render status: 200, json: { message: "success" }
+      asset.admin_data.update!( sonyci_id: [ sony_ci_id ] )
+      # Re-save the Asset to re-index it.
+      # TODO: Is there a faster way to save the Sony Ci ID to the AdminData and
+      # re-index the Asset?
+      asset.save!
+      render status: 200,
+             json: {
+               message: "success",
+               guid: asset.id,
+               sony_ci_id: sony_ci_id
+             }
     end
 
     private
 
-      def asset_admin_data_from_sony_ci_filename
-        Asset.find(guid_from_sony_ci_filename).admin_data
+      def asset
+        @asset ||= Asset.find(guid_from_sony_ci_filename)
       end
 
       # Returns the assumed GUID from the Sony Ci Filename.


### PR DESCRIPTION
Re-indexes Asset after webhook from Sony Ci

The Asset was not being reindexed, and so it was saving on the Asset's admin data, but not the Solr doc.

This explicitly calls Asset#save! to re-index, but Asset#save! also persists in Fedora, which is slow, so if
there's a faster way to just save AdminData and re-index without Fedora, we should do that

Closes #620.