### PR TITLE
Another batch of spec fixes

### DIFF
--- a/app/controllers/concerns/hyrax/child_work_redirect.rb
+++ b/app/controllers/concerns/hyrax/child_work_redirect.rb
@@ -7,7 +7,7 @@ module Hyrax::ChildWorkRedirect
         # Calling `#t` in a controller context does not mark _html keys as html_safe
         flash[:notice] = view_context.t('hyrax.works.create.after_create_html', application_name: view_context.application_name)
         if(params.has_key?(:child_work_create) && !params.fetch("child_work_create").blank? && curation_concern.valid_child_concerns.include?(params.fetch("child_work_create").constantize))
-          redirect_to polymorphic_path([main_app, :new, :hyrax, :parent, params.fetch("child_work_create").underscore], parent_id: curation_concern.id)
+          redirect_to polymorphic_path([main_app, :new, :hyrax, :parent, params.fetch("child_work_create").underscore.to_sym], parent_id: curation_concern.id)
         else
           redirect_to [main_app, curation_concern]
         end
@@ -25,7 +25,7 @@ module Hyrax::ChildWorkRedirect
       wants.html do
         flash[:notice] = "Work \"#{curation_concern}\" successfully updated."
         if(params.has_key?(:child_work_create) && !params.fetch("child_work_create").blank? && curation_concern.valid_child_concerns.include?(params.fetch("child_work_create").constantize))
-          redirect_to polymorphic_path([main_app, :new, :hyrax, :parent, params.fetch("child_work_create").underscore], parent_id: curation_concern.id)
+          redirect_to polymorphic_path([main_app, :new, :hyrax, :parent, params.fetch("child_work_create").underscore.to_sym], parent_id: curation_concern.id)
         else
           redirect_to [main_app, curation_concern]
         end

--- a/app/controllers/concerns/hyrax/child_work_redirect.rb
+++ b/app/controllers/concerns/hyrax/child_work_redirect.rb
@@ -7,7 +7,11 @@ module Hyrax::ChildWorkRedirect
         # Calling `#t` in a controller context does not mark _html keys as html_safe
         flash[:notice] = view_context.t('hyrax.works.create.after_create_html', application_name: view_context.application_name)
         if(params.has_key?(:child_work_create) && !params.fetch("child_work_create").blank? && curation_concern.valid_child_concerns.include?(params.fetch("child_work_create").constantize))
-          redirect_to polymorphic_path([main_app, :new, :hyrax, :parent, params.fetch("child_work_create").underscore.to_sym], parent_id: curation_concern.id)
+          if App.rails_5_1?
+            redirect_to polymorphic_path([main_app, :new, :hyrax, :parent, params.fetch("child_work_create").underscore], parent_id: curation_concern.id)
+          else
+            redirect_to polymorphic_path([main_app, :new, :hyrax, :parent, params.fetch("child_work_create").underscore.to_sym], parent_id: curation_concern.id)
+          end
         else
           redirect_to [main_app, curation_concern]
         end
@@ -25,7 +29,11 @@ module Hyrax::ChildWorkRedirect
       wants.html do
         flash[:notice] = "Work \"#{curation_concern}\" successfully updated."
         if(params.has_key?(:child_work_create) && !params.fetch("child_work_create").blank? && curation_concern.valid_child_concerns.include?(params.fetch("child_work_create").constantize))
-          redirect_to polymorphic_path([main_app, :new, :hyrax, :parent, params.fetch("child_work_create").underscore.to_sym], parent_id: curation_concern.id)
+          if App.rails_5_1?
+            redirect_to polymorphic_path([main_app, :new, :hyrax, :parent, params.fetch("child_work_create").underscore], parent_id: curation_concern.id)
+          else
+            redirect_to polymorphic_path([main_app, :new, :hyrax, :parent, params.fetch("child_work_create").underscore.to_sym], parent_id: curation_concern.id)
+          end
         else
           redirect_to [main_app, curation_concern]
         end

--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -66,7 +66,14 @@ module Hyrax
       end
 
       def query_solr
-        search_results(params)
+        if App.rails_5_1?
+          search_results(params)
+        else
+          Hyrax::SearchService.new(config: blacklight_config,
+                                   scope: self,
+                                   user_params: params,
+                                   search_builder_class: blacklight_config.search_builder_class).search_results
+        end
       end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,4 +42,14 @@ module ApplicationHelper
   def query_ids(query)
     query_docs(query).map(&:id)
   end
+
+  # passing in just a field_name has been deprecated in Blacklight 7.0
+  # we need to pass in a Blacklight::Configuration::Field object instead
+  def field_value_for(doc_presenter, field_name)
+    if App.rails_5_1?
+      doc_presenter.field_value(field_name)
+    else
+      doc_presenter.field_value(Blacklight::Configuration::Field.new(field: field_name))
+    end
+  end
 end

--- a/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
@@ -179,7 +179,12 @@ module AAPB
         # created. So we go ahead and just create it synchronously before hand
         # to avoid that issue.
         def sipity_agent
-          PowerConverter.convert_to_sipity_agent(submitter)
+          if App.rails_5_1?
+            # Hyrax 4.0.0 deprecated PowerConverter
+            PowerConverter.convert_to_sipity_agent(submitter)
+          else
+            Sipity.Agent(submitter)
+          end
         end
 
         # When running ingest methods concurrently in background jobs, we need

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -6,56 +6,112 @@
 # view will have to be updated to reflect those changes if so desired.
 %>
 
