### PR TITLE
Double include

### DIFF
--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: 'ubuntu-latest'
     container: dtzar/helm-kubectl:3.9.4
     env:
+      REPO: '${{ github.repository }}'
       HELM_EXPERIMENTAL_OCI: 1
       HELM_RELEASE_NAME: ams-demo
       KUBE_NAMESPACE: ams-demo
-      HELM_EXTRA_ARGS: >
-        --values ops/demo-deploy.yaml
+      HELM_EXTRA_ARGS: "--values ops/demo-deploy.yaml"
       KUBECONFIG_FILE: ${{ secrets.KUBECONFIG_FILE_DEMO }}
       KUBECONFIG: ./kubeconfig.yml
       SOLR_PASSWORD: ${{ secrets.SOLR_PASSWORD_DEMO }}
@@ -26,8 +26,6 @@ jobs:
           echo "DEPLOY_TAG=${GITHUB_SHA::8}" >> $GITHUB_ENV;
       - name: Downcase repo
         run: echo "REPO_LOWER=${REPO,,}" >> $GITHUB_ENV
-        env:
-          REPO: '${{ github.repository }}'
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Do deploy

--- a/app/models/digital_instantiation.rb
+++ b/app/models/digital_instantiation.rb
@@ -46,7 +46,7 @@ class DigitalInstantiation < ActiveFedora::Base
   property :bulkrax_identifier, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#bulkraxIdentifier"), multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
-  
+
   property :date, predicate: ::RDF::URI.new("http://purl.org/dc/terms/date"), multiple: true, index_to_parent: true do |index|
     index.as :stored_searchable, :facetable
   end
@@ -159,7 +159,4 @@ class DigitalInstantiation < ActiveFedora::Base
     find_or_create_instantiation_admin_data
     self.instantiation_admin_data.save
   end
-
-  # This must be included at the end, because it finalizes the metadata if you have any further properties define above in current model
-  include ::Hyrax::BasicMetadata
 end

--- a/app/models/physical_instantiation.rb
+++ b/app/models/physical_instantiation.rb
@@ -27,7 +27,7 @@ class PhysicalInstantiation < ActiveFedora::Base
   property :bulkrax_identifier, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#bulkraxIdentifier"), multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
-  
+
   property :date, predicate: ::RDF::URI.new("http://purl.org/dc/terms/date"), multiple: true, index_to_parent: true do |index|
     index.as :stored_searchable, :facetable
   end
@@ -138,6 +138,4 @@ class PhysicalInstantiation < ActiveFedora::Base
     find_or_create_instantiation_admin_data
     self.instantiation_admin_data.save
   end
-  # This must be included at the end, because it finalizes the metadata if you have any further properties define above in current model
-  include ::Hyrax::BasicMetadata
 end


### PR DESCRIPTION
only include the basic metadata once per model. no real bug we are fixing here, just cleaning up something that could be a problem at some point.