### PR TITLE
I70 regress sidekiq for dual boot support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ if ENV['DEPENDENCIES_NEXT'] && !ENV['DEPENDENCIES_NEXT'].empty?
     gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', branch: 'gbh-patch'
     gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
   end
+  gem 'sidekiq', '~> 6.4.0'
 else
   # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
   gem 'rails', '~> 5.1.5'
@@ -40,6 +41,7 @@ else
     gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', ref: '23efea3fd9d8d98746b73e570e0dc214ff764271'
     gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
   end
+  gem 'sidekiq'
 end
 
 gem 'dotenv-rails'
@@ -59,7 +61,6 @@ gem 'jbuilder', '~> 2.5'
 
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 4.0'
-gem 'sidekiq'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
@@ -97,7 +98,7 @@ group :development do
   # gem 'spring-watcher-listen', '~> 2.0.0'
   gem "letter_opener"
   gem 'faker'
-  gem 'xray-rails'
+  # gem 'xray-rails' should be commented out when actively using sidekiq.
 end
 
 gem 'rsolr', '>= 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1001,8 +1001,6 @@ GEM
       rexml
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    xray-rails (0.3.2)
-      rails (>= 3.1.0)
 
 PLATFORMS
   ruby
@@ -1065,7 +1063,6 @@ DEPENDENCIES
   webmock (~> 3.7)
   webpacker
   willow_sword!
-  xray-rails
 
 BUNDLED WITH
    2.3.7

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -865,8 +865,6 @@ GEM
     redic (1.5.3)
       hiredis
     redis (4.8.1)
-    redis-client (0.15.0)
-      connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
     redlock (1.3.2)
@@ -989,11 +987,10 @@ GEM
       sxp (~> 1.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.1.2)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.14.0)
+    sidekiq (6.4.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -1115,8 +1112,6 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    xray-rails (0.3.2)
-      rails (>= 3.1.0)
     yaml-ld (0.0.2)
       json-ld (~> 3.2, >= 3.2.3)
       psych (>= 3.3)
@@ -1176,7 +1171,7 @@ DEPENDENCIES
   sass-rails (~> 6.0)
   selenium-webdriver
   shoulda-matchers
-  sidekiq
+  sidekiq (~> 6.4.0)
   simple_form (= 5.0.0)
   solr_wrapper (~> 2.1)
   sony_ci_api!
@@ -1188,7 +1183,6 @@ DEPENDENCIES
   webmock (~> 3.7)
   webpacker
   willow_sword!
-  xray-rails
 
 BUNDLED WITH
    2.3.7

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,11 @@ config = YAML.load(ERB.new(IO.read(Rails.root + 'config' + 'redis.yml')).result)
 
 url = Rails.env == 'production' ? "redis://:#{config[:password]}@#{config[:host]}:#{config[:port]}/" : "redis://#{config[:host]}:#{config[:port]}/"
 
-redis_conn = { url: url, network_timeout: config[:network_timeout] }
+redis_conn = if App.rails_5_1?
+  { url: url, network_timeout: config[:network_timeout] }
+else
+  { url: url }
+end
 
 Sidekiq.configure_server do |s|
   s.redis = redis_conn
@@ -11,6 +15,5 @@ end
 Sidekiq.configure_client do |s|
   s.redis = redis_conn
 end
-
 
 Sidekiq.logger.level = Logger::DEBUG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     expose:
       - 8080
     environment:
-      - VIRTUAL_PORT=8983
+      - VIRTUAL_PORT=8080
       - VIRTUAL_HOST=fcrepo.ams.test
       - JAVA_OPTIONS=-Dfcrepo.object.directory="/data/objects" -Dfcrepo.binary.directory="/data/binaries" -Dfcrepo.mysql.host=db -Dfcrepo.mysql.username=root -Dfcrepo.mysql.password=DatabaseFTW
       - MODESHAPE_CONFIG=classpath:/config/jdbc-mysql/repository.json


### PR DESCRIPTION
We upgraded sidekiq to 7.1.2 when using dual boot which was too high of a jump. This PR regresses the version to 6.4.0 and sidekiq is working again. 

yes there are failures but at least it processed. 

ref: https://github.com/scientist-softserv/ams/issues/70


# before

![image](https://github.com/WGBH-MLA/ams/assets/10081604/720c73c7-bb89-400f-87be-c3a15a3b43ef)

# after
![image](https://github.com/WGBH-MLA/ams/assets/10081604/722ffe33-2f0c-48f7-ab3a-65aa6f3eb9c6)

![image](https://github.com/WGBH-MLA/ams/assets/10081604/c171061d-073a-4896-bfd1-cd8673015e0a)
