### PR TITLE
Allows batch update of plain title and description

### DIFF
--- a/config/batch_ingest.yml
+++ b/config/batch_ingest.yml
@@ -59,12 +59,14 @@ ingest_types:
           - eidr_id
           - topics
           - subject
+          - title
           - program_title
           - episode_title
           - segment_title
           - raw_footage_title
           - promo_title
           - clip_title
+          - description
           - program_description
           - episode_description
           - segment_description
@@ -113,12 +115,14 @@ ingest_types:
           - eidr_id
           - topics
           - subject
+          - title
           - program_title
           - episode_title
           - segment_title
           - raw_footage_title
           - promo_title
           - clip_title
+          - description
           - program_description
           - episode_description
           - segment_description


### PR DESCRIPTION
Previously you could only update specific title and description types, e.g. program_title,
series_description. This adds the non-typed (plain) Assett.title and Asset.description as allowed
CSV headers in a batch update.

Closes #667.