### PR TITLE
Prevent Assets missing children from being pushed to AAPB (Validator)

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -12,7 +12,7 @@ module Hyrax
         add_title_types(env)
         add_description_types(env)
         add_date_types(env)
-        set_aapb_pushable(env)
+        env.curation_concern.aapb_pushable = has_all_children?(env.curation_concern)
 
         # queue indexing if we are importing
         env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
@@ -224,12 +224,8 @@ module Hyrax
           typed_values.map { |v| v[:value] if v[:type] == type } .compact
         end
 
-        def set_aapb_pushable(env)
-          # FIXME: Remove #to_i when :intended_children_count is indexed as an integer.
-          #        @see app/models/asset.rb
-          if env.curation_concern.all_members.size == env.curation_concern.intended_children_count.to_i
-            env.curation_concern.aapb_pushable = true
-          end
+        def has_all_children?(curation_concern)
+          curation_concern.all_members.size == curation_concern.intended_children_count.to_i
         end
     end
   end

--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -24,7 +24,7 @@ module Hyrax
         add_title_types(env)
         add_description_types(env)
         add_date_types(env)
-        set_aapb_pushable(env)
+        env.curation_concern.aapb_pushable = has_all_children?(env.curation_concern)
 
         # queue indexing if we are importing
         env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing

--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -13,6 +13,11 @@ module Hyrax
         add_description_types(env)
         add_date_types(env)
 
+        # TODO: extract
+        if env.curation_concern.all_members.size == env.curation_concern.intended_children_count.to_i
+          env.curation_concern.aapb_pushable = true
+        end
+
         # queue indexing if we are importing
         env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
         save_aapb_admin_data(env) && super && create_or_update_contributions(env, contributions)
@@ -23,6 +28,12 @@ module Hyrax
         add_title_types(env)
         add_description_types(env)
         add_date_types(env)
+
+        # TODO: extract
+        if env.curation_concern.all_members.size == env.curation_concern.intended_children_count.to_i
+          env.curation_concern.aapb_pushable = true
+        end
+
         # queue indexing if we are importing
         env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
         save_aapb_admin_data(env) && super && create_or_update_contributions(env, contributions)

--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -12,7 +12,7 @@ module Hyrax
         add_title_types(env)
         add_description_types(env)
         add_date_types(env)
-        env.curation_concern.aapb_pushable = has_all_children?(env.curation_concern)
+        set_validation_status(env)
 
         # queue indexing if we are importing
         env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
@@ -24,7 +24,7 @@ module Hyrax
         add_title_types(env)
         add_description_types(env)
         add_date_types(env)
-        env.curation_concern.aapb_pushable = has_all_children?(env.curation_concern)
+        set_validation_status(env)
 
         # queue indexing if we are importing
         env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
@@ -224,8 +224,15 @@ module Hyrax
           typed_values.map { |v| v[:value] if v[:type] == type } .compact
         end
 
-        def has_all_children?(curation_concern)
-          curation_concern.all_members.size == curation_concern.intended_children_count.to_i
+        def set_validation_status(env)
+          intended_children_count = env.curation_concern.intended_children_count.to_i
+          current_children_count = env.curation_concern.all_members.size
+
+          if current_children_count != intended_children_count
+            env.curation_concern.validation_status_for_aapb = [Asset::VALIDATION_STATUSES[:missing_children]]
+          else
+            env.curation_concern.validation_status_for_aapb = [Asset::VALIDATION_STATUSES[:valid]]
+          end
         end
     end
   end

--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -225,6 +225,8 @@ module Hyrax
         end
 
         def set_aapb_pushable(env)
+          # FIXME: Remove #to_i when :intended_children_count is indexed as an integer.
+          #        @see app/models/asset.rb
           if env.curation_concern.all_members.size == env.curation_concern.intended_children_count.to_i
             env.curation_concern.aapb_pushable = true
           end

