### PR TITLE
:gear: update fedora port so that devs can see fedora in the UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     expose:
       - 8080
     environment:
-      - VIRTUAL_PORT=8983
+      - VIRTUAL_PORT=8080
       - VIRTUAL_HOST=fcrepo.ams.test
       - JAVA_OPTIONS=-Dfcrepo.object.directory="/data/objects" -Dfcrepo.binary.directory="/data/binaries" -Dfcrepo.mysql.host=db -Dfcrepo.mysql.username=root -Dfcrepo.mysql.password=DatabaseFTW
       - MODESHAPE_CONFIG=classpath:/config/jdbc-mysql/repository.json


### PR DESCRIPTION
update the VIRTUAL_PORT of fcrepo so that devs can access fcrepo.ams.test. Before this we would get a gateway error. 

![image](https://github.com/WGBH-MLA/ams/assets/10081604/1b8f3335-2578-4fea-8905-d08892f0e2a7)
