### PR TITLE
Block pushing assets to AAPB until their validation status is set

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -235,7 +235,9 @@ module Hyrax
           current_children_count = env.curation_concern.all_members.reject { |child| child.is_a?(Contribution) }.size
           intended_children_count = env.curation_concern.intended_children_count.to_i
 
-          if current_children_count < intended_children_count
+          if env.curation_concern.intended_children_count.nil? && env.curation_concern.validation_status_for_aapb.empty?
+            env.curation_concern.validation_status_for_aapb = [Asset::VALIDATION_STATUSES[:status_not_validated]]
+          elsif current_children_count < intended_children_count
             env.curation_concern.validation_status_for_aapb = [Asset::VALIDATION_STATUSES[:missing_children]]
           else
             env.curation_concern.validation_status_for_aapb = [Asset::VALIDATION_STATUSES[:valid]]

--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -235,7 +235,7 @@ module Hyrax
           current_children_count = env.curation_concern.all_members.reject { |child| child.is_a?(Contribution) }.size
           intended_children_count = env.curation_concern.intended_children_count.to_i
 
-          if env.curation_concern.intended_children_count.nil? && env.curation_concern.validation_status_for_aapb.empty?
+          if env.curation_concern.intended_children_count.blank? && env.curation_concern.validation_status_for_aapb.blank?
             env.curation_concern.validation_status_for_aapb = [Asset::VALIDATION_STATUSES[:status_not_validated]]
           elsif current_children_count < intended_children_count
             env.curation_concern.validation_status_for_aapb = [Asset::VALIDATION_STATUSES[:missing_children]]

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -10,7 +10,7 @@ class Asset < ActiveFedora::Base
     valid: 'valid',
     missing_children: 'missing child record(s)',
     status_not_validated: 'not yet validated',
-    empty: 'unable to validate'
+    empty: 'missing a validation status'
   }.freeze
 
   self.indexer = AssetIndexer

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -8,7 +8,9 @@ class Asset < ActiveFedora::Base
   # @see Push#add_status_error
   VALIDATION_STATUSES = {
     valid: 'valid',
-    missing_children: 'missing child record(s)'
+    missing_children: 'missing child record(s)',
+    status_not_validated: 'not yet validated',
+    empty: 'unable to validate'
   }.freeze
 
   self.indexer = AssetIndexer

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -34,11 +34,18 @@ class Push < ApplicationRecord
       end
       return if invalid_docs.blank?
 
-      add_status_error(invalid_docs, Asset::VALIDATION_STATUSES[:missing_children])
+      Asset::VALIDATION_STATUSES.each_pair do |status_key, status_value|
+        next if status_key == :valid
+        add_status_error(invalid_docs, status_value)
+      end
     end
 
     def add_status_error(invalid_docs, status)
-      ids_matching_status = invalid_docs.select { |doc| doc.validation_status_for_aapb.include?(status) }.map(&:id)
+      if status == Asset::VALIDATION_STATUSES[:empty]
+        ids_matching_status = invalid_docs.select { |doc| doc.validation_status_for_aapb.blank? }.map(&:id)
+      else
+       ids_matching_status = invalid_docs.select { |doc| doc.validation_status_for_aapb.include?(status) }.map(&:id)
+      end
       # Prevents adding errors to docs that don't have a value
       # in :validation_status_for_aapb, including all non-Assets.
       return if ids_matching_status.blank?

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -41,11 +41,12 @@ class Push < ApplicationRecord
     end
 
     def add_status_error(invalid_docs, status)
-      if status == Asset::VALIDATION_STATUSES[:empty]
-        ids_matching_status = invalid_docs.select { |doc| doc.validation_status_for_aapb.blank? }.map(&:id)
-      else
-       ids_matching_status = invalid_docs.select { |doc| doc.validation_status_for_aapb.include?(status) }.map(&:id)
-      end
+      ids_matching_status = if status == Asset::VALIDATION_STATUSES[:empty]
+                              invalid_docs.select { |doc| doc.validation_status_for_aapb.blank? }.map(&:id)
+                            else
+                              invalid_docs.select { |doc| doc.validation_status_for_aapb.include?(status) }.map(&:id)
+                            end
+
       # Prevents adding errors to docs that don't have a value
       # in :validation_status_for_aapb, including all non-Assets.
       return if ids_matching_status.blank?

--- a/spec/actors/hyrax/actors/asset_actor_spec.rb
+++ b/spec/actors/hyrax/actors/asset_actor_spec.rb
@@ -57,12 +57,12 @@ RSpec.describe Hyrax::Actors::AssetActor do
     context "when the asset's intended number of children is not set" do
       let(:intended_children_count) { nil }
 
-      it 'sets the status to "valid"' do
+      it 'sets the status to "not yet validated"' do
         expect(asset.validation_status_for_aapb).to be_empty
 
         middleware.public_send(method, env)
 
-        expect(asset.validation_status_for_aapb).to eq(['valid'])
+        expect(asset.validation_status_for_aapb).to eq(['not yet validated'])
       end
     end
   end

--- a/spec/controllers/pushes_controller_spec.rb
+++ b/spec/controllers/pushes_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PushesController, type: :controller do
   let!(:user) { create :admin_user }
 
   # Use a real memoized method to generate test assets once.
-  let!(:assets) { create_list :asset, rand(2..4) }
+  let!(:assets) { create_list :asset, rand(2..4), validation_status_for_aapb: [Asset::VALIDATION_STATUSES[:valid]] }
 
   # Ensure user is signed in before each test.
   before { sign_in(user) }

--- a/spec/features/pushes_spec.rb
+++ b/spec/features/pushes_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "Pushes features", type: :controller, js: true do
 
   # let it bang
   let!(:user) { create :admin_user }
-  let!(:asset) { create(:asset, user: user, program_title: ['foo']) }
-  let!(:asset2) { create(:asset, user: user, program_title: ['foo bar']) }
-  let!(:asset3) { create(:asset, user: user, needs_update: true) }
+  let!(:asset) { create(:asset, user: user, program_title: ['foo'], validation_status_for_aapb: [Asset::VALIDATION_STATUSES[:valid]]) }
+  let!(:asset2) { create(:asset, user: user, program_title: ['foo bar'], validation_status_for_aapb: [Asset::VALIDATION_STATUSES[:valid]]) }
+  let!(:asset3) { create(:asset, user: user, needs_update: true, validation_status_for_aapb: [Asset::VALIDATION_STATUSES[:valid]]) }
 
   # Login/logout before/after each test.
   before { login_as(user) }


### PR DESCRIPTION
- Set Asset.validation_status_for_aapb as part of asset_actor
- Do not allow asset to be pushable unless validation_status_for_aapb is valid.

Ref https://github.com/scientist-softserv/ams/issues/51

<details>
<summary> For non-asset id </summary>

![Screenshot 2023-08-09 at 6 10 07 PM](https://github.com/WGBH-MLA/ams/assets/17851674/f7d395de-3964-4391-b2d1-cdac0d5f2982)
</details>
<details>
<summary> For asset id not yet validated </summary>

![Screenshot 2023-08-09 at 6 20 00 PM](https://github.com/WGBH-MLA/ams/assets/17851674/1a188fc6-bf15-42a0-b701-cd27f5797703)
</details>
<details>
<summary> For asset id with empty validation status</summary>

![Screenshot 2023-08-09 at 6 38 06 PM](https://github.com/WGBH-MLA/ams/assets/17851674/7edc24e5-f76e-4dd8-80a9-da96523cf510)
</details>