-<% doc_presenter = index_presenter(document) %>
+<% if App.rails_5_1? %>
+  <% doc_presenter = index_presenter(document) %>
 
-<% if field_value_for(doc_presenter, 'has_model_ssim') == 'Collection' %>
-  <div class="col-md-8">
-<% else %>
-  <div class="col-md-10">
-<% end %>
-    <div class="metadata">
-      <div class="row">
-      <% if !document.display_dates.empty? %>
-        <div class="col-md-12 metadata-col">
-          <% index_fields(document).select{ |k,v| document.display_dates.has_key?(k) }.each do |field_name, field| %>
-            <% if should_render_index_field? document, field %>
-              <h4><%= render_index_field_label document, field: field_name %></h4> <%= field_value_for(doc_presenter, field_name) %>
+  <% if(doc_presenter.field_value('has_model_ssim') == 'Collection') %>
+    <div class="col-md-8">
+  <% else %>
+    <div class="col-md-10">
+  <% end %>
+      <div class="metadata">
+        <div class="row">
+        <% if !document.display_dates.empty? %>
+          <div class="col-md-12 metadata-col">
+            <% index_fields(document).select{ |k,v| document.display_dates.has_key?(k) }.each do |field_name, field| %>
+              <% if should_render_index_field? document, field %>
+                <h4><%= render_index_field_label document, field: field_name %></h4> <%= doc_presenter.field_value field_name %>
+              <% end %>
             <% end %>
-          <% end %>
-        </div>
-      <% end %>
+          </div>
+        <% end %>
 
-      <% if !document.identifying_data.empty? %>
-        <div class="col-md-12 metadata-col">
-          <% index_fields(document).select{ |k,v| document.identifying_data.has_key?(k) }.each do |field_name, field| %>
-            <% if should_render_index_field? document, field %>
-              <h4><%= render_index_field_label document, field: field_name %></h4> <%= field_value_for(doc_presenter, field_name) %>
+        <% if !document.identifying_data.empty? %>
+          <div class="col-md-12 metadata-col">
+            <% index_fields(document).select{ |k,v| document.identifying_data.has_key?(k) }.each do |field_name, field| %>
+              <% if should_render_index_field? document, field %>
+                <h4><%= render_index_field_label document, field: field_name %></h4> <%= doc_presenter.field_value field_name %>
+              <% end %>
             <% end %>
-          <% end %>
-        </div>
-      <% end %>
+          </div>
+        <% end %>
 
-      <% if document.display_description.present? %>
-        <% index_fields(document).select{ |k,v| k == "description" }.each do |field_name, field| %>
-          <% if should_render_index_field? document, field %>
-            <div class="col-md-12 metadata-desc-col">
-              <p><strong>Description:</strong> <%= field_value_for(doc_presenter, field_name) %></p>
-            </div>
+        <% if document.display_description.present? %>
+          <% index_fields(document).select{ |k,v| k == "description" }.each do |field_name, field| %>
+            <% if should_render_index_field? document, field %>
+              <div class="col-md-12 metadata-desc-col">
+                <p><strong>Description:</strong> <%= doc_presenter.field_value field_name %></p>
+              </div>
+            <% end %>
           <% end %>
         <% end %>
-      <% end %>
-    </div>
-  </div>
-<% if(field_value_for(doc_presenter, 'has_model_ssim') == 'Collection') %>
-  <% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
-  <div class="col-md-4">
-    <div class="collection-counts-wrapper">
-      <div class="collection-counts-item">
-        <span><%= collection_presenter.total_viewable_collections %></span>Collections
-      </div>
-      <div class="collection-counts-item">
-        <span><%= collection_presenter.total_viewable_works %></span>Works
       </div>
     </div>
-  </div>
+  <% if(doc_presenter.field_value('has_model_ssim') == 'Collection') %>
+    <% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
+    <div class="col-md-4">
+      <div class="collection-counts-wrapper">
+        <div class="collection-counts-item">
+          <span><%= collection_presenter.total_viewable_collections %></span>Collections
+        </div>
+        <div class="collection-counts-item">
+          <span><%= collection_presenter.total_viewable_works %></span>Works
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <% doc_presenter = index_presenter(document) %>
+
+  <% if field_value_for(doc_presenter, 'has_model_ssim') == 'Collection' %>
+    <div class="col-md-8">
+  <% else %>
+    <div class="col-md-10">
+  <% end %>
+      <div class="metadata">
+        <div class="row">
+        <% if !document.display_dates.empty? %>
+          <div class="col-md-12 metadata-col">
+            <% index_fields(document).select{ |k,v| document.display_dates.has_key?(k) }.each do |field_name, field| %>
+              <% if should_render_index_field? document, field %>
+                <h4><%= render_index_field_label document, field: field_name %></h4> <%= field_value_for(doc_presenter, field_name) %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if !document.identifying_data.empty? %>
+          <div class="col-md-12 metadata-col">
+            <% index_fields(document).select{ |k,v| document.identifying_data.has_key?(k) }.each do |field_name, field| %>
+              <% if should_render_index_field? document, field %>
+                <h4><%= render_index_field_label document, field: field_name %></h4> <%= field_value_for(doc_presenter, field_name) %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if document.display_description.present? %>
+          <% index_fields(document).select{ |k,v| k == "description" }.each do |field_name, field| %>
+            <% if should_render_index_field? document, field %>
+              <div class="col-md-12 metadata-desc-col">
+                <p><strong>Description:</strong> <%= field_value_for(doc_presenter, field_name) %></p>
+              </div>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  <% if(field_value_for(doc_presenter, 'has_model_ssim') == 'Collection') %>
+    <% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
+    <div class="col-md-4">
+      <div class="collection-counts-wrapper">
+        <div class="collection-counts-item">
+          <span><%= collection_presenter.total_viewable_collections %></span>Collections
+        </div>
+        <div class="collection-counts-item">
+          <span><%= collection_presenter.total_viewable_works %></span>Works
+        </div>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -8,7 +8,7 @@
 
 <% doc_presenter = index_presenter(document) %>
 
