### PR TITLE
I57 test bulkrax after upgrades

### DIFF
--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 1d176b340a275647f1aa5659e470aa7b79d4897e
+  revision: eca45757eabde6fe2e4ad53048c7e639950ea950
   branch: gbh-patch
   specs:
     bulkrax (1.0.2)


### PR DESCRIPTION
This PR updates bulkrax to bring in dual boot support. Their version of bulkrax was calling nested indexing which is no  longer supported in hyrax 4, which is the version we upgraded them to. Bulkrax is functional again when using rails 6. 

ref: 
- issue: https://github.com/scientist-softserv/ams/issues/57
- bulkrax: https://github.com/samvera-labs/bulkrax/commit/eca45757eabde6fe2e4ad53048c7e639950ea950 