### PR TITLE
Adds API endpoint to get an Asset

### DIFF
--- a/app/controllers/api/assets_controller.rb
+++ b/app/controllers/api/assets_controller.rb
@@ -1,0 +1,38 @@
+module API
+  class AssetsController < APIController
+    # Authenticate user before all actions.
+    # NOTE: For Basic HTTP auth to work:
+    #   * the `http_authenticatable` config option for Devise must be set to true
+    #     (see config/initializers/devise.rb).
+    #   * The Authorization request header must be set to "Basic {cred}" where
+    #     {cred} is the base64 encoded username:password.
+    # TODO: Move authn into base APIController class and make modifications so
+    # that the SonyCi::APIController will work with authn, which needs to be
+    # done.
+    before_action do
+      authenticate_user!
+    end
+
+
+    def show
+      respond_to do |format|
+        format.json { render json: pbcore_json }
+        format.xml { render xml: pbcore_xml }
+      end
+    end
+
+    private
+
+    def pbcore_json
+      @pbcore_json ||= Hash.from_xml(pbcore_xml).to_json
+    end
+
+    def pbcore_xml
+      @pbcore_xml ||= solr_doc.export_as_pbcore
+    end
+
+    def solr_doc
+      @solr_doc ||= SolrDocument.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,3 +1,25 @@
 class APIController < ActionController::API
+  # Gives us respond_to in controller actions which we use to respond with
+  # JSON or PBCore XML.
+  include ActionController::MimeResponds
+
+  # Authenticate user before all actions.
+  # NOTE: For Basic HTTP auth to work:
+  #   * the `http_authenticatable` config option for Devise must be set to true
+  #     (see config/initializers/devise.rb).
+  #   * The Authorization request header must be set to "Basic {cred}" where
+  #     {cred} is the base64 encoded username:password.
+  before_action do
+    authenticate_user!
+  end
+
   # Common API features here, e.g. auth.
+  rescue_from ActiveFedora::ObjectNotFoundError, with: :not_found
+
+  private
+
+  def not_found(error)
+    # TODO: render errors in the proper format: xml or json.
+    render text: "Not Found", status: 404
+  end
 end

--- a/app/controllers/sony_ci/api_controller.rb
+++ b/app/controllers/sony_ci/api_controller.rb
@@ -2,6 +2,9 @@ require 'sony_ci_api'
 
 module SonyCi
   class APIController < ::APIController
+
+    respond_to :json
+
     # Specify error handlers for different kinds of errors. NOTE: for *all*
     # endpoints, we *always* want to respond with JSON and an appropriate HTTP
     # error, regardless of success or error. We *never* want to accidentally

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -68,7 +68,7 @@ Devise.setup do |config|
   # given strategies, for example, `config.http_authenticatable = [:database]` will
   # enable it only for database authentication. The supported strategies are:
   # :database      = Support basic authentication with authentication key + password
-  # config.http_authenticatable = false
+  config.http_authenticatable = true
 
   # If 401 status code should be returned for AJAX requests. True by default.
   # config.http_authenticatable_on_xhr = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,10 @@ Rails.application.routes.draw do
     get '/api/get_filename', controller: 'api', action: :get_filename, defaults: { format: :json }
   end
 
+  namespace :api do
+    resources :assets, only: [:show], defaults: { format: :json }
+  end
+
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/api/assets_controller_spec.rb
+++ b/spec/controllers/api/assets_controller_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe API::AssetsController, controller: true do
+  describe 'GET /api/assets/{id}' do
+    let(:password) { "abc123" }
+    let(:user) { create(:user, password: password) }
+    let(:encoded_username_and_password) { Base64.encode64("#{request_username}:#{request_password}").strip }
+    let(:format) { :json }
+
+    before do
+      request.headers['Authorization'] = "Basic #{encoded_username_and_password}"
+      get :show, params: { id: asset_id }, format: format
+    end
+
+    context 'when username is wrong,' do
+      let(:request_password) { password }
+      let(:request_username) { 'wrong username' }
+      let(:asset_id) { 'anything' }
+      it 'returns a 401' do
+        expect(response.status).to eq 401
+      end
+    end
+
+    context 'when password is wrong,' do
+      let(:request_username) { user.user_key }
+      let(:request_password) { 'wrong password' }
+      let(:asset_id) { 'anything' }
+      it 'returns a 401' do
+        expect(response.status).to eq 401
+      end
+    end
+
+    context 'when username and password are correct,' do
+      let(:request_username) { user.user_key}
+      let(:request_password) { password }
+
+      context 'when an Asset exists' do
+        let(:asset) { create(:asset) }
+        let(:asset_id) { asset.id }
+        let(:pbcore_xml) { SolrDocument.find(asset_id).export_as_pbcore }
+
+        context 'when the format is .json' do
+          let(:format) { :json }
+          let(:pbcore_json) { Hash.from_xml(pbcore_xml).to_json }
+
+          it 'responds with a 200 status' do
+            expect(response.status).to eq 200
+          end
+
+          it 'response with the JSON for an Asset' do
+            expect(response.body).to eq pbcore_json
+          end
+        end
+
+        context 'when the format is .xml' do
+          let(:format) { :xml }
+
+          it 'responds with a 200 status' do
+            expect(response.status).to eq 200
+          end
+
+          it 'responds with the PBCore XML for an Asset' do
+            pbcore_xml = SolrDocument.find(asset.id).export_as_pbcore
+            expect(response.body).to eq pbcore_xml
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Adds endpoint /api/assets/[:id].
* Uses an API-specific Assets controller to keep API access logic separate from
  catalog controller.
* For now, using Basic HTTP authentication where "Authorization" request header
  is sent with base64 encoded username:password, which Devise then authenticates
  against the database.
* NOTE: Does not use CanCan's authorization at this time because:
	* currently any user can view an Asset, and that's what we're doing here.
	* CanCan currently operates on the Asset model (i.e. ActitveFedora) and here
	  we are trying to keep the API endpoints fast by only fetching from Solr
	  and leaving Fedora out of it.
	* If more detailed authorization is needed, then we should add authn rules
	  to the Ability class for SolrDocument models.

Closes #634.