-<% if(doc_presenter.field_value('has_model_ssim') == 'Collection') %>
+<% if field_value_for(doc_presenter, 'has_model_ssim') == 'Collection' %>
   <div class="col-md-8">
 <% else %>
   <div class="col-md-10">
@@ -19,7 +19,7 @@
         <div class="col-md-12 metadata-col">
           <% index_fields(document).select{ |k,v| document.display_dates.has_key?(k) }.each do |field_name, field| %>
             <% if should_render_index_field? document, field %>
-              <h4><%= render_index_field_label document, field: field_name %></h4> <%= doc_presenter.field_value field_name %>
+              <h4><%= render_index_field_label document, field: field_name %></h4> <%= field_value_for(doc_presenter, field_name) %>
             <% end %>
           <% end %>
         </div>
@@ -29,7 +29,7 @@
         <div class="col-md-12 metadata-col">
           <% index_fields(document).select{ |k,v| document.identifying_data.has_key?(k) }.each do |field_name, field| %>
             <% if should_render_index_field? document, field %>
-              <h4><%= render_index_field_label document, field: field_name %></h4> <%= doc_presenter.field_value field_name %>
+              <h4><%= render_index_field_label document, field: field_name %></h4> <%= field_value_for(doc_presenter, field_name) %>
             <% end %>
           <% end %>
         </div>
@@ -39,14 +39,14 @@
         <% index_fields(document).select{ |k,v| k == "description" }.each do |field_name, field| %>
           <% if should_render_index_field? document, field %>
             <div class="col-md-12 metadata-desc-col">
-              <p><strong>Description:</strong> <%= doc_presenter.field_value field_name %></p>
+              <p><strong>Description:</strong> <%= field_value_for(doc_presenter, field_name) %></p>
             </div>
           <% end %>
         <% end %>
       <% end %>
     </div>
   </div>
-<% if(doc_presenter.field_value('has_model_ssim') == 'Collection') %>
+<% if(field_value_for(doc_presenter, 'has_model_ssim') == 'Collection') %>
   <% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
   <div class="col-md-4">
     <div class="collection-counts-wrapper">

--- a/app/views/hyrax/assets/_show_actions.html.erb
+++ b/app/views/hyrax/assets/_show_actions.html.erb
@@ -31,7 +31,11 @@
             <ul class="dropdown-menu">
               <% presenter.valid_child_concerns.each do |concern| %>
                 <li>
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+                  <% if App.rails_5_1? %>
+                    <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                  <% else %>
+                    <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+                  <% end %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/hyrax/assets/_show_actions.html.erb
+++ b/app/views/hyrax/assets/_show_actions.html.erb
@@ -20,7 +20,7 @@
       <% if can? :destroy, Asset %>
         <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
       <% end %>
-      
+
       <% if presenter.media_available? %>
         <%= link_to "Download Media", "/concern/assets/#{presenter.id}/download_media.zip", class: 'btn btn-default' %>
       <% end %>
@@ -31,7 +31,7 @@
             <ul class="dropdown-menu">
               <% presenter.valid_child_concerns.each do |concern| %>
                 <li>
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/hyrax/digital_instantiations/_show_actions.html.erb
+++ b/app/views/hyrax/digital_instantiations/_show_actions.html.erb
@@ -17,11 +17,11 @@
   <% if presenter.editor? %>
 
       <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
-      
+
       <% if can? :destroy, DigitalInstantiation %>
         <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
       <% end %>
-      
+
       <% if presenter.valid_child_concerns.length > 0 %>
         <div class="btn-group">
           <button type="button" class="btn btn-default dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -29,7 +29,7 @@
             <ul class="dropdown-menu">
               <% presenter.valid_child_concerns.each do |concern| %>
                 <li>
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/hyrax/digital_instantiations/_show_actions.html.erb
+++ b/app/views/hyrax/digital_instantiations/_show_actions.html.erb
@@ -29,7 +29,11 @@
             <ul class="dropdown-menu">
               <% presenter.valid_child_concerns.each do |concern| %>
                 <li>
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+                  <% if App.rails_5_1? %>
+                    <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                  <% else %>
+                    <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+                  <% end %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/hyrax/essence_tracks/_show_actions.html.erb
+++ b/app/views/hyrax/essence_tracks/_show_actions.html.erb
@@ -16,11 +16,11 @@
   <% end %>
   <% if presenter.editor? %>
       <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
-      
+
       <% if can? :destroy, EssenceTrack %>
         <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
       <% end %>
-      
+
       <% if presenter.valid_child_concerns.length > 0 %>
         <div class="btn-group">
           <button type="button" class="btn btn-default dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -28,7 +28,7 @@
             <ul class="dropdown-menu">
               <% presenter.valid_child_concerns.each do |concern| %>
                 <li>
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/hyrax/essence_tracks/_show_actions.html.erb
+++ b/app/views/hyrax/essence_tracks/_show_actions.html.erb
@@ -28,7 +28,11 @@
             <ul class="dropdown-menu">
               <% presenter.valid_child_concerns.each do |concern| %>
                 <li>
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+                  <% if App.rails_5_1? %>
+                    <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                  <% else %>
+                    <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+                  <% end %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/hyrax/physical_instantiations/_show_actions.html.erb
+++ b/app/views/hyrax/physical_instantiations/_show_actions.html.erb
@@ -17,7 +17,7 @@
   <% if presenter.editor? %>
 
       <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
