### PR TITLE
Remove actor customizations

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -14,8 +14,10 @@ module Hyrax
         add_date_types(env)
         set_validation_status(env)
 
-        # queue indexing if we are importing
-        env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        if App.rails_5_1?
+          # queue indexing if we are importing
+          env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        end
         save_aapb_admin_data(env) && super && create_or_update_contributions(env, contributions)
       end
 
@@ -26,8 +28,10 @@ module Hyrax
         add_date_types(env)
         set_validation_status(env)
 
-        # queue indexing if we are importing
-        env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        if App.rails_5_1?
+          # queue indexing if we are importing
+          env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        end
         save_aapb_admin_data(env) && super && create_or_update_contributions(env, contributions)
       end
 

--- a/app/actors/hyrax/actors/contribution_actor.rb
+++ b/app/actors/hyrax/actors/contribution_actor.rb
@@ -4,13 +4,18 @@ module Hyrax
   module Actors
     class ContributionActor < Hyrax::Actors::BaseActor
       def create(env)
-        # queue indexing if we are importing
-        env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        if App.rails_5_1?
+          # queue indexing if we are importing
+          env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        end
         super
       end
 
       def update(env)
-        env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        if App.rails_5_1?
+          # queue indexing if we are importing
+          env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        end
         super
       end
     end

--- a/app/actors/hyrax/actors/digital_instantiation_actor.rb
+++ b/app/actors/hyrax/actors/digital_instantiation_actor.rb
@@ -8,8 +8,10 @@ module Hyrax
         pbcore_doc = PBCore::InstantiationDocument.parse(xml_file)
         set_env_attributes_from_pbcore(env, pbcore_doc)
 
-        # queue indexing if we are importing
-        env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        if App.rails_5_1?
+          # queue indexing if we are importing
+          env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        end
 
         if env.attributes['bulkrax_identifier'].present?
           save_instantiation_aapb_admin_data(env) && super
@@ -21,8 +23,10 @@ module Hyrax
       def update(env)
         xml_file = file_uploaded?(env) ? uploaded_xml(env) : env.attributes.delete(:pbcore_xml)
 
-        # queue indexing if we are importing
-        env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        if App.rails_5_1?
+          # queue indexing if we are importing
+          env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        end
 
         if env.curation_concern&.bulkrax_identifier
           save_instantiation_aapb_admin_data(env) && super

--- a/app/actors/hyrax/actors/environment.rb
+++ b/app/actors/hyrax/actors/environment.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # OVERRIDE Hyrax 2.9 to add in import flag
+# TODO: Remove this with if App.rails_5_1? cleanup
 module Hyrax
   module Actors
     class Environment

--- a/app/actors/hyrax/actors/essence_track_actor.rb
+++ b/app/actors/hyrax/actors/essence_track_actor.rb
@@ -5,13 +5,18 @@ module Hyrax
     class EssenceTrackActor < Hyrax::Actors::BaseActor
 
       def create(env)
-        # queue indexing if we are importing
-        env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        if App.rails_5_1?
+          # queue indexing if we are importing
+          env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        end
         super
       end
 
       def update(env)
-        env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        if App.rails_5_1?
+          # queue indexing if we are importing
+          env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        end
         super
       end
     end

--- a/app/actors/hyrax/actors/interpret_visibility_actor_decorator.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor_decorator.rb
@@ -1,6 +1,6 @@
 # deal with fact that this class creates a brand new environment and does not pass
 # any added arguments down to the new version. For importer flag compatibility
-
+# TODO: Remove with if App.rails_5_1? cleanup
 module Hyrax
   module Actors
     module InterpretVisibilityActorDecorator

--- a/app/actors/hyrax/actors/physical_instantiation_actor.rb
+++ b/app/actors/hyrax/actors/physical_instantiation_actor.rb
@@ -4,15 +4,19 @@ module Hyrax
   module Actors
     class PhysicalInstantiationActor < Hyrax::Actors::BaseActor
       def create(env)
-        # queue indexing if we are importing
-        env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        if App.rails_5_1?
+          # queue indexing if we are importing
+          env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        end
 
         save_instantiation_aapb_admin_data(env) && super
       end
 
       def update(env)
-        # queue indexing if we are importing
-        env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        if App.rails_5_1?
+          # queue indexing if we are importing
+          env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing
+        end
         save_instantiation_aapb_admin_data(env) && super
       end
 


### PR DESCRIPTION
Refs https://github.com/scientist-softserv/ams/issues/30 
Actor changes dealing with nested indexing are obsolete with upgrade.
Ran specs locally for `DEPENDENCIES_NEXT=1` with only the 10 known failures appearing.

**Conditionally remove env.curation_concern.reindex_extent**

- Custom actors use env.curation_concern.reindex_extent = "queue#{env.importing.id}" if env.importing in queued_nesting_indexer.rb and nested indexing is obsolete.
- Both of the overridden actors are there to bring in the importer flag in order to support the nested indexing. There is no harm in keeping but they can be deleted during the cleanup of App.rails_5_1?
- Jobs, Actors, and Indexers are all affected.
- Unsure if any searches will break due to removing nested indexing... if so, after testing, may need to change to graph searches.