### PR TITLE
i729 Adjust logic determining if an Asset is missing children

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -228,7 +228,7 @@ module Hyrax
           intended_children_count = env.curation_concern.intended_children_count.to_i
           current_children_count = env.curation_concern.all_members.size
 
-          if current_children_count != intended_children_count
+          if current_children_count < intended_children_count
             env.curation_concern.validation_status_for_aapb = [Asset::VALIDATION_STATUSES[:missing_children]]
           else
             env.curation_concern.validation_status_for_aapb = [Asset::VALIDATION_STATUSES[:valid]]

--- a/spec/actors/hyrax/actors/asset_actor_spec.rb
+++ b/spec/actors/hyrax/actors/asset_actor_spec.rb
@@ -41,6 +41,30 @@ RSpec.describe Hyrax::Actors::AssetActor do
         expect(asset.validation_status_for_aapb).to eq(['missing child record(s)'])
       end
     end
+
+    context 'when the asset has more children than intended' do
+      let(:intended_children_count) { 0 }
+
+      it 'sets the status to "valid"' do
+        expect(asset.validation_status_for_aapb).to be_empty
+
+        middleware.public_send(method, env)
+
+        expect(asset.validation_status_for_aapb).to eq(['valid'])
+      end
+    end
+
+    context "when the asset's intended number of children is not set" do
+      let(:intended_children_count) { nil }
+
+      it 'sets the status to "valid"' do
+        expect(asset.validation_status_for_aapb).to be_empty
+
+        middleware.public_send(method, env)
+
+        expect(asset.validation_status_for_aapb).to eq(['valid'])
+      end
+    end
   end
 
   describe '#create' do


### PR DESCRIPTION
Using "less than" instead of "does not equal" fixes a couple issues:

- If a new child record was created through the UI, the Asset would be marked as missing children
- If a pre-existing Asset, whose :intended_children_count had not been set, was updated outside of Bulkrax, it would be marked as missing children