-      
+
       <% if can? :destroy, PhysicalInstantiation %>
         <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
       <% end %>
@@ -29,7 +29,7 @@
             <ul class="dropdown-menu">
               <% presenter.valid_child_concerns.each do |concern| %>
                 <li>
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/hyrax/physical_instantiations/_show_actions.html.erb
+++ b/app/views/hyrax/physical_instantiations/_show_actions.html.erb
@@ -29,7 +29,11 @@
             <ul class="dropdown-menu">
               <% presenter.valid_child_concerns.each do |concern| %>
                 <li>
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+                  <% if App.rails_5_1? %>
+                    <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                  <% else %>
+                    <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+                  <% end %>
                 </li>
               <% end %>
             </ul>

--- a/spec/features/batch_ingest/aapb_pbcore_zipped_spec.rb
+++ b/spec/features/batch_ingest/aapb_pbcore_zipped_spec.rb
@@ -5,96 +5,95 @@ require 'aapb/batch_ingest'
 RSpec.feature "Ingest: AAPB PBCore - Zipped" do
 
   context 'where batch contains valid Assets (no children)', reset_data: false do
-    if App.rails_5_1?
-      before :all do
-        # Build a list of PBCore Description Documents, keeping it pretty small to
-        # avoid long ingest times.
-        @pbcore_description_documents = build_list(:pbcore_description_document, rand(2..4), :full_aapb)
-        @pbcore_description_documents.each do |pbcore_description_document|
-          pbcore_description_document.instantiations = [
-            # Add 1-3 Digital Instantiations
-            build_list(:pbcore_instantiation, rand(1..3), :digital),
-            # Add 1 Physical Instantiation
-            build(:pbcore_instantiation, :physical)
-          ].flatten
 
-          # Add 1-3 Essence Tracks for each instantiation
-          pbcore_description_document.instantiations.each do |instantiation|
-            instantiation.essence_tracks = build_list(:pbcore_instantiation_essence_track, rand(1..3))
-          end
-        end
+    before :all do
+      # Build a list of PBCore Description Documents, keeping it pretty small to
+      # avoid long ingest times.
+      @pbcore_description_documents = build_list(:pbcore_description_document, rand(2..4), :full_aapb)
+      @pbcore_description_documents.each do |pbcore_description_document|
+        pbcore_description_document.instantiations = [
+          # Add 1-3 Digital Instantiations
+          build_list(:pbcore_instantiation, rand(1..3), :digital),
+          # Add 1 Physical Instantiation
+          build(:pbcore_instantiation, :physical)
+        ].flatten
 
-        zipped_batch = make_aapb_pbcore_zipped_batch(@pbcore_description_documents)
-
-        user, admin_set = create_user_and_admin_set_for_deposit
-        @batch = run_batch_ingest(ingest_file_path: zipped_batch,
-                                  ingest_type: 'aapb_pbcore_zipped',
-                                  admin_set: admin_set,
-                                  submitter: user)
-
-        # Reload the batch so all the child BatchItems are populated.
-        @batch.reload
-
-        # Grab the ingested objects from the BatchItem's #repo_object_id values.
-        # We store in an instance var to use it more than once between tests.
-        # We rescue from any ObjectNotFound error to mystery errors in the before
-        # hook; we would rather have failed tests.
-        @ingested_objects = @batch.batch_items.map do |batch_item|
-          ActiveFedora::Base.find(batch_item.repo_object_id.to_s)
-        rescue ActiveFedora::ObjectNotFoundError
-          nil
-        end.compact
-
-      end
-
-      let(:expected_batch_item_count) do
-        instantiations = @pbcore_description_documents.map(&:instantiations).flatten
-        physical_instantiations = instantiations.select { |i| i.physical }
-        physical_instantiation_essence_tracks = physical_instantiations.map(&:essence_tracks).flatten
-        # The expected number of batch items is the  number of Assets, the number
-        # of Instantiations, and the number of  Essence Tracks from Physical
-        # Instantiations only. A little odd, but this is just how the ingest works
-        # right now.
-        @pbcore_description_documents.count \
-          + instantiations.count \
-          + physical_instantiation_essence_tracks.count
-      end
-
-      it 'creates the correct number of batch item records' do
-        expect(@batch.batch_items.to_a.count).to eq expected_batch_item_count
-      end
-
-      it 'ingests the correct number of objects' do
-        expect(@ingested_objects.count).to eq expected_batch_item_count
-      end
-
-      it 'creates additional BatchItem records that all share the same `id_within_batch` value' do
-        batch_items_by_repo_object_id = @batch.batch_items.index_by(&:repo_object_id)
-        ingested_objects_by_id = @ingested_objects.index_by(&:id)
-        batch_items_by_repo_object_id.each do |repo_object_id, batch_item|
-          # There should be at most 1 parent work ID; assets won't have one.
-          parent_work_id = ingested_objects_by_id[repo_object_id].parent_work_ids.first
-          if parent_work_id
-            parent_batch_item = batch_items_by_repo_object_id[parent_work_id]
-            expect(batch_item.id_within_batch).to eq parent_batch_item.id_within_batch
-          end
+        # Add 1-3 Essence Tracks for each instantiation
+        pbcore_description_document.instantiations.each do |instantiation|
+          instantiation.essence_tracks = build_list(:pbcore_instantiation_essence_track, rand(1..3))
         end
       end
 