--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -12,11 +12,7 @@ module Hyrax
         add_title_types(env)
         add_description_types(env)
         add_date_types(env)
-
-        # TODO: extract
-        if env.curation_concern.all_members.size == env.curation_concern.intended_children_count.to_i
-          env.curation_concern.aapb_pushable = true
-        end
+        set_aapb_pushable(env)
 
         # queue indexing if we are importing
         env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
@@ -28,11 +24,7 @@ module Hyrax
         add_title_types(env)
         add_description_types(env)
         add_date_types(env)
-
-        # TODO: extract
-        if env.curation_concern.all_members.size == env.curation_concern.intended_children_count.to_i
-          env.curation_concern.aapb_pushable = true
-        end
+        set_aapb_pushable(env)
 
         # queue indexing if we are importing
         env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
@@ -230,6 +222,12 @@ module Hyrax
 
         def get_typed_value(type, typed_values)
           typed_values.map { |v| v[:value] if v[:type] == type } .compact
+        end
+
+        def set_aapb_pushable(env)
+          if env.curation_concern.all_members.size == env.curation_concern.intended_children_count.to_i
+            env.curation_concern.aapb_pushable = true
+          end
         end
     end
   end

--- a/app/indexers/asset_indexer.rb
+++ b/app/indexers/asset_indexer.rb
@@ -18,6 +18,7 @@ class AssetIndexer < AMS::WorkIndexer
       solr_doc['created_date_drsim'] = object.created_date if object.created_date
       solr_doc['copyright_date_drsim'] = object.copyright_date if object.copyright_date
       solr_doc[Solrizer.solr_name('bulkrax_identifier', :facetable)] = object.bulkrax_identifier
+      solr_doc['intended_children_count_isi'] = object.intended_children_count.to_i
 
       if object.admin_data
         # Index the admin_data_gid

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -205,11 +205,13 @@ class Asset < ActiveFedora::Base
   end
 
   # TODO: rename?
+  # FIXME: figure out how to index as Integer (currently <String>)
   property :intended_children_count, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#intendedChildrenCount"), multiple: false do |index|
     index.type :integer
     index.as :stored_sortable
   end
 
+  # FIXME: figure out how to index as Boolean (currently <Array[String]>)
   property :aapb_pushable, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#aapbPushable"), multiple: false do |index|
     index.type :boolean
     index.as :stored_searchable

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -204,7 +204,9 @@ class Asset < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  # TODO: rename?
+  # This property is intended to be an Integer, but ActiveFedora stores everything as Strings. We don't declare indexing
+  # rules in a block here because indexing for this property is handled manually.
+  # @see AssetIndexer#generate_solr_document
   property :intended_children_count, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#intendedChildrenCount"), multiple: false
 
   property :aapb_pushable, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/terms/aapbPushable"), multiple: false do |index|

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -5,6 +5,12 @@ class Asset < ActiveFedora::Base
   include ::AMS::CascadeDestroyMembers
   include ::AMS::AllMembers
 
+  # @see Push#add_status_error
+  VALIDATION_STATUSES = {
+    valid: 'valid',
+    missing_children: 'missing child record(s)'
+  }.freeze
+
   self.indexer = AssetIndexer
   before_save :save_admin_data
   # Change this to restrict which works can be added as a child.
@@ -209,8 +215,7 @@ class Asset < ActiveFedora::Base
   # @see AssetIndexer#generate_solr_document
   property :intended_children_count, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#intendedChildrenCount"), multiple: false
 
-  property :aapb_pushable, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/terms/aapbPushable"), multiple: false do |index|
-    index.type :boolean
+  property :validation_status_for_aapb, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#validationStatusForAapb"), multiple: true do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -204,6 +204,17 @@ class Asset < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  # TODO: rename?
+  property :intended_children_count, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#intendedChildrenCount"), multiple: false do |index|
+    index.type :integer
+    index.as :stored_sortable
+  end
+
+  property :aapb_pushable, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#aapbPushable"), multiple: false do |index|
+    index.type :boolean
+    index.as :stored_searchable
+  end
+
   def admin_data_gid=(new_admin_data_gid)
     raise "Can't modify admin data of this asset" if persisted? && !admin_data_gid_was.nil? && admin_data_gid_was != new_admin_data_gid
     new_admin_data = AdminData.find_by_gid!(new_admin_data_gid)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -205,14 +205,9 @@ class Asset < ActiveFedora::Base
   end
 
   # TODO: rename?
