### PR TITLE
i729 Ignore Contributions when determining if an Asset is missing child records

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -225,8 +225,15 @@ module Hyrax
         end
 
         def set_validation_status(env)
+          # Filter out Contributions from child count since they don't get included in the :intended_children_count
+          # at time of import.
+          # @see AAPB::BatchIngest::PBCoreXMLMapper#asset_attributes
+          #
+          # This is ultimately because there is a possibility that the creation of all of an Asset's
+          # Contributions could be skipped, which would significantly throw off the count for comparison.
+          # @see #create_or_update_contributions
+          current_children_count = env.curation_concern.all_members.reject { |child| child.is_a?(Contribution) }.size
           intended_children_count = env.curation_concern.intended_children_count.to_i
-          current_children_count = env.curation_concern.all_members.size
 
           if current_children_count < intended_children_count
             env.curation_concern.validation_status_for_aapb = [Asset::VALIDATION_STATUSES[:missing_children]]

--- a/app/parsers/pbcore_xml_parser.rb
+++ b/app/parsers/pbcore_xml_parser.rb
@@ -152,7 +152,6 @@ class PbcoreXmlParser < Bulkrax::XmlParser
 
   def instantiation_rows(instantiations, xml_asset, asset, asset_id)
     xml_records = []
-    children_count = 0
     instantiations.each.with_index do |inst, i|
       instantiation_class =  'PhysicalInstantiation' if inst.physical
       instantiation_class ||= 'DigitalInstantiation' if inst.digital
@@ -171,7 +170,6 @@ class PbcoreXmlParser < Bulkrax::XmlParser
         parse_rows([xml_track], 'EssenceTrack', asset_id, asset, j+1)
         xml_record[:children] << xml_track[work_identifier]
         xml_tracks << xml_track
-        children_count += 1
       end
       parse_rows([xml_record], instantiation_class, asset_id, asset)
       add_object(xml_record)
@@ -180,9 +178,7 @@ class PbcoreXmlParser < Bulkrax::XmlParser
     end
     xml_records.each do |row|
       xml_asset[:children] << row[work_identifier]
-      children_count += 1
     end
-    xml_asset[:intended_children_count] = children_count
   end
 
   def parse_rows(rows, type, asset_id, parent_asset = nil, counter = nil)

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -126,7 +126,7 @@ module AAPB
           attrs[:contributors]                = people_attributes(all_people)
           attrs[:producing_organization]      = creator_orgs.map {|co| co.creator.value}
 
-          intended_children_count = all_people.size
+          intended_children_count = 0
           intended_children_count += pbcore.instantiations.size
           intended_children_count += pbcore.instantiations.map(&:essence_tracks).flatten.size
           attrs[:intended_children_count]     = intended_children_count

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -126,7 +126,7 @@ module AAPB
           attrs[:contributors]                = people_attributes(all_people)
           attrs[:producing_organization]      = creator_orgs.map {|co| co.creator.value}
 
-          intended_children_count = 0
+          intended_children_count = all_people.size
           intended_children_count += pbcore.instantiations.size
           intended_children_count += pbcore.instantiations.map(&:essence_tracks).flatten.size
           attrs[:intended_children_count]     = intended_children_count

--- a/spec/actors/hyrax/actors/asset_actor_spec.rb
+++ b/spec/actors/hyrax/actors/asset_actor_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Hyrax::Actors::AssetActor do
     end
 
     context 'when the asset is missing children' do
-      let(:intended_children_count) { 5 }
+      let(:intended_children_count) { 10 }
 
       it 'sets the status to "missing child record(s)"' do
         expect(asset.validation_status_for_aapb).to be_empty

--- a/spec/fixtures/bulkrax/xml/pbcore_doc.xml
+++ b/spec/fixtures/bulkrax/xml/pbcore_doc.xml
@@ -9,6 +9,26 @@
   <pbcoreDescription descriptionType="Series Description">Houston Symphony is a series of live recordings of the Houston Symphony orchestral performances.</pbcoreDescription>
   <pbcoreGenre source="AAPB Topical Genre">Music</pbcoreGenre>
   <pbcoreGenre source="AAPB Format Genre">Performance for a Live Audience</pbcoreGenre>