-      it 'has a status of completed' do
-        expect(@batch.status).to eq "completed"
-      end
+      zipped_batch = make_aapb_pbcore_zipped_batch(@pbcore_description_documents)
 
-      it 'has no errors for any batch item' do
-        expect(@batch.batch_items.map(&:error)).to all(be_nil)
-      end
+      user, admin_set = create_user_and_admin_set_for_deposit
+      @batch = run_batch_ingest(ingest_file_path: zipped_batch,
+                                ingest_type: 'aapb_pbcore_zipped',
+                                admin_set: admin_set,
+                                submitter: user)
 
-      it 'has status of "completed" for each batch item' do
-        expect(@batch.batch_items.map(&:status)).to all( eq 'completed' )
+      # Reload the batch so all the child BatchItems are populated.
+      @batch.reload
+
+      # Grab the ingested objects from the BatchItem's #repo_object_id values.
+      # We store in an instance var to use it more than once between tests.
+      # We rescue from any ObjectNotFound error to mystery errors in the before
+      # hook; we would rather have failed tests.
+      @ingested_objects = @batch.batch_items.map do |batch_item|
+        ActiveFedora::Base.find(batch_item.repo_object_id.to_s)
+      rescue ActiveFedora::ObjectNotFoundError
+        nil
+      end.compact
+
+    end
+
+    let(:expected_batch_item_count) do
+      instantiations = @pbcore_description_documents.map(&:instantiations).flatten
+      physical_instantiations = instantiations.select { |i| i.physical }
+      physical_instantiation_essence_tracks = physical_instantiations.map(&:essence_tracks).flatten
+      # The expected number of batch items is the  number of Assets, the number
+      # of Instantiations, and the number of  Essence Tracks from Physical
+      # Instantiations only. A little odd, but this is just how the ingest works
+      # right now.
+      @pbcore_description_documents.count \
+        + instantiations.count \
+        + physical_instantiation_essence_tracks.count
+    end
+
+    it 'creates the correct number of batch item records' do
+      expect(@batch.batch_items.to_a.count).to eq expected_batch_item_count
+    end
+
+    it 'ingests the correct number of objects' do
+      expect(@ingested_objects.count).to eq expected_batch_item_count
+    end
+
+    it 'creates additional BatchItem records that all share the same `id_within_batch` value' do
+      batch_items_by_repo_object_id = @batch.batch_items.index_by(&:repo_object_id)
+      ingested_objects_by_id = @ingested_objects.index_by(&:id)
+      batch_items_by_repo_object_id.each do |repo_object_id, batch_item|
+        # There should be at most 1 parent work ID; assets won't have one.
+        parent_work_id = ingested_objects_by_id[repo_object_id].parent_work_ids.first
+        if parent_work_id
+          parent_batch_item = batch_items_by_repo_object_id[parent_work_id]
+          expect(batch_item.id_within_batch).to eq parent_batch_item.id_within_batch
+        end
       end
-    # TODO: Tests for invalid Assets.
-    else
-      skip 'Until we decide if we keep Hyrax::BatchIngest, see: https://github.com/scientist-softserv/ams/issues/58'
+    end
+
+    it 'has a status of completed' do
+      expect(@batch.status).to eq "completed"
+    end
+
+    it 'has no errors for any batch item' do
+      expect(@batch.batch_items.map(&:error)).to all(be_nil)
+    end
+
+    it 'has status of "completed" for each batch item' do
+      expect(@batch.batch_items.map(&:status)).to all( eq 'completed' )
     end
   end
+
+  # TODO: Tests for invalid Assets.
+
 end


### PR DESCRIPTION
This PR will fix another set of specs from the Rails 6.1/Hyrax 4/Blacklight 7 upgrade.  This will bring the failing spec count down from 26 to 10.

ref: https://github.com/scientist-softserv/ams/issues/67

<details><summary>Remaining Failures</summary>

