### PR TITLE
Reconcile Jobs w/ Upgrade

### DIFF
--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
-# OVERRIDE Bulkrax 1.0.2 to rescue errors and to add queued indexing
+# OVERRIDE Bulkrax 1.0.2 to rescue errors (and to add queued indexing if App.rails_5_1?)
 
 require_dependency Bulkrax::Engine.root.join('app', 'jobs', 'bulkrax', 'importer_job').to_s
 
-  Bulkrax::ImporterJob.class_eval do
-    def perform(importer_id, only_updates_since_last_import = false)
-      importer = Bulkrax::Importer.find(importer_id)
+Bulkrax::ImporterJob.class_eval do
+  def perform(importer_id, only_updates_since_last_import = false)
+    importer = Bulkrax::Importer.find(importer_id)
 
-      importer.current_run
-      unzip_imported_file(importer.parser)
-      import(importer, only_updates_since_last_import)
-      update_current_run_counters(importer)
-      schedule(importer) if importer.schedulable?
-      # OVERRIDE Bulkrax 1.0.2 to add queued indexing
-      Bulkrax::IndexAfterJob.set(wait: 1.minute).perform_later(importer)
-    rescue RuntimeError => e
-      # Quits job when xml format is invalid
-      Rails.logger.error "#{e.class}: #{e.message}\n\nBacktrace:\n#{e.backtrace.join("\n")}"
-      nil
-    end
+    importer.current_run
+    unzip_imported_file(importer.parser)
+    import(importer, only_updates_since_last_import)
+    update_current_run_counters(importer)
+    schedule(importer) if importer.schedulable?
+    # OVERRIDE Bulkrax 1.0.2 to add queued indexing if App.rails_5_1?
+    # TODO: delete with dual boot cleanup - nested indexing is replaced by graph indexer
+    Bulkrax::IndexAfterJob.set(wait: 1.minute).perform_later(importer) if App.rails_5_1?
+  rescue RuntimeError => e
+    # Quits job when xml format is invalid
+    Rails.logger.error "#{e.class}: #{e.message}\n\nBacktrace:\n#{e.backtrace.join("\n")}"
+    nil
   end
+end

--- a/app/jobs/bulkrax/index_after_job.rb
+++ b/app/jobs/bulkrax/index_after_job.rb
@@ -1,3 +1,4 @@
+# TODO: delete with dual boot cleanup - nested indexing is replaced by graph indexer
 module Bulkrax
   class IndexAfterJob < ApplicationJob
     queue_as :import


### PR DESCRIPTION
Remove job related to nested indexing. Hyrax 4 uses only graph indexer.

Ref https://github.com/scientist-softserv/ams/issues/26

# Notes
## Bulkrax namespaced jobs: 
using Bulkrax 1.0.2 branch `gbh-patch` hash `23efea3fd9d8d98746b73e570e0dc214ff764271`
- ImporterJob:
  - overrides Bulkrax to add `IndexAfterJob`
  - Rescues RunTimeError with logger message
  - Remove IndexAfterJob but keep
- IndexAfterJob:
  - does a full nested reindex after the import is complete
  - Remove
- ImportWorkJob:
  - Override to retry Ldp::NotFound with 3 retries
  - Keep job
-  DeleteWorkJob:
    - defines perform via class_eval 
    - Also call AMS::AssetDestroyer when destroying a work that is an Asset
    - Keep job
- ChildRelationshipsJobDecorator:
  - Override to add a limit of 5 to the number of relationship job reschedules
  - Modifies `work_membership` method to raiseChildWorksError if not all children are found
  - Keep job

## Hyrax namespaced jobs:
- CoolDigitalJob, CoolPhysicalJob, CoolEssenceJob:
  - Keep only if keeping Batch Ingest
  - Ref https://github.com/scientist-softserv/ams/issues/58 - Remove or test
 
## Other jobs:
- ExportRecordsJob:
  - Keep
- PushToAapbJob:
  - Keep