### PR TITLE
Migrate OLD GUIDs and Fix the Specs

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -117,7 +117,9 @@ module Hyrax
         end
 
         def find_or_create_admin_data(env)
-          return env.curation_concern.admin_data if env.curation_concern.admin_data.present?
+          # Don't use present? here. It is broken for some ActiveRecord objects. Maybe due to overriding getter
+          # See: https://stackoverflow.com/questions/35410668/what-determines-the-return-value-of-present
+          return env.curation_concern.admin_data if env.curation_concern.admin_data.is_a?(AdminData)
 
           admin_data = AdminData.find_by_gid(env.attributes['admin_data_gid']) if env.attributes['bulkrax_identifier'].present?
           admin_data ||= ::AdminData.create

--- a/lib/tasks/ams/migrate_old_guids.rake
+++ b/lib/tasks/ams/migrate_old_guids.rake
@@ -1,0 +1,60 @@
+namespace :ams do
+  desc 'Migrate Fedora records out of "hard-coded" location'
+  task migrate_old_guids: :environment do
+    require 'ruby-progressbar'
+
+    client = Blacklight.default_index.connection
+    start_date = Date.new(2000, 1, 1)
+    end_date = Date.new(2022, 11, 27)
+    models = %w[Asset PhysicalInstantiation DigitalInstantiation EssenceTrack]
+    query = "system_create_dtsi:[#{start_date.strftime('%Y-%m-%dT00:00:00Z')} TO #{end_date.strftime('%Y-%m-%dT23:59:59Z')}] " \
+            "has_model_ssim:(#{models.join(' OR ')})"
+    params = {
+      q: query,
+      fl: 'id',
+      sort: 'system_create_dtsi asc',
+      rows: 2_147_483_647,
+      wt: 'json'
+    }
+
+    response = client.post('select', params: params)
+    total = response['response']['numFound']
+    raise StandardError, "No Solr documents found matching query: #{query}" if total.zero?
+
+    docs = response['response']['docs']
+    ids = docs.map { |doc| doc['id'] }
+    progressbar = ProgressBar.create(total: total, format: '%a %e %P% Processed: %c from %C')
+    logger = ActiveSupport::Logger.new('tmp/imports/migrate_old_guids.log')
+    ids_file_path = 'tmp/imports/migrate_old_guids_ids.txt'
+
+    FileUtils.rm(ids_file_path) if File.exist?(ids_file_path)
+    File.open(ids_file_path, 'w') do |file|
+      ids.each do |id|
+        file.puts(id)
+      end
+    end
+
+    begin
+      ids.each do |id|
+        logger.info("Starting #{id}")
+        new_uri = "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{::Noid::Rails.treeify(id)}"
+        new_location_ping = %x{curl -I #{new_uri} 2> /dev/null}
+
+        if new_location_ping.match?('200 OK')
+          logger.debug("#{id} already exists at #{new_uri}, skipping...")
+          progressbar.increment
+          next
+        end
+
+        old_uri = "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{::Noid::Rails.treeify(id, false)}"
+        new_uri_path = new_uri.sub(/\w+-\w+-\w+$/, '')
+        %x{curl -X PUT "#{new_uri_path}" > /dev/null 2>&1}
+        %x{curl -X MOVE -H "Destination: #{new_uri}" "#{old_uri}" > /dev/null 2>&1}
+
+        progressbar.increment
+      end
+    rescue => e
+      logger.error("#{e.class} | #{e.message} | #{id} | Continuing...")
+    end
+  end
+end

--- a/spec/factories/digital_instantiation.rb
+++ b/spec/factories/digital_instantiation.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     duration { '1:23:45' }
     file_size { '12354435234' }
     local_instantiation_identifier { ["1234"] }
-    digital_instantiation_pbcore_xml { Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/sample_instantiation_valid.xml'), 'text/xml') }
+    digital_instantiation_pbcore_xml { File.open(Rails.root.join('spec/fixtures/sample_instantiation_valid.xml')) }
     trait :aapb_moving_image do
       holding_organization { "American Archive of Public Broadcasting" }
       media_type { "Moving Image" }

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -146,7 +146,7 @@ describe SolrDocument do
             # 11 members across 3 different types
             create_list(:contribution, 9),
             create(:digital_instantiation),
-            create(:digital_instantiation)
+            create(:physical_instantiation)
         ].flatten)
       }
 
@@ -163,6 +163,4 @@ describe SolrDocument do
       end
     end
   end
-
-
 end

--- a/spec/parsers/csv_parser_spec.rb
+++ b/spec/parsers/csv_parser_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe CsvParser do
       context 'with fill_in_blank_source_identifiers set' do
         it 'fills in the source_identifier if fill_in_blank_source_identifiers is set' do
           expect(subject).to receive(:increment_counters).twice
-          expect(Bulkrax).to receive(:fill_in_blank_source_identifiers).exactly(6).times.and_return(->(_obj, _index) { "4649ee79-7d7a-4df0-86d6-d6865e2925ca"} )
+          expect(Bulkrax).to receive(:fill_in_blank_source_identifiers).exactly(6).times.and_return(->(_obj, _asset_id, _index) { "4649ee79-7d7a-4df0-86d6-d6865e2925ca"} )
           subject.create_works
           expect(subject.seen).to include("4649ee79-7d7a-4df0-86d6-d6865e2925ca")
         end


### PR DESCRIPTION
this fixes specs and should resolve a "admindata cant be updated" when admindata is blank bug. It also adds a rake task for migrating GUIDs in the fcrepo tree.