-  # FIXME: figure out how to index as Integer (currently <String>)
-  property :intended_children_count, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#intendedChildrenCount"), multiple: false do |index|
-    index.type :integer
-    index.as :stored_sortable
-  end
+  property :intended_children_count, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#intendedChildrenCount"), multiple: false
 
-  # FIXME: figure out how to index as Boolean (currently <Array[String]>)
-  property :aapb_pushable, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#aapbPushable"), multiple: false do |index|
+  property :aapb_pushable, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/terms/aapbPushable"), multiple: false do |index|
     index.type :boolean
     index.as :stored_searchable
   end

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -39,6 +39,10 @@ class Push < ApplicationRecord
 
     def add_status_error(invalid_docs, status)
       ids_matching_status = invalid_docs.select { |doc| doc.validation_status_for_aapb.include?(status) }.map(&:id)
+      # Prevents adding errors to docs that don't have a value
+      # in :validation_status_for_aapb, including all non-Assets.
+      return if ids_matching_status.blank?
+
       errors.add(:pushed_id_csv, "The following IDs are #{status}: #{ids_matching_status.join(', ')}")
     end
 

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -30,9 +30,7 @@ class Push < ApplicationRecord
 
     # TODO: rename method when :aapb_pushable is used for generic validation
     def validate_missing_children
-      # FIXME: switch for cleaner version when :aapb_pushable is indexed as a boolean
-      missing_children_ids = export_search.solr_documents.reject { |doc| doc['aapb_pushable_tesim'] == ['true'] }.map(&:id)
-      # missing_children_ids = export_search.solr_documents.reject(&:aapb_pushable).map(&:id)
+      missing_children_ids = export_search.solr_documents.reject(&:aapb_pushable).map(&:id)
       return if missing_children_ids.blank?
 
       # TODO: reword error message when :aapb_pushable is used for generic validation

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -17,6 +17,13 @@ class SolrDocument
   SolrDocument.use_extension(AMS::CsvExportExtension)
   SolrDocument.use_extension(AMS::PbcoreXmlExportExtension)
 
+  # TODO: Swap these lines when :aapb_pushable is indexed as a boolean
+  #       @see app/models/asset.rb
+  # attribute :intended_children_count, Solr::String, 'intended_children_count_isi'
+  # attribute :aapb_pushable, Solr::String, 'aapb_pushable_bsi'
+  attribute :intended_children_count, Solr::String, 'intended_children_count_ssi'
+  attribute :aapb_pushable, Solr::String, 'aapb_pushable_tesim'
+
   # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document
   # Semantic mappings of solr stored fields. Fields may be multi or
   # single valued. See Blacklight::Document::SemanticFields#field_semantics
@@ -451,7 +458,7 @@ class SolrDocument
     self[Solrizer.solr_name('aapb_preservation_disk')]
   end
 
-  def bulkrax_importer_id 
+  def bulkrax_importer_id
     self[Solrizer.solr_name('bulkrax_importer_id')]
   end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -17,13 +17,8 @@ class SolrDocument
   SolrDocument.use_extension(AMS::CsvExportExtension)
   SolrDocument.use_extension(AMS::PbcoreXmlExportExtension)
 