+  <pbcoreCreator>
+    <creator>Magistrelli, Mark</creator>
+    <creatorRole>Writer</creatorRole>
+  </pbcoreCreator>
+  <pbcoreCreator>
+    <creator>King, Dr. James C.</creator>
+    <creatorRole>Executive Producer</creatorRole>
+  </pbcoreCreator>
+  <pbcoreCreator>
+    <creator>Cincinnati Public Radio</creator>
+    <creatorRole>Producing Organization</creatorRole>
+  </pbcoreCreator>
+  <pbcoreContributor>
+    <contributor>Clooney, Nick, 1934-</contributor>
+    <contributorRole>Host</contributorRole>
+  </pbcoreContributor>
+  <pbcorePublisher>
+    <publisher>Prairie Public Broadcasting, Inc.</publisher>
+    <publisherRole>Publisher</publisherRole>
+  </pbcorePublisher>
   <pbcoreInstantiation>
     <instantiationIdentifier source="Librarian">4344</instantiationIdentifier>
     <instantiationPhysical>DAT</instantiationPhysical>

--- a/spec/parsers/pbcore_xml_parser_spec.rb
+++ b/spec/parsers/pbcore_xml_parser_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe PbcoreXmlParser do
     let(:importer) { FactoryBot.create(:bulkrax_importer_pbcore_xml) }
 
     before do
+      Bulkrax.fill_in_blank_source_identifiers = ->(type, index, key_count) { "#{type}-#{index}-#{key_count}" }
       Bulkrax.field_mappings['PbcoreXmlParser'] = {
         'bulkrax_identifier' => { from: ['pbcoreIdentifier'], source_identifier: true }
       }
@@ -41,7 +42,7 @@ RSpec.describe PbcoreXmlParser do
           xml_parser.create_works
 
           entry = importer.entries.find_by(identifier: 'Asset-cpb-aacip-20-000000hr-1')
-          expect(entry.raw_metadata['intended_children_count']).to eq(5)
+          expect(entry.raw_metadata['intended_children_count']).to eq(9)
         end
       end
     end

--- a/spec/parsers/pbcore_xml_parser_spec.rb
+++ b/spec/parsers/pbcore_xml_parser_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe PbcoreXmlParser do
           xml_parser.create_works
 
           entry = importer.entries.find_by(identifier: 'Asset-cpb-aacip-20-000000hr-1')
-          expect(entry.raw_metadata['intended_children_count']).to eq(9)
+          expect(entry.raw_metadata['intended_children_count']).to eq(5)
         end
       end
     end

--- a/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
+++ b/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLMapper, :pbcore_xpath_helper do
       let(:pbcore_xml) { File.read('./spec/fixtures/bulkrax/xml/pbcore_doc.xml') }
 
       it 'sets :intended_children_count to the sum of all child records in the XML' do
-        expect(attrs[:intended_children_count]).to eq(9)
+        expect(attrs[:intended_children_count]).to eq(5)
       end
     end
   end

--- a/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
+++ b/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
@@ -101,18 +101,10 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLMapper, :pbcore_xpath_helper do
     end
 
     describe 'counting the intended number of child records' do
-      let(:essence_track) { build(:pbcore_instantiation_essence_track) }
-      let(:instantiations) do
-        [
-          build(:pbcore_instantiation, :digital, essence_tracks: [essence_track, essence_track]),
-          build(:pbcore_instantiation, :physical, essence_tracks: [essence_track])
-        ]
-      end
-      let(:pbcore_xml) { build(:pbcore_description_document, instantiations: instantiations).to_xml }
+      let(:pbcore_xml) { File.read('./spec/fixtures/bulkrax/xml/pbcore_doc.xml') }
 
-      it 'sets :intended_children_count to the sum of all instantiations and essence tracks' do
-        # 1 digital + 1 physical + 3 essence tracks
-        expect(attrs[:intended_children_count]).to eq(5)
+      it 'sets :intended_children_count to the sum of all child records in the XML' do
+        expect(attrs[:intended_children_count]).to eq(9)
       end
     end
   end


### PR DESCRIPTION
There is a possibility that the creation of all of an `Asset`'s `Contribution`s could be skipped, which would significantly throw off the count for comparison.

It has been decided to ignore `Contribution`s entirely when it comes to validating `Asset`s for missing children, at least until `Contribution` creation is consistent. 