### PR TITLE
:broom: expose export button

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,6 +8,7 @@ class CatalogController < ApplicationController
   add_results_collection_tool :export_search_results if App.rails_5_1?
 
   configure_blacklight do |config|
+    config.add_results_collection_tool :export_search_results if !App.rails_5_1?
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
     # config.advanced_search[:qt] ||= 'advanced'


### PR DESCRIPTION
previously we accidentally hid the export button behind a rails_5_1? conditional. I needed to access it in rails 6 for export testing. This exposes it again by conditionally placing the method call inside of the blacklight configuration block for rails 6.

## rails 6.1

<img width="1146" alt="image" src="https://github.com/WGBH-MLA/ams/assets/10081604/780ba0a8-b2ea-4525-9e98-c86f012c3008">


## production rails

<img width="1347" alt="image" src="https://github.com/WGBH-MLA/ams/assets/10081604/9e690ffe-e703-45d4-bb97-e37b57887eca">