-  # TODO: Swap these lines when :aapb_pushable is indexed as a boolean
-  #       and :intended_children_count is indexed as an integer.
-  #       @see app/models/asset.rb
-  # attribute :intended_children_count, Solr::String, 'intended_children_count_isi'
-  # attribute :aapb_pushable, Solr::String, 'aapb_pushable_bsi'
-  attribute :intended_children_count, Solr::String, 'intended_children_count_ssi'
-  attribute :aapb_pushable, Solr::String, 'aapb_pushable_tesim'
+  attribute :intended_children_count, Solr::String, 'intended_children_count_isi'
+  attribute :aapb_pushable, Solr::String, 'aapb_pushable_bsi'
 
   # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document
   # Semantic mappings of solr stored fields. Fields may be multi or

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -18,7 +18,7 @@ class SolrDocument
   SolrDocument.use_extension(AMS::PbcoreXmlExportExtension)
 
   attribute :intended_children_count, Solr::String, 'intended_children_count_isi'
-  attribute :aapb_pushable, Solr::String, 'aapb_pushable_bsi'
+  attribute :validation_status_for_aapb, Solr::Array, 'validation_status_for_aapb_tesim'
 
   # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document
   # Semantic mappings of solr stored fields. Fields may be multi or

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -18,6 +18,7 @@ class SolrDocument
   SolrDocument.use_extension(AMS::PbcoreXmlExportExtension)
 
   # TODO: Swap these lines when :aapb_pushable is indexed as a boolean
+  #       and :intended_children_count is indexed as an integer.
   #       @see app/models/asset.rb
   # attribute :intended_children_count, Solr::String, 'intended_children_count_isi'
   # attribute :aapb_pushable, Solr::String, 'aapb_pushable_bsi'

--- a/app/parsers/pbcore_xml_parser.rb
+++ b/app/parsers/pbcore_xml_parser.rb
@@ -152,6 +152,7 @@ class PbcoreXmlParser < Bulkrax::XmlParser
 
   def instantiation_rows(instantiations, xml_asset, asset, asset_id)
     xml_records = []
+    children_count = 0
     instantiations.each.with_index do |inst, i|
       instantiation_class =  'PhysicalInstantiation' if inst.physical
       instantiation_class ||= 'DigitalInstantiation' if inst.digital
@@ -170,6 +171,7 @@ class PbcoreXmlParser < Bulkrax::XmlParser
         parse_rows([xml_track], 'EssenceTrack', asset_id, asset, j+1)
         xml_record[:children] << xml_track[work_identifier]
         xml_tracks << xml_track
+        children_count += 1
       end
       parse_rows([xml_record], instantiation_class, asset_id, asset)
       add_object(xml_record)
@@ -178,7 +180,9 @@ class PbcoreXmlParser < Bulkrax::XmlParser
     end
     xml_records.each do |row|
       xml_asset[:children] << row[work_identifier]
+      children_count += 1
     end
+    xml_asset[:intended_children_count] = children_count
   end
 
   def parse_rows(rows, type, asset_id, parent_asset = nil, counter = nil)

--- a/app/views/pushes/new.html.erb
+++ b/app/views/pushes/new.html.erb
@@ -47,7 +47,8 @@
   function validate(id_field_val){
     $.post('/pushes/validate_ids', { id_field: id_field_val }, function(resp) {
       $('#loader').hide();
-      
+      $('#valid-box').empty();
+
       var message;
       if(resp.error) {
         message = resp.error;
@@ -57,7 +58,10 @@
         $('#valid-box').addClass("green").removeClass("red");
       }
 
-      $('#valid-box').text(message);
+      messages_array = message.split("\n\n")
+      messages_array.forEach(msg => {
+        $('#valid-box').append('<p>' + msg + '</p>')
+      });
     });
   }
 </script>


### PR DESCRIPTION
# Summary

Adds new validations the ensures an `Asset` has all of it's children (and that it's children have their children) present in the database and associated with it before pushing it to AAPB.

### Demo: https://share.getcloudapp.com/P8uX1kN0

![image](https://github.com/WGBH-MLA/ams/assets/32469930/cd96ff45-0554-426f-8f8f-e6474d2e7ea9)
