### PR TITLE
i729 Apply missing children validator to PBCore XML ingester

### DIFF
--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -125,6 +125,11 @@ module AAPB
           all_people = pbcore.contributors + pbcore.publishers + creator_people
           attrs[:contributors]                = people_attributes(all_people)
           attrs[:producing_organization]      = creator_orgs.map {|co| co.creator.value}
+
+          intended_children_count = 0
+          intended_children_count += pbcore.instantiations.size
+          intended_children_count += pbcore.instantiations.map(&:essence_tracks).flatten.size
+          attrs[:intended_children_count]     = intended_children_count
         end
       end
 

--- a/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
+++ b/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
@@ -99,6 +99,22 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLMapper, :pbcore_xpath_helper do
         expect(attrs[:date]).to eq ['2001', '2002-02', '2003-03-03']
       end
     end
+
+    describe 'counting the intended number of child records' do
+      let(:essence_track) { build(:pbcore_instantiation_essence_track) }
+      let(:instantiations) do
+        [
+          build(:pbcore_instantiation, :digital, essence_tracks: [essence_track, essence_track]),
+          build(:pbcore_instantiation, :physical, essence_tracks: [essence_track])
+        ]
+      end
+      let(:pbcore_xml) { build(:pbcore_description_document, instantiations: instantiations).to_xml }
+
+      it 'sets :intended_children_count to the sum of all instantiations and essence tracks' do
+        # 1 digital + 1 physical + 3 essence tracks
+        expect(attrs[:intended_children_count]).to eq(5)
+      end
+    end
   end
 
   describe '#physical_instantiation_attributes' do


### PR DESCRIPTION
Batch ingests of type `AAPB PBCore - Zipped` will now work with the missing child record validator introduced in #728 