### PR TITLE
Comment indexer for future removal

### DIFF
--- a/app/indexers/queued_nesting_indexer.rb
+++ b/app/indexers/queued_nesting_indexer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+# TODO: Remove this with if App.rails_5_1? cleanup
 class QueuedNestingIndexer
   extend Samvera::NestingIndexer
   def self.reindex_relationships(id:, maximum_nesting_depth: nil, extent:)


### PR DESCRIPTION
Calling QueuedNestingIndexer is obsolete after upgrades. This PR adds a comment to mark it for future deletion.

refs https://github.com/scientist-softserv/ams/issues/34