### PR TITLE
✅ Get ".png" specs passing in Hyrax 4.0

### DIFF
--- a/app/services/aapb/work_thumbnail_path_service.rb
+++ b/app/services/aapb/work_thumbnail_path_service.rb
@@ -1,15 +1,14 @@
 module AAPB
   class WorkThumbnailPathService < Hyrax::WorkThumbnailPathService
-    class << self
-      class_attribute :object_type
-      def call(object)
-        self.object_type = object.class.name.underscore
-        super
-      end
+    class_attribute :object_type
 
-      def default_image
-        ActionController::Base.helpers.image_path "#{self.object_type}.png"
-      end
+    def self.call(object)
+      self.object_type = object.class.name.underscore
+      super(object)
+    end
+
+    def self.default_image
+      ActionController::Base.helpers.image_path "#{self.object_type}.png"
     end
   end
 end

--- a/app/services/hyrax/workflow/workflow_factory_decorator.rb
+++ b/app/services/hyrax/workflow/workflow_factory_decorator.rb
@@ -3,7 +3,7 @@ module Hyrax
     module WorkflowFactoryDecorator
       def create_workflow_entity!
         Sipity::Entity.find_or_create_by!(proxy_for_global_id: work.to_global_id.to_s) do |e|
-          e.workflow = work.active_workflow
+          e.workflow = App.rails_5_1? ? work.active_workflow : work.admin_set.active_workflow
           e.workflow_state = nil
         end
       end


### PR DESCRIPTION
This commit will refactor the `WorkThumbnailPathService` away from the `class << self` pattern to a more standard `def self.method_name` pattern because it seems to not work as expected in Rails 6.1.  This commit also fixes `Hyrax::Workflow::WorkflowFactoryDecorator` to use `work.admin_set.active_workflow` instead of `work.active_workflow` because in Hyrax 4.0 because Hyrax::InAdminSet mixin has been deprecated Instead #active_workflow is now a method on the AdminSet model.

Ref:
  - https://github.com/samvera/hyrax/commit/e3c0e5215e20690dbc1b27c36628dca983de53b5
  - https://github.com/scientist-softserv/ams/issues/65

### Failures
https://gist.github.com/kirkkwang/dc5c9c73b993be05e48ce2e048b45474

### Failure Details
https://gist.github.com/kirkkwang/a48c1140f950e3792da3354ac2e51a78