```rb
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Hyrax::EssenceTrackPresenter has tests
     # Add your tests here
     # ./spec/presenters/hyrax/essence_track_presenter_spec.rb:6

  2) FileSet has tests
     # Add your tests here
     # ./spec/models/file_set_spec.rb:4

  3) Bulkrax::CsvEntry exporting by Asset worktype writes the csv file with the asset and its children in a single row
     # Temporarily skipped with xit
     # ./spec/models/bulkrax/csv_entry_spec.rb:195

  4) Qa::LocalAuthority add some examples to (or delete) /app/samvera/hyrax-webapp/spec/models/qa/local_authority_spec.rb
     # Not yet implemented
     # ./spec/models/qa/local_authority_spec.rb:4

  5) Hyrax::EssenceTracksController has tests
     # Add your tests here
     # ./spec/controllers/hyrax/essence_tracks_controller_spec.rb:6

  6) Hyrax::AssetForm has tests
     # Add your tests here
     # ./spec/forms/hyrax/asset_form_spec.rb:6

  7) Hyrax::AssetsController has tests
     # Add your tests here
     # ./spec/controllers/hyrax/assets_controller_spec.rb:6

  8) Hyrax::Actors::PhysicalInstantiationActor has tests
     # Add your tests here
     # ./spec/actors/hyrax/actors/physical_instantiation_actor_spec.rb:6

  9) Search by dates Range * TO YYYY-MM returns all assets with a date on or before the last day of the specified year and month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:110

  10) Search by dates Range YYYY-MM TO YYYY returns all assets with a date on or after the first day of the earlier year/month, and on or before the last day of the later year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:154

  11) Search by dates Range * TO YYYY-MM-DD returns all assets with a date on or before the last day of the specified year and month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:118

  12) Search by dates Range YYYY-MM TO YYYY-MM returns all assets with a date on or after the first day of the earlier year/month, and on or before the last day of the later year/month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:167

  13) Search by dates Range * TO YYYY returns all assets with a date on or before the last day of the specified year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:101

  14) Search by dates Range YYYY TO YYYY-MM-DD returns all assets with a date on or after the first day of the earlier year, and on or before the last year/month/day
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:145

  15) Search by dates Range YYYY TO YYYY returns all assets with a date on or after the first day of the earlier year, and on or before the last day of the later year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:125

  16) Search by dates Range YYYY-MM-DD TO YYYY-MM returns all assets with a date on or after the first year/month/day and on or before the last day of the later year/month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:203

  17) Search by dates Range YYYY-MM-DD TO YYYY-MM-DD returns all assets with a date on or after the first year/month/day and on or before the later year/month/day
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:214

  18) Search by dates Range YYYY-MM-DD TO YYYY returns all assets with a date on or after the first year/month/day and on or before the last day of the later year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:191

  19) Search by dates with exact YYYY returns all assets with at least one date within that year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:53

  20) Search by dates Range YYYY-MM TO YYYY-MM-DD returns all assets with a date on or after the first day of the earlier year/month, and on or before the later year/month/day
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:180

  21) Search by dates Exact YYYY-MM-DD returns all assets with a date on that exact day
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:70

  22) Search by dates Range YYYY TO * returns all assets with a date after the first day of the specified year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:77

  23) Search by dates with exact YYYY-MM returns all assets with at least one date for that year and month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:62

  24) Search by dates Range YYYY-MM TO * returns all assets with a date after the first of the specified year and month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:86

  25) Search by dates Range YYYY TO YYYY-MM returns all assets with a date on or after the first day of the earlier year, and on or before the last day of the later year/month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:135

  26) Search by dates Range YYYY-MM-DD TO * returns all assets with a date after the first of the specified year and month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:94

  27) Hyrax::DigitalInstantiationForm has tests
     # Add your tests here
     # ./spec/forms/hyrax/digital_instantiation_form_spec.rb:6

  28) Hyrax::DigitalInstantiationsController has tests
     # Add your tests here
     # ./spec/controllers/hyrax/digital_instantiations_controller_spec.rb:6

  29) Hyrax::Actors::EssenceTrackActor has tests
     # Add your tests here
     # ./spec/actors/hyrax/actors/essence_track_actor_spec.rb:6

  30) Hyrax::PhysicalInstantiationsController has tests
     # Add your tests here
     # ./spec/controllers/hyrax/physical_instantiations_controller_spec.rb:6

  31) Hyrax::DigitalInstantiationPresenter has tests
     # Add your tests here
     # ./spec/presenters/hyrax/digital_instantiation_presenter_spec.rb:6

  32) Qa::LocalAuthorityEntry add some examples to (or delete) /app/samvera/hyrax-webapp/spec/models/qa/local_authority_entry_spec.rb
     # Not yet implemented
     # ./spec/models/qa/local_authority_entry_spec.rb:4

  33) Hyrax::PhysicalInstantiationPresenter has tests
     # Add your tests here
     # ./spec/presenters/hyrax/physical_instantiation_presenter_spec.rb:6

  34) Hyrax::EssenceTrackForm has tests
     # Add your tests here
     # ./spec/forms/hyrax/essence_track_form_spec.rb:6

  35) Hyrax::Actors::DigitalInstantiationActor has tests
     # Add your tests here
     # ./spec/actors/hyrax/actors/digital_instantiation_actor_spec.rb:6

  36) Collection has tests
     # Add your tests here
     # ./spec/models/collection_spec.rb:4

  37) Hyrax::PhysicalInstantiationForm has tests
     # Add your tests here
     # ./spec/forms/hyrax/physical_instantiation_form_spec.rb:6

  38) InstantiationAdminData add some examples to (or delete) /app/samvera/hyrax-webapp/spec/models/instantiation_admin_data_spec.rb
     # Not yet implemented
     # ./spec/models/instantiation_admin_data_spec.rb:4


Failures:

  1) Pushes features #pushes gets the correct record set when navigating from a catalog search
     Failure/Error: click_link('Push To AAPB', class: 'aapb-push-button')

     Capybara::ElementNotFound:
       Unable to find link "Push To AAPB" with classes [aapb-push-button]
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:312:in `block in synced_resolve'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/base.rb:84:in `synchronize'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:301:in `synced_resolve'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:60:in `find'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/actions.rb:42:in `click_link'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/session.rb:773:in `click_link'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `call'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `click_link'
     # ./spec/features/pushes_spec.rb:48:in `block (3 levels) in <top (required)>'

  2) Create Asset with Asset Type Create adminset, create asset Create Asset with Asset Type
     Failure/Error: find('button.multiselect').click

     Capybara::ElementNotFound:
       Unable to find css "button.multiselect" within #<Capybara::Node::Element tag="div" path="/HTML/BODY[1]/DIV[2]/DIV[2]/FORM[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[2]/DIV[2]/DIV[2]/DIV[1]/DIV[1]">
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:312:in `block in synced_resolve'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/base.rb:84:in `synchronize'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:301:in `synced_resolve'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:60:in `find'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/session.rb:773:in `find'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `call'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `find'
     # ./spec/features/create_asset_with_genre_vocabulary_spec.rb:60:in `block (4 levels) in <top (required)>'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/session.rb:365:in `within'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `call'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `within_element'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/rspec/matcher_proxies.rb:15:in `within'
     # ./spec/features/create_asset_with_genre_vocabulary_spec.rb:59:in `block (3 levels) in <top (required)>'

  3) Create and Validate Asset Create adminset, create asset Create and Validate Asset, Search asset
     Failure/Error: expect(page).to have_content asset_attributes[:spatial_coverage]
       expected to find text "My Test Spatial coverage" in "AMS\nAMS\nSwitch language\nEnglish\nView\n user34@example.com\nprofile\nHome\nAbout\nHelp\nContact\nSearch in\nAll Fields\nTitles (All)\nSeries Title\nDescriptions (All)\nContributor\nCreator\nTitle\nAbstract or Summary\nPublisher\nDate Created\nSubject\nLanguage\nResource Type\nInstantiation Format\nLocal Id\nDepositor\nRights Statement\nLicense\nBroadcast\nCreated\nDate\nCopyright Date\nSpatial Coverage\nTemporal Coverage\nAudience Level\nAudience Rating\nRights Summary\nPbs Nola Code\nEidr\nLocal Instantiation Identifier\nPortrayal\nsearch for\nGo\nAll\nAll\nMore options\nHomeDashboardWorksTest Series Title 2; Test...\nAsset\n  Test Series Title 2; Test Series Title 11; Test Program Title 3; Test Program Title 12; Test Episode Number Title 14; Test Episode Number Title 5; Test Episode Title 13; Test Episode Title 4; Test Segment Title 15; Test Segment Title 6; Test Clip Title 9; Test Clip Title 18; Test Promo Title 17; Test Promo Title 8; Test Raw Footage Title 16; Test Raw Footage Title 7; Test Title 10; Test Title 1 Public Deposited\nEdit\nAttach Child\n\n\n\n\nNot playable: unrecognized media type: \"\".\nAsset Details\nCredits\nInstantiations\nThis Asset has no files associated with it. Click \"edit\" to add more files.\nIn Administrative Set:\nDefault Admin Set\nA service of Samvera.\nAMS v4.0.0\nCopyright © 2018 Samvera Licensed under the Apache License, Version 2.0". (However, it was found 1 time including non-visible text.)
     # ./spec/features/create_asset_spec.rb:148:in `block (3 levels) in <top (required)>'

  4) AdminAddUserroleAsAdminsetManager. As Admin add a UserRole as Adminset Manager Assign set of user (role) as Manager to AdminSet
     Failure/Error: expect(page).to have_content admin_set.title[0]
       expected to find text "Title 3" in "AMS\nAMS\nSwitch language\nEnglish\nView\n admin17@example.com\nprofile\nadmin17@example.com\nDashboard\nACTIVITY\nYour activity\nStatistics\nREPOSITORY CONTENTS\nCollections\nWorks\nImporters\nExporters\nTASKS\nReview Submissions\nManage Users\nManage Embargoes\nManage Leases\nCONFIGURATION\nSettings\nManage Users\nManage Role\nWorkflow Roles\nHomeDashboardCollections\nCollections\nAll Collections\nYour Collections\nAdd New Collection\n0 collections you own in the repository\nCollections listing\nFilter collections:\nSearch AMS\nGo\nListing of items you have deposited in AMS\nSelect all files to be added to a collection or edited\nSelect\nSelect to access selection option\nTitle Type Last modified Items Visibility of Collection Actions"
     # ./spec/features/admin_add_userrole_as_adminset_manager_spec.rb:19:in `block (3 levels) in <top (required)>'

  5) Create and Validate Asset,Digital Instantiation, EssenseTrack Create adminset, create asset, import pbcore xml for digital instantiation and essensetrack Create and Validate Asset, Search asset
     Failure/Error: find('button.multiselect').click

     Capybara::ElementNotFound:
       Unable to find css "button.multiselect" within #<Capybara::Node::Element tag="div" path="/HTML/BODY[1]/DIV[2]/DIV[2]/FORM[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[2]/DIV[3]/DIV[2]/DIV[1]/DIV[2]">
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:312:in `block in synced_resolve'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/base.rb:84:in `synchronize'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:301:in `synced_resolve'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:60:in `find'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/session.rb:773:in `find'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `call'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `find'
     # ./spec/features/create_asset_with_digitalinstantiation_spec.rb:137:in `block (4 levels) in <top (required)>'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/session.rb:365:in `within'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `call'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `within_element'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/rspec/matcher_proxies.rb:15:in `within'
     # ./spec/features/create_asset_with_digitalinstantiation_spec.rb:136:in `block (3 levels) in <top (required)>'

  6) Create Asset with Asset Type Create adminset, create asset Create Asset with Asset Type
     Failure/Error: find('button.multiselect').click

     Capybara::ElementNotFound:
       Unable to find css "button.multiselect" within #<Capybara::Node::Element tag="div" path="/HTML/BODY[1]/DIV[2]/DIV[2]/FORM[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[2]/DIV[1]/DIV[2]/DIV[1]/DIV[6]">
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:312:in `block in synced_resolve'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/base.rb:84:in `synchronize'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:301:in `synced_resolve'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/node/finders.rb:60:in `find'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/session.rb:773:in `find'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `call'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `find'
     # ./spec/features/create_asset_with_asset_types_vocabulary_spec.rb:58:in `block (4 levels) in <top (required)>'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/session.rb:365:in `within'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `call'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `within_element'
     # /usr/local/bundle/gems/capybara-3.39.2/lib/capybara/rspec/matcher_proxies.rb:15:in `within'
     # ./spec/features/create_asset_with_asset_types_vocabulary_spec.rb:57:in `block (3 levels) in <top (required)>'

  7) AssignMultipleRolesAsManager. Add Manager permissions to user (Role) Assign set of user (role) as Manager to multiple AdminSet
     Failure/Error: expect(page).to have_content 'You are not authorized to access this page.'
       expected to find text "You are not authorized to access this page." in "AMS\nAMS\nSwitch language\nEnglish\nView\n user252@example.com\nprofile\nuser252@example.com\nDashboard\nACTIVITY\nYour activity\nREPOSITORY CONTENTS\nCollections\nWorks\nImporters\nExporters\nHomeDashboardCollections\nCollections\n0 collections you own in the repository\nCollections listing\nFilter collections:\nSearch AMS\nGo\nListing of items you have deposited in AMS\nSelect all files to be added to a collection or edited\nSelect\nSelect to access selection option\nTitle Type Last modified Items Visibility of Collection Actions"
     # ./spec/features/admin/admin_sets/add_multiple_userrole_as_manager_spec.rb:62:in `block (3 levels) in <top (required)>'

  8) PushesController GET /pushes/index assigns @pushes to all Push model instances
     Failure/Error: before { get :index }

     NoMethodError:
       undefined method `formats' for #<ActionView::Template app/views/pushes/index.html.erb locals=[]>
       Did you mean?  format
     # /usr/local/bundle/gems/react-rails-2.7.1/lib/react/rails/controller_lifecycle.rb:31:in `use_react_component_helper'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/template_assertions.rb:62:in `process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `block in process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `catch'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `_catch_warden'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `process'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/integration.rb:16:in `block (2 levels) in <module:Integration>'
     # ./spec/controllers/pushes_controller_spec.rb:16:in `block (3 levels) in <top (required)>'

  9) PushesController GET /pushes/:id assign @push to the Push instance for the ID given
     Failure/Error: before { get :show, params: { id: push.id } }

     NoMethodError:
       undefined method `formats' for #<ActionView::Template app/views/pushes/show.html.erb locals=[]>
       Did you mean?  format
     # /usr/local/bundle/gems/react-rails-2.7.1/lib/react/rails/controller_lifecycle.rb:31:in `use_react_component_helper'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/template_assertions.rb:62:in `process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `block in process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `catch'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `_catch_warden'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `process'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/integration.rb:16:in `block (2 levels) in <module:Integration>'
     # ./spec/controllers/pushes_controller_spec.rb:24:in `block (3 levels) in <top (required)>'

  10) Admin::UsersController GET #new returns a success response
      Failure/Error: get :new

      NoMethodError:
        undefined method `formats' for #<ActionView::Template:0x0000ffff370b8830>
        Did you mean?  format
      # /usr/local/bundle/gems/react-rails-2.7.1/lib/react/rails/controller_lifecycle.rb:31:in `use_react_component_helper'
      # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/template_assertions.rb:62:in `process'
      # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `block in process'
      # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `catch'
      # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `_catch_warden'
      # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `process'
      # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/integration.rb:16:in `block (2 levels) in <module:Integration>'
      # ./spec/controllers/admin/users_controller_spec.rb:10:in `block (3 levels) in <top (required)>'

Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /app/samvera/hyrax-webapp/spec/services/aapb/batch_ingest/zipped_pbcore_reader_spec.rb:25:in `block (4 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 14 minutes 12 seconds (files took 9.07 seconds to load)
630 examples, 10 failures, 38 pending

Failed examples:

rspec ./spec/features/pushes_spec.rb:42 # Pushes features #pushes gets the correct record set when navigating from a catalog search
rspec ./spec/features/create_asset_with_genre_vocabulary_spec.rb:31 # Create Asset with Asset Type Create adminset, create asset Create Asset with Asset Type
rspec ./spec/features/create_asset_spec.rb:67 # Create and Validate Asset Create adminset, create asset Create and Validate Asset, Search asset
rspec ./spec/features/admin_add_userrole_as_adminset_manager_spec.rb:15 # AdminAddUserroleAsAdminsetManager. As Admin add a UserRole as Adminset Manager Assign set of user (role) as Manager to AdminSet
rspec ./spec/features/create_asset_with_digitalinstantiation_spec.rb:63 # Create and Validate Asset,Digital Instantiation, EssenseTrack Create adminset, create asset, import pbcore xml for digital instantiation and essensetrack Create and Validate Asset, Search asset
rspec ./spec/features/create_asset_with_asset_types_vocabulary_spec.rb:31 # Create Asset with Asset Type Create adminset, create asset Create Asset with Asset Type
rspec ./spec/features/admin/admin_sets/add_multiple_userrole_as_manager_spec.rb:15 # AssignMultipleRolesAsManager. Add Manager permissions to user (Role) Assign set of user (role) as Manager to multiple AdminSet
rspec ./spec/controllers/pushes_controller_spec.rb:17 # PushesController GET /pushes/index assigns @pushes to all Push model instances
rspec ./spec/controllers/pushes_controller_spec.rb:25 # PushesController GET /pushes/:id assign @push to the Push instance for the ID given
rspec ./spec/controllers/admin/users_controller_spec.rb:9 # Admin::UsersController GET #new returns a success response

Randomized with seed 30145
```

</details>