### PR TITLE
:gear: [i32] - resolve selenium error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -235,4 +235,4 @@ services:
     environment:
       - JAVA_OPTS=-Dwebdriver.chrome.whitelistedIps=
       - VIRTUAL_PORT=7900
-      - VIRTUAL_HOST=chrome.ams.test
+      - VIRTUAL_HOST=chrome.hyku.test

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,7 +41,9 @@ end
 
 ENV['WEB_HOST'] ||= `hostname -s`.strip
 if ENV['CHROME_HOSTNAME'].present?
+  # Uses faster rack_test driver when JavaScript support not needed
   Capybara.default_max_wait_time = 8
+  # Capybara.default_driver = :rack_test
 
   if App.rails_5_1?
     capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(


### PR DESCRIPTION
desired_capabilities is deprecated. This PR changes the way we initialize selenium driver per the newer requirements when dual booting. 

It also changes the docker-compose.yml file to allow devs to run feature specs locally. 

ref:
- https://github.com/SeleniumHQ/selenium/blob/trunk/rb/lib/selenium/webdriver/remote/driver.rb#L32

Issue:
- https://github.com/scientist-softserv/ams/issues/64

I confirmed that feature specs can run locally in rails 5 and 6. There are still failures in rails 6 but we'll handle that in a separate ticket. 

**rails_5_1?** 
```ruby
Finished in 4 minutes 12.4 seconds (files took 16.21 seconds to load)
54 examples, 0 failures, 18 pending
```
**rails 6**
```ruby
Finished in 2 minutes 47.8 seconds (files took 16.44 seconds to load)
54 examples, 21 failures, 18 pending
```

![Screen Recording 2023-08-11 at 10 02 33 AM](https://github.com/WGBH-MLA/ams/assets/10081604/7a040eeb-006a-4291-a351-36090901b00a)

