### PR TITLE
Comment out importers for prod

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,5 +13,5 @@
   - [mailers, 10]
   - [exports, 10]
   - [push_to_aapb, 1]
-  - [import, 1]
+  # - [import, 1]
   # - [export, 10]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,6 +206,7 @@ services:
       args:
         - SETTINGS__BULKRAX__ENABLED=true
     image: ghcr.io/wgbh-mla/ams/worker:${TAG:-latest}
+    command: bash -l c "./bin/worker default ingest mailers exports push_to_aapb import export"
     depends_on:
       check_volumes:
         condition: service_completed_successfully


### PR DESCRIPTION
we keep the import commented out so that prod can have its workers separated between with and without Bulkrax. this is done so that prod still gets the custom priorities (where it is most important), where dev and demo just override the command to use all the queues (but looses priorities)