### PR TITLE
I68 fix remaining feature specs

### DIFF
--- a/app/assets/javascripts/global/multiselect.js
+++ b/app/assets/javascripts/global/multiselect.js
@@ -6,8 +6,6 @@ $( document ).on('turbolinks:load', function() {
     });
 
     $("select[multiple='multiple']").each(function() {
-        if ($(this).first().val() == "")
-            $(this).first().remove();
         $(this).multiselect();
     });
 });

--- a/app/views_rails_6_1/hyrax/assets/_metadata.html.erb
+++ b/app/views_rails_6_1/hyrax/assets/_metadata.html.erb
@@ -4,11 +4,11 @@
 
     <div class="block">
 
-      <a class="btn btn-default btn-block header collapsed" id="tab-<%= t('.details') %>" role="button" data-toggle="collapse" href="#collapse-<%= t('.details') %>" aria-expanded="false" aria-controls="collapse-<%= t('.details') %>">
+      <a class="btn btn-default btn-block header" id="tab-<%= t('.details') %>" role="button" data-toggle="collapse" href="#collapse-<%= t('.details') %>" aria-expanded="false" aria-controls="collapse-<%= t('.details') %>">
         <%= presenter.human_readable_type + " " + t('.details') %></h2>
       </a>
 
-      <div class="collapse" id="collapse-<%= t('.details') %>">
+      <div class="collapse show" id="collapse-<%= t('.details') %>">
 
         <dl class="work-show <%= dom_class(@presenter) %>" <%= presenter.microdata_type_to_html %>>
 

--- a/app/views_rails_6_1/hyrax/base/_form_metadata.html.erb
+++ b/app/views_rails_6_1/hyrax/base/_form_metadata.html.erb
@@ -33,7 +33,7 @@
               </a>
             </h5>
           </div>
-          <div id="collapse-<%= group %>" class="collapse <%= 'show' if f.object.expand_field_group?(group) %>" aria-labelledby="heading-<%= group %>" data-parent="#accordion">
+          <div id="collapse-<%= group %>" class="collapse <%= 'show' if f.object.expand_field_group?(group) %>" aria-labelledby="heading-<%= group %>">
             <div class="card-body">
               <% fields.each do |term| %>
                 <%= render_edit_field_partial(term, f: f) %>

--- a/app/views_rails_6_1/hyrax/base/_form_progress.html.erb
+++ b/app/views_rails_6_1/hyrax/base/_form_progress.html.erb
@@ -37,13 +37,11 @@
       <div class="list-group-item">
         <%= f.input :child_work_create , :as => :hidden, :input_html => { :value => "", name:"child_work_create", id: "child_work_create" } %>
         <% @form.model.valid_child_concerns.each do |child| %>
-          <%# Using `button_tag` here because simple form button comes
-              with `btn btn-default` which was throwing off the style %>
-          <%= button_tag "Save & Create #{child.model_name.human.titleize}",
-                         type: 'button',
-                         class: 'btn btn-primary associated_work_actions',
-                         onclick: "ChildWorkActions.saveActon(this);",
-                         value: child.model_name %>
+          <%= f.button :button,"Save & Create "+child.model_name.human.titleize,
+                       onclick:"ChildWorkActions.saveActon(this);",
+                       class: 'btn btn-primary associated_work_actions',
+                       value:child.model_name,
+                       style: "color: white;" %>
           <br />
           <br />
         <% end %>

--- a/spec/features/admin/admin_sets/add_multiple_userrole_as_manager_spec.rb
+++ b/spec/features/admin/admin_sets/add_multiple_userrole_as_manager_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.feature 'AssignMultipleRolesAsManager.', js: true do
-  if App.rails_5_1?
     context 'Add Manager permissions to user (Role)' do
       let(:admin_user) { create :admin_user }
       let!(:user) { create :user }
@@ -60,12 +59,11 @@ RSpec.feature 'AssignMultipleRolesAsManager.', js: true do
 
         # Check other user AdminSet permissions exist
         visit '/admin/admin_sets'
-        expect(page).to have_content 'You are not authorized to access this page.'
+        if App.rails_5_1?
+          expect(page).to have_content 'You are not authorized to access this page.'
+        else
+          expect(page).to have_content '0 collections you own in the repository'
+        end
       end
     end
-  else
-    skip 'Skipping tests until bootstrap upgrade is complete'
-    # ref: https://github.com/scientist-softserv/ams/issues/28
-    # ref: https://github.com/scientist-softserv/ams/issues/32
   end
-end

--- a/spec/features/admin_add_userrole_as_adminset_manager_spec.rb
+++ b/spec/features/admin_add_userrole_as_adminset_manager_spec.rb
@@ -1,60 +1,56 @@
 require 'rails_helper'
 
 RSpec.feature 'AdminAddUserroleAsAdminsetManager.', js: true do
-  if App.rails_5_1?
-    context 'As Admin add a UserRole as Adminset Manager' do
-      let(:admin_user) { create :admin_user }
-      let!(:user) { create :user }
-      let!(:user_with_role) { create :user, role_names: ['test_role'] }
-      let!(:admin_set) { create :admin_set }
 
-      before do
-        login_as(admin_user)
-      end
+  context 'As Admin add a UserRole as Adminset Manager' do
+    let(:admin_user) { create :admin_user }
+    let!(:user) { create :user }
+    let!(:user_with_role) { create :user, role_names: ['test_role'] }
+    let!(:admin_set) { create :admin_set }
+    let(:route) { "/admin/admin_sets/#{admin_set.id}?locale=en" }
 
-      scenario 'Assign set of user (role) as Manager to AdminSet' do
-
-        # Check AdminSet exist
-        visit '/admin/admin_sets'
-        expect(page).to have_content admin_set.title[0]
-
-        # Open AdminSet and edit
-        find('td a', text: admin_set.title.first).click
-        click_on('Edit')
-        expect(page).to have_content 'Edit Administrative Set'
-
-        # Add participants
-        click_on('Participants')
-        fill_in('permission_template_access_grants_attributes_0_agent_id', with: user_with_role.groups.first)
-        find("#group-participants-form select option[value='manage']").select_option
-        find('#group-participants-form .btn').click
-        expect(page).to have_content  'participant rights have been updated'
-
-        # Login manager role user to check permissions
-        visit destroy_user_session_path
-        login_as(user_with_role)
-
-        # Check AdminSet permissions exist
-        visit '/admin/admin_sets'
-        expect(page).to have_content admin_set.title[0]
-
-        # Open AdminSet and edit
-        find('td a', text: admin_set.title.first).click
-        click_on('Edit')
-        expect(page).to have_content 'Edit Administrative Set'
-
-        # Login other user to check permissions
-        visit destroy_user_session_path
-        login_as(user)
-
-        # Check other user AdminSet permissions exist
-        visit '/admin/admin_sets'
-        expect(page).to have_content 'You are not authorized to access this page.'
-      end
+    before do
+      login_as(admin_user)
     end
-  else
-    skip 'Skipping tests until bootstrap upgrade is complete'
-    # ref: https://github.com/scientist-softserv/ams/issues/28
-    # ref: https://github.com/scientist-softserv/ams/issues/32
+
+    scenario 'Assign set of user (role) as Manager to AdminSet' do
+
+      # Check AdminSet exist
+      visit 'dashboard/collections'
+      expect(page).to have_content admin_set.title[0]
+
+      # Open AdminSet and edit
+      find("a[href='#{route}']").click
+      click_on('Edit')
+      expect(page).to have_content 'Edit Administrative Set'
+
+      # Add participants
+      click_on('Participants')
+      fill_in('permission_template_access_grants_attributes_0_agent_id', with: user_with_role.groups.first)
+      find("#group-participants-form select option[value='manage']").select_option
+      find('#group-participants-form .btn').click
+      expect(page).to have_content  'participant rights have been updated'
+
+      # Login manager role user to check permissions
+      visit destroy_user_session_path
+      login_as(user_with_role)
+
+      # Check AdminSet permissions exist
+      visit 'dashboard/collections'
+      expect(page).to have_content admin_set.title[0]
+
+      # Open AdminSet and edit
+      find("a[href='#{route}']").click
+      click_on('Edit')
+      expect(page).to have_content 'Edit Administrative Set'
+
+      # Login other user to check permissions
+      visit destroy_user_session_path
+      login_as(user)
+
+      # Check other user AdminSet permissions exist
+      visit 'dashboard/collections'
+      expect(page).to have_content '0 collections you can manage in the repository'
+    end
   end
 end

--- a/spec/features/create_asset_spec.rb
+++ b/spec/features/create_asset_spec.rb
@@ -4,168 +4,162 @@ require_relative '../../app/services/description_types_service'
 require_relative '../../app/services/date_types_service'
 
 RSpec.feature 'Create and Validate Asset', js: true, asset_form_helpers: true, clean:true do
-  if App.rails_5_1?
-    context 'Create adminset, create asset' do
-      let(:admin_user) { create :admin_user }
-      let!(:user_with_role) { create :user, role_names: ['ingester'] }
-      let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
-      let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-      let!(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  context 'Create adminset, create asset' do
+    let(:admin_user) { create :admin_user }
+    let!(:user_with_role) { create :user, role_names: ['ingester'] }
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let!(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
 
-      let(:input_date_format) { '%m/%d/%Y' }
-      let(:output_date_format) { '%F' }
+    let(:input_date_format) { '%m/%d/%Y' }
+    let(:output_date_format) { '%F' }
 
-      let(:asset_attributes) do
-        { title: "My Test Title", description: "My Test Description", spatial_coverage: 'My Test Spatial coverage',
-          temporal_coverage: 'My Test Temporal coverage', audience_level: 'My Test Audience level',
-          audience_rating: 'My Test Audience rating', annotation: 'My Test Annotation', rights_summary: 'My Test Rights summary' }
-      end
+    let(:asset_attributes) do
+      { title: "My Test Title", description: "My Test Description", spatial_coverage: 'My Test Spatial coverage',
+        temporal_coverage: 'My Test Temporal coverage', audience_level: 'My Test Audience level',
+        audience_rating: 'My Test Audience rating', annotation: 'My Test Annotation', rights_summary: 'My Test Rights summary' }
+    end
 
-      # Use contolled vocab to retrieve all title types.
-      let(:title_types) { TitleTypesService.new.all_terms }
-      let(:description_types) { DescriptionTypesService.new.all_terms }
-
-
-      # Make an array of [title, title_type] pairs.
-      # Ensure there are 2 titles for every title type.
-      let(:titles_with_types) do
-        (title_types * 2).each_with_index.map do |title_type, i|
-          test_title = "Test #{title_type} Title #{i+1}".gsub(/\s+/, ' ')
-          [test_title, title_type]
-        end
-      end
+    # Use contolled vocab to retrieve all title types.
+    let(:title_types) { TitleTypesService.new.all_terms }
+    let(:description_types) { DescriptionTypesService.new.all_terms }
 
 
-      # Make an array of [description, description_type] pairs.
-      # Ensure there are 2 descriptions for every description type.
-      let(:descriptions_with_types) do
-        (description_types * 2).each_with_index.map do |description_type, i|
-          test_description = "Test #{description_type} Description #{i+1}".gsub(/\s+/, ' ')
-          [test_description, description_type]
-        end
-      end
-
-      # array of main titles, i.e. all titles without a type
-      let(:main_titles) do
-        titles_with_types.select do |_title, title_type|
-          title_type.blank?
-        end.map do |title, _title_type|
-          title
-        end
-      end
-
-      # Specify a main description.
-      let(:main_description) { descriptions_with_types.first.first }
-
-      # Make an array of [date, date_type] pairs.
-      # Ensure there are 2 date for every date type.
-      let(:dates_with_types) do
-        (DateTypesService.all_terms * 2).each_with_index.map { |date_type, i| [rand_date_time.strftime(output_date_format), date_type] }
-      end
-
-      let(:contribution_attributes) {FactoryBot.attributes_for(:contribution)}
-
-      scenario 'Create and Validate Asset, Search asset' do
-        Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
-        Hyrax::PermissionTemplateAccess.create!(
-          permission_template_id: permission_template.id,
-          agent_type: 'group',
-          agent_id: 'ingester',
-          access: 'deposit'
-        )
-        # Login role user to create asset
-        login_as(user_with_role)
-
-        # create asset
-        visit new_hyrax_asset_path
-
-        expect(page).to have_content "Add New Asset"
-
-        click_link "Files" # switch tab
-        expect(page).to have_content "Add files"
-        expect(page).to have_content "Add folder"
-
-        # validate metadata with errors
-        page.find("#required-metadata")[:class].include?("incomplete")
-
-        click_link "Descriptions" # switch tab
-
-        click_link "Identifying Information" # expand field group
-        wait_for(2) # wait untill all elements are visiable
-
-        fill_in_titles_with_types(titles_with_types)                                # see AssetFormHelper#fill_in_titles_with_types
-        fill_in_descriptions_with_types(descriptions_with_types)                    # see AssetFormHelper#fill_in_descriptions_with_types
-
-        # validated metadata without errors
-        page.find("#required-metadata")[:class].include?("complete")
-
-        # wait untill all elements are visiable
-        wait_for(2)
-
-        click_link "Subject Information" # expand field group
-
-        fill_in('Spatial coverage', with: asset_attributes[:spatial_coverage])
-        fill_in('Temporal coverage', with: asset_attributes[:temporal_coverage])
-        fill_in('Audience level', with: asset_attributes[:audience_level])
-        fill_in('Audience rating', with: asset_attributes[:audience_rating])
-        fill_in('Annotation', with: asset_attributes[:annotation])
-
-        click_link "Rights" # expand field group
-        wait_for(2) # wait untill all elements are visiable
-
-        fill_in('Rights summary', with: asset_attributes[:rights_summary])
-
-
-        click_link "Credits" # expand field group
-        wait_for(2) # wait untill all elements are visiable
-
-        select(contribution_attributes[:contributor_role], :from => "asset_child_contributors_0_role")
-
-        fill_in('asset_child_contributors_0_contributor', with: contribution_attributes[:contributor].first)
-        fill_in('asset_child_contributors_0_portrayal', with: contribution_attributes[:portrayal])
-        fill_in('asset_child_contributors_0_affiliation', with: contribution_attributes[:affiliation])
-
-        click_link "Relationships" # define adminset relation
-        find("#asset_admin_set_id option[value='#{admin_set_id}']").select_option
-
-
-        # set it public
-        find('body').click
-        choose('asset_visibility_open')
-        expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
-
-        click_on('Save')
-
-        visit '/'
-        find("#search-submit-header").click
-
-        # Expect metadata for Asset to be displayed on the search results page.
-        main_titles.each do |main_title|
-          expect(page).to have_content main_title
-        end
-
-        # open asset with detail show
-        click_on main_titles.first
-        expect(page).to have_content asset_attributes[:spatial_coverage]
-        expect(page).to have_content asset_attributes[:temporal_coverage]
-        expect(page).to have_content asset_attributes[:audience_level]
-        expect(page).to have_content asset_attributes[:audience_rating]
-        expect(page).to have_content asset_attributes[:annotation]
-        expect(page).to have_content asset_attributes[:rights_summary]
-        expect(page).to have_current_path(guid_regex)
-
-        find("#tab-Credits").click
-        within('#collapse-Credits') do
-          expect(page).to have_content contribution_attributes[:contributor].first
-          expect(page).to have_content contribution_attributes[:portrayal]
-          expect(page).to have_content contribution_attributes[:affiliation]
-          expect(page).to have_content contribution_attributes[:contributor_role]
-        end
+    # Make an array of [title, title_type] pairs.
+    # Ensure there are 2 titles for every title type.
+    let(:titles_with_types) do
+      (title_types * 2).each_with_index.map do |title_type, i|
+        test_title = "Test #{title_type} Title #{i+1}".gsub(/\s+/, ' ')
+        [test_title, title_type]
       end
     end
-  else
-    skip 'Skipping tests until bootstrap upgrade is complete'
-    # ref: https://github.com/scientist-softserv/ams/issues/28
-    # ref: https://github.com/scientist-softserv/ams/issues/32
+
+
+    # Make an array of [description, description_type] pairs.
+    # Ensure there are 2 descriptions for every description type.
+    let(:descriptions_with_types) do
+      (description_types * 2).each_with_index.map do |description_type, i|
+        test_description = "Test #{description_type} Description #{i+1}".gsub(/\s+/, ' ')
+        [test_description, description_type]
+      end
+    end
+
+    # array of main titles, i.e. all titles without a type
+    let(:main_titles) do
+      titles_with_types.select do |_title, title_type|
+        title_type.blank?
+      end.map do |title, _title_type|
+        title
+      end
+    end
+
+    # Specify a main description.
+    let(:main_description) { descriptions_with_types.first.first }
+
+    # Make an array of [date, date_type] pairs.
+    # Ensure there are 2 date for every date type.
+    let(:dates_with_types) do
+      (DateTypesService.all_terms * 2).each_with_index.map { |date_type, i| [rand_date_time.strftime(output_date_format), date_type] }
+    end
+
+    let(:contribution_attributes) {FactoryBot.attributes_for(:contribution)}
+
+    scenario 'Create and Validate Asset, Search asset' do
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'group',
+        agent_id: 'ingester',
+        access: 'deposit'
+      )
+      # Login role user to create asset
+      login_as(user_with_role)
+
+      # create asset
+      visit new_hyrax_asset_path
+
+      expect(page).to have_content "Add New Asset"
+
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+
+      # validate metadata with errors
+      page.find("#required-metadata")[:class].include?("incomplete")
+
+      click_link "Descriptions" # switch tab
+
+      click_link "Identifying Information" # expand field group
+      wait_for(2) # wait untill all elements are visiable
+
+      fill_in_titles_with_types(titles_with_types)                                # see AssetFormHelper#fill_in_titles_with_types
+      fill_in_descriptions_with_types(descriptions_with_types)                    # see AssetFormHelper#fill_in_descriptions_with_types
+
+      # validated metadata without errors
+      page.find("#required-metadata")[:class].include?("complete")
+
+      # wait untill all elements are visiable
+      wait_for(2)
+
+      click_link "Subject Information" # expand field group
+
+      fill_in('Spatial coverage', with: asset_attributes[:spatial_coverage])
+      fill_in('Temporal coverage', with: asset_attributes[:temporal_coverage])
+      fill_in('Audience level', with: asset_attributes[:audience_level])
+      fill_in('Audience rating', with: asset_attributes[:audience_rating])
+      fill_in('Annotation', with: asset_attributes[:annotation])
+
+      click_link "Rights" # expand field group
+      wait_for(2) # wait untill all elements are visiable
+
+      fill_in('Rights summary', with: asset_attributes[:rights_summary])
+
+
+      click_link "Credits" # expand field group
+      wait_for(2) # wait untill all elements are visiable
+
+      select(contribution_attributes[:contributor_role], :from => "asset_child_contributors_0_role")
+
+      fill_in('asset_child_contributors_0_contributor', with: contribution_attributes[:contributor].first)
+      fill_in('asset_child_contributors_0_portrayal', with: contribution_attributes[:portrayal])
+      fill_in('asset_child_contributors_0_affiliation', with: contribution_attributes[:affiliation])
+
+      click_link "Relationships" # define adminset relation
+      find("#asset_admin_set_id option[value='#{admin_set_id}']").select_option
+
+
+      # set it public
+      find('body').click
+      choose('asset_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+
+      click_on('Save')
+
+      visit '/'
+      find("#search-submit-header").click
+
+      # Expect metadata for Asset to be displayed on the search results page.
+      main_titles.each do |main_title|
+        expect(page).to have_content main_title
+      end
+
+      # open asset with detail show
+      click_on main_titles.first
+      expect(page).to have_content asset_attributes[:spatial_coverage]
+      expect(page).to have_content asset_attributes[:temporal_coverage]
+      expect(page).to have_content asset_attributes[:audience_level]
+      expect(page).to have_content asset_attributes[:audience_rating]
+      expect(page).to have_content asset_attributes[:annotation]
+      expect(page).to have_content asset_attributes[:rights_summary]
+      expect(page).to have_current_path(guid_regex)
+
+      find("#tab-Credits").click
+      within('#collapse-Credits') do
+        expect(page).to have_content contribution_attributes[:contributor].first
+        expect(page).to have_content contribution_attributes[:portrayal]
+        expect(page).to have_content contribution_attributes[:affiliation]
+        expect(page).to have_content contribution_attributes[:contributor_role]
+      end
+    end
   end
 end

--- a/spec/features/create_asset_with_asset_types_vocabulary_spec.rb
+++ b/spec/features/create_asset_with_asset_types_vocabulary_spec.rb
@@ -2,84 +2,78 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.feature 'Create Asset with Asset Type', js: true, asset_form_helpers: true, clean:true do
-  if App.rails_5_1?
-    context 'Create adminset, create asset' do
-      let(:admin_user) { create :admin_user }
-      let!(:user_with_role) { create :user, role_names: ['ingester'] }
+  context 'Create adminset, create asset' do
+    let(:admin_user) { create :admin_user }
+    let!(:user_with_role) { create :user, role_names: ['ingester'] }
 
-      let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
-      let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-      let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
 
-      let(:asset_attributes) do
-        { title: "My Asset Test Title"+ get_random_string, description: "My Asset Test Description", asset_type: "Album" }
-      end
-
-      before do
-        # Create a single action that can be taken
-        Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
-
-        # Grant the user access to deposit into the admin set.
-        Hyrax::PermissionTemplateAccess.create!(
-          permission_template_id: permission_template.id,
-          agent_type: 'user',
-          agent_id: user_with_role.user_key,
-          access: 'deposit'
-        )
-        login_as user_with_role
-      end
-
-      scenario 'Create Asset with Asset Type' do
-        # create asset
-        visit new_hyrax_asset_path
-
-        expect(page).to have_content "Add New Asset"
-
-        click_link "Files" # switch tab
-        expect(page).to have_content "Add files"
-        expect(page).to have_content "Add folder"
-
-        # validate metadata with errors
-        page.find("#required-metadata")[:class].include?("incomplete")
-
-        click_link "Descriptions" # switch tab
-
-        click_link "Identifying Information" # expand field group
-
-        # wait untill all elements are visiable
-        wait_for(2)
-
-        fill_in_title asset_attributes[:title]                # see AssetFormHelpers#fill_in_title
-        fill_in_description asset_attributes[:description]    # see AssetFormHelpers#fill_in_description
-
-        # validated metadata without errors
-        page.find("#required-metadata")[:class].include?("complete")
-
-        within('.asset_asset_types') do
-          find('button.multiselect').click
-          find('label.checkbox',text:asset_attributes[:asset_type]).click
-        end
-
-        click_link "Relationships" # define adminset relation
-        find("#asset_admin_set_id option[value='#{admin_set_id}']").select_option
-
-        click_on('Save')
-
-        visit '/'
-        find("#search-submit-header").click
-
-        # expect assets is showing up
-        expect(page).to have_content asset_attributes[:title]
-
-        # open asset with detail show
-        click_on(asset_attributes[:title])
-
-        expect(page).to have_content asset_attributes[:asset_type]
-      end
+    let(:asset_attributes) do
+      { title: "My Asset Test Title"+ get_random_string, description: "My Asset Test Description", asset_type: "Album" }
     end
-  else
-    skip 'Skipping tests until bootstrap upgrade is complete'
-    # ref: https://github.com/scientist-softserv/ams/issues/28
-    # ref: https://github.com/scientist-softserv/ams/issues/32
+
+    before do
+      # Create a single action that can be taken
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+
+      # Grant the user access to deposit into the admin set.
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'user',
+        agent_id: user_with_role.user_key,
+        access: 'deposit'
+      )
+      login_as user_with_role
+    end
+
+    scenario 'Create Asset with Asset Type' do
+      # create asset
+      visit new_hyrax_asset_path
+
+      expect(page).to have_content "Add New Asset"
+
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+
+      # validate metadata with errors
+      page.find("#required-metadata")[:class].include?("incomplete")
+
+      click_link "Descriptions" # switch tab
+
+      click_link "Identifying Information" # expand field group
+
+      # wait untill all elements are visiable
+      wait_for(2)
+
+      fill_in_title asset_attributes[:title]                # see AssetFormHelpers#fill_in_title
+      fill_in_description asset_attributes[:description]    # see AssetFormHelpers#fill_in_description
+
+      # validated metadata without errors
+      page.find("#required-metadata")[:class].include?("complete")
+
+      within('.asset_asset_types') do
+        find('button.multiselect').click
+        find('label.checkbox',text:asset_attributes[:asset_type]).click
+      end
+
+      click_link "Relationships" # define adminset relation
+      find("#asset_admin_set_id option[value='#{admin_set_id}']").select_option
+
+      click_on('Save')
+
+      visit '/'
+      find("#search-submit-header").click
+
+      # expect assets is showing up
+      expect(page).to have_content asset_attributes[:title]
+
+      # open asset with detail show
+      click_on(asset_attributes[:title])
+
+      expect(page).to have_content asset_attributes[:asset_type]
+    end
   end
 end

--- a/spec/features/create_asset_with_digitalinstantiation_spec.rb
+++ b/spec/features/create_asset_with_digitalinstantiation_spec.rb
@@ -1,191 +1,185 @@
 require 'rails_helper'
 
-RSpec.feature 'Create and Validate Asset,Digital Instantiation, EssenseTrack', js: true, asset_form_helpers: true,
+RSpec.feature 'Create and Validate Asset,Digital Instantiation, EssenseTrack', js: true, turbolinks: true, asset_form_helpers: true,
               disable_animation:true, expand_fieldgroup: true  do
-  if App.rails_5_1?
-    context 'Create adminset, create asset, import pbcore xml for digital instantiation and essensetrack' do
-      let(:admin_user) { create :admin_user }
-      let!(:user_with_role) { create :user, role_names: ['ingester'] }
-      # let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
-      let(:admin_set_id) { create(:admin_set).id }
-      let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-      let!(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  context 'Create adminset, create asset, import pbcore xml for digital instantiation and essensetrack' do
+    let(:admin_user) { create :admin_user }
+    let!(:user_with_role) { create :user, role_names: ['ingester'] }
+    # let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:admin_set_id) { create(:admin_set).id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let!(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
 
-      let(:input_date_format) { '%m/%d/%Y' }
-      let(:output_date_format) { '%F' }
+    let(:input_date_format) { '%m/%d/%Y' }
+    let(:output_date_format) { '%F' }
 
-      let(:asset_attributes) do
-        { title: "My Test Title"+ get_random_string, description: "My Test Description",spatial_coverage: 'My Test Spatial coverage',
-          temporal_coverage: 'My Test Temporal coverage', audience_level: 'My Test Audience level',
-          audience_rating: 'My Test Audience rating', annotation: 'My Test Annotation', rights_summary: 'My Test Rights summary' }
+    let(:asset_attributes) do
+      { title: "My Test Title"+ get_random_string, description: "My Test Description",spatial_coverage: 'My Test Spatial coverage',
+        temporal_coverage: 'My Test Temporal coverage', audience_level: 'My Test Audience level',
+        audience_rating: 'My Test Audience rating', annotation: 'My Test Annotation', rights_summary: 'My Test Rights summary' }
+    end
+
+    let(:digital_instantiation_attributes) do
+      {
+        location: 'Test Location',
+        rights_summary: 'My Test Rights summary',
+        rights_link: 'In Copyright',
+        holding_organization: 'WGBH',
+        pbcore_xml_doc: "#{Rails.root}/spec/fixtures/sample_instantiation_valid.xml"
+      }
+    end
+
+    let(:pbcore_xml_doc) { PBCore::InstantiationDocument.parse(File.read("#{Rails.root}/spec/fixtures/sample_instantiation_valid.xml")) }
+
+
+    # Use contolled vocab to retrieve all title types.
+    let(:title_types) { TitleTypesService.new.all_terms }
+    let(:description_types) { DescriptionTypesService.new.all_terms }
+
+    # Make an array of [title, title_type] pairs.
+    # Ensure there are 2 titles for every title type.
+    let(:titles_with_types) do
+      (title_types).each_with_index.map { |title_type, i| ["Test #{title_type} Title #{i + 1}", title_type] }
+    end
+
+    # Specify a main title.
+    let(:main_title) { titles_with_types.first.first.split.join(" ") }
+
+    # Make an array of [description, description_type] pairs.
+    # Ensure there are 2 descriptions for every description type.
+    let(:descriptions_with_types) do
+      (description_types).each_with_index.map { |description_type, i| ["Test #{description_type} Description #{i + 1}", description_type] }
+    end
+
+    # Specify a main description.
+    let(:main_description) { descriptions_with_types.first.first }
+
+    # Make an array of [date, date_type] pairs.
+    # Ensure there are 2 date for every date type.
+    let(:dates_with_types) do
+      (DateTypesService.all_terms * 2).each_with_index.map { |date_type, i| [rand_date_time.strftime(output_date_format), date_type] }
+    end
+
+    scenario 'Create and Validate Asset, Search asset' do
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'user',
+        agent_id: user_with_role.email,
+        access: 'manage'
+      )
+      # Login role user to create asset
+      login_as(user_with_role)
+
+      # create asset
+      visit new_hyrax_asset_path
+
+      expect(page).to have_content "Add New Asset"
+
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+
+      # validate metadata with errors
+      page.find("#required-metadata")[:class].include?("incomplete")
+
+      click_link "Descriptions" # switch tab
+
+      #show all fields groups
+      disable_collapse
+
+      fill_in_titles_with_types(titles_with_types)                                # see AssetFormHelper#fill_in_titles_with_types
+      fill_in_descriptions_with_types(descriptions_with_types)                    # see AssetFormHelper#fill_in_descriptions_with_types
+
+      # validated metadata without errors
+      page.find("#required-metadata")[:class].include?("complete")
+
+      fill_in('Spatial coverage', with: asset_attributes[:spatial_coverage])
+      fill_in('Temporal coverage', with: asset_attributes[:temporal_coverage])
+      fill_in('Audience level', with: asset_attributes[:audience_level])
+      fill_in('Audience rating', with: asset_attributes[:audience_rating])
+
+      # Use ID for asset_annotation on asset since we have related Annotations.
+      fill_in('asset_annotation', with: asset_attributes[:annotation])
+      fill_in('Rights summary', with: asset_attributes[:rights_summary])
+
+      click_link "Relationships" # define adminset relation
+
+      find("#asset_admin_set_id option[value='#{admin_set_id}']").select_option
+
+      # set it public
+      find('body').click
+      choose('asset_visibility_open')
+
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+
+      click_on('Save & Create Digital Instantiation')
+
+      expect(page).to have_content 'Add New Digital Instantiation', wait: 5
+
+      # TODO: Why do we need to call this twice?
+      disable_collapse
+      disable_collapse
+
+      attach_file('Digital instantiation pbcore xml', File.absolute_path(digital_instantiation_attributes[:pbcore_xml_doc]))
+      fill_in('Location', with: digital_instantiation_attributes[:location])
+
+      # Select Holding Organization
+      select = page.find('select#digital_instantiation_holding_organization')
+      select.select digital_instantiation_attributes[:holding_organization]
+
+      fill_in('Rights summary', with: digital_instantiation_attributes[:rights_summary])
+
+      # fill_in('Rights link', with: digital_instantiation_attributes[:rights_link])
+      # select(digital_instantiation_attributes[:rights_link], from: 'Rights link')
+
+      within('.digital_instantiation_rights_link') do
+        find('button.multiselect').click
+        find('label.checkbox', text: digital_instantiation_attributes[:rights_link]).click
       end
 
-      let(:digital_instantiation_attributes) do
-        {
-          location: 'Test Location',
-          rights_summary: 'My Test Rights summary',
-          rights_link: 'In Copyright',
-          holding_organization: 'WGBH',
-          pbcore_xml_doc: "#{Rails.root}/spec/fixtures/sample_instantiation_valid.xml"
-        }
-      end
+      # set it public
+      find('body').click
+      choose('digital_instantiation_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
 
-      let(:pbcore_xml_doc) { PBCore::InstantiationDocument.parse(File.read("#{Rails.root}/spec/fixtures/sample_instantiation_valid.xml")) }
+      click_link "Relationships" # define adminset relation
+      find("#digital_instantiation_admin_set_id option[value='#{admin_set_id}']").select_option
 
+      click_on('Save')
+      # Wait for the DigitalInstantiation to be saved
+      Timeout::timeout(10) { DigitalInstantiation.where(title: digital_instantiation_attributes[:title]).first }
 
-      # Use contolled vocab to retrieve all title types.
-      let(:title_types) { TitleTypesService.new.all_terms }
-      let(:description_types) { DescriptionTypesService.new.all_terms }
+      # Expect page to have the main_title as the DigitalInstantiation's title.
+      expect(page).to have_content digital_instantiation_attributes[:main_title]
+      expect(page).to have_content digital_instantiation_attributes[:location]
+      expect(page).to have_content pbcore_xml_doc.digital.value
+      expect(page).to have_content pbcore_xml_doc.media_type.value
 
-      # Make an array of [title, title_type] pairs.
-      # Ensure there are 2 titles for every title type.
-      let(:titles_with_types) do
-        (title_types).each_with_index.map { |title_type, i| ["Test #{title_type} Title #{i + 1}", title_type] }
-      end
+      # rights link
+      expect(page).to have_content "http://rightsstatements.org/page/InC/1.0/?language=en"
+      expect(page).to have_content digital_instantiation_attributes[:rights_summary]
+      expect(page).to have_content digital_instantiation_attributes[:holding_organization]
+      expect(page).to have_current_path(guid_regex)
 
-      # Specify a main title.
-      let(:main_title) { titles_with_types.first.first.split.join(" ") }
+      # Go to search page
+      visit '/'
+      find("#search-submit-header").click
 
-      # Make an array of [description, description_type] pairs.
-      # Ensure there are 2 descriptions for every description type.
-      let(:descriptions_with_types) do
-        (description_types).each_with_index.map { |description_type, i| ["Test #{description_type} Description #{i + 1}", description_type] }
-      end
+      # Get the Asset record, it's DigitalInstantiation, and it's EssenceTracks
+      # in order to test what you see in the search interface.
+      asset = Asset.where(title: main_title).first
+      digital_instantiation = asset.members.first
+      essence_tracks = digital_instantiation.members.to_a
 
-      # Specify a main description.
-      let(:main_description) { descriptions_with_types.first.first }
-
-      # Make an array of [date, date_type] pairs.
-      # Ensure there are 2 date for every date type.
-      let(:dates_with_types) do
-        (DateTypesService.all_terms * 2).each_with_index.map { |date_type, i| [rand_date_time.strftime(output_date_format), date_type] }
-      end
-
-      scenario 'Create and Validate Asset, Search asset' do
-        Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
-        Hyrax::PermissionTemplateAccess.create!(
-          permission_template_id: permission_template.id,
-          agent_type: 'user',
-          agent_id: user_with_role.email,
-          access: 'manage'
-        )
-        # Login role user to create asset
-        login_as(user_with_role)
-
-        # create asset
-        visit new_hyrax_asset_path
-
-        expect(page).to have_content "Add New Asset"
-
-        click_link "Files" # switch tab
-        expect(page).to have_content "Add files"
-        expect(page).to have_content "Add folder"
-
-        # validate metadata with errors
-        page.find("#required-metadata")[:class].include?("incomplete")
-
-        click_link "Descriptions" # switch tab
-
-        #show all fields groups
-        disable_collapse
-
-        fill_in_titles_with_types(titles_with_types)                                # see AssetFormHelper#fill_in_titles_with_types
-        fill_in_descriptions_with_types(descriptions_with_types)                    # see AssetFormHelper#fill_in_descriptions_with_types
-
-        # validated metadata without errors
-        page.find("#required-metadata")[:class].include?("complete")
-
-        fill_in('Spatial coverage', with: asset_attributes[:spatial_coverage])
-        fill_in('Temporal coverage', with: asset_attributes[:temporal_coverage])
-        fill_in('Audience level', with: asset_attributes[:audience_level])
-        fill_in('Audience rating', with: asset_attributes[:audience_rating])
-
-        # Use ID for asset_annotation on asset since we have related Annotations.
-        fill_in('asset_annotation', with: asset_attributes[:annotation])
-        fill_in('Rights summary', with: asset_attributes[:rights_summary])
-
-        click_link "Relationships" # define adminset relation
-
-        find("#asset_admin_set_id option[value='#{admin_set_id}']").select_option
-
-        # set it public
-        find('body').click
-        choose('asset_visibility_open')
-
-        expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
-
-        click_on('Save & Create Digital Instantiation')
-
-        expect(page).to have_content 'Add New Digital Instantiation', wait: 5
-
-        # TODO: Why do we need to call this twice?
-        disable_collapse
-        disable_collapse
-
-        attach_file('Digital instantiation pbcore xml', File.absolute_path(digital_instantiation_attributes[:pbcore_xml_doc]))
-        fill_in('Location', with: digital_instantiation_attributes[:location])
-
-        # Select Holding Organization
-        select = page.find('select#digital_instantiation_holding_organization')
-        select.select digital_instantiation_attributes[:holding_organization]
-
-        fill_in('Rights summary', with: digital_instantiation_attributes[:rights_summary])
-
-        # fill_in('Rights link', with: digital_instantiation_attributes[:rights_link])
-        # select(digital_instantiation_attributes[:rights_link], from: 'Rights link')
-
-        within('.digital_instantiation_rights_link') do
-          find('button.multiselect').click
-          find('label.checkbox', text: digital_instantiation_attributes[:rights_link]).click
-        end
-
-        # set it public
-        find('body').click
-        choose('digital_instantiation_visibility_open')
-        expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
-
-        click_link "Relationships" # define adminset relation
-        find("#digital_instantiation_admin_set_id option[value='#{admin_set_id}']").select_option
-
-        click_on('Save')
-        # Wait for the DigitalInstantiation to be saved
-        Timeout::timeout(10) { DigitalInstantiation.where(title: digital_instantiation_attributes[:title]).first }
-
-        # Expect page to have the main_title as the DigitalInstantiation's title.
-        expect(page).to have_content digital_instantiation_attributes[:main_title]
-        expect(page).to have_content digital_instantiation_attributes[:location]
-        expect(page).to have_content pbcore_xml_doc.digital.value
-        expect(page).to have_content pbcore_xml_doc.media_type.value
-
-        # rights link
-        expect(page).to have_content "http://rightsstatements.org/page/InC/1.0/?language=en"
-        expect(page).to have_content digital_instantiation_attributes[:rights_summary]
-        expect(page).to have_content digital_instantiation_attributes[:holding_organization]
-        expect(page).to have_current_path(guid_regex)
-
-        # Go to search page
-        visit '/'
-        find("#search-submit-header").click
-
-        # Get the Asset record, it's DigitalInstantiation, and it's EssenceTracks
-        # in order to test what you see in the search interface.
-        asset = Asset.where(title: main_title).first
-        digital_instantiation = asset.members.first
-        essence_tracks = digital_instantiation.members.to_a
-
-        # Expect to see the Asset in search results.
-        expect(page).to have_search_result asset
-        # Expect to NOT see the DigitalInstantiation in the search results.
-        expect(page).to_not have_search_result digital_instantiation
-        # Expect to NOT see the EssenceTracks in the search results.
-        essence_tracks.each do |essence_track|
-          expect(page).to_not have_search_result essence_track
-        end
+      # Expect to see the Asset in search results.
+      expect(page).to have_search_result asset
+      # Expect to NOT see the DigitalInstantiation in the search results.
+      expect(page).to_not have_search_result digital_instantiation
+      # Expect to NOT see the EssenceTracks in the search results.
+      essence_tracks.each do |essence_track|
+        expect(page).to_not have_search_result essence_track
       end
     end
-  else
-    skip 'Skipping tests until bootstrap upgrade is complete'
-    # ref: https://github.com/scientist-softserv/ams/issues/28
-    # ref: https://github.com/scientist-softserv/ams/issues/32
   end
 end

--- a/spec/features/create_asset_with_genre_vocabulary_spec.rb
+++ b/spec/features/create_asset_with_genre_vocabulary_spec.rb
@@ -2,90 +2,79 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.feature 'Create Asset with Asset Type', js: true, asset_form_helpers: true, clean:true do
-  if App.rails_5_1?
-    context 'Create adminset, create asset' do
-      let(:admin_user) { create :admin_user }
-      let!(:user_with_role) { create :user, role_names: ['ingester'] }
+  context 'Create adminset, create asset' do
+    let(:admin_user) { create :admin_user }
+    let!(:user_with_role) { create :user, role_names: ['ingester'] }
 
-      let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
-      let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-      let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
 
-      let(:asset_attributes) do
-        { title: "My Asset Test Title "+ get_random_string, description:"My Asset Test Description", genre:"Call-in" }
-      end
-
-      before do
-        # Create a single action that can be taken
-        Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
-
-        # Grant the user access to deposit into the admin set.
-        Hyrax::PermissionTemplateAccess.create!(
-            permission_template_id: permission_template.id,
-            agent_type: 'user',
-            agent_id: user_with_role.user_key,
-            access: 'deposit'
-        )
-        login_as user_with_role
-      end
-
-      scenario 'Create Asset with Asset Type' do
-        # create asset
-        visit new_hyrax_asset_path
-
-        expect(page).to have_content "Add New Asset"
-
-        click_link "Files" # switch tab
-        expect(page).to have_content "Add files"
-        expect(page).to have_content "Add folder"
-
-        # validate metadata with errors
-        page.find("#required-metadata")[:class].include?("incomplete")
-
-        click_link "Descriptions" # switch tab
-        click_link "Identifying Information" # expand field group
-
-        # wait untill all elements are visiable
-        wait_for(2)
-        fill_in_title asset_attributes[:title]              # see AssetFormHelpers#fill_in_title
-        fill_in_description asset_attributes[:description]  # see AssetFormHelpers#fill_in_description
-
-        # validated metadata without errors
-        page.find("#required-metadata")[:class].include?("complete")
-
-        click_link "Subject Information" # expand field group
-
-        # wait untill all elements are visiable
-        wait_for(2)
-        within('.asset_genre') do
-          find('button.multiselect').click
-          find('label.checkbox',text:asset_attributes[:genre]).click
-        end
-
-
-
-
-
-
-        click_link "Relationships" # define adminset relation
-        find("#asset_admin_set_id option[value='#{admin_set_id}']").select_option
-
-        click_on('Save')
-
-        visit '/'
-        find("#search-submit-header").click
-
-        # expect assets is showing up
-        expect(page).to have_content asset_attributes[:title]
-
-        # open asset with detail show
-        click_on(asset_attributes[:title])
-        expect(page).to have_content asset_attributes[:genre]
-      end
+    let(:asset_attributes) do
+      { title: "My Asset Test Title "+ get_random_string, description:"My Asset Test Description", genre:"Call-in" }
     end
-  else
-    skip 'Skipping tests until bootstrap upgrade is complete'
-    # ref: https://github.com/scientist-softserv/ams/issues/28
-    # ref: https://github.com/scientist-softserv/ams/issues/32
+
+    before do
+      # Create a single action that can be taken
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+
+      # Grant the user access to deposit into the admin set.
+      Hyrax::PermissionTemplateAccess.create!(
+          permission_template_id: permission_template.id,
+          agent_type: 'user',
+          agent_id: user_with_role.user_key,
+          access: 'deposit'
+      )
+      login_as user_with_role
+    end
+
+    scenario 'Create Asset with Asset Type' do
+      # create asset
+      visit new_hyrax_asset_path
+
+      expect(page).to have_content "Add New Asset"
+
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+
+      # validate metadata with errors
+      page.find("#required-metadata")[:class].include?("incomplete")
+
+      click_link "Descriptions" # switch tab
+      click_link "Identifying Information" # expand field group
+
+      # wait untill all elements are visiable
+      wait_for(2)
+      fill_in_title asset_attributes[:title]              # see AssetFormHelpers#fill_in_title
+      fill_in_description asset_attributes[:description]  # see AssetFormHelpers#fill_in_description
+
+      # validated metadata without errors
+      page.find("#required-metadata")[:class].include?("complete")
+
+      click_link "Subject Information" # expand field group
+
+      # wait untill all elements are visiable
+      wait_for(2)
+      within('.asset_genre') do
+        find('button.multiselect').click
+        find('label.checkbox',text:asset_attributes[:genre]).click
+      end
+
+      click_link "Relationships" # define adminset relation
+      find("#asset_admin_set_id option[value='#{admin_set_id}']").select_option
+
+      click_on('Save')
+
+      visit '/'
+      find("#search-submit-header").click
+
+      # expect assets is showing up
+      expect(page).to have_content asset_attributes[:title]
+
+      # open asset with detail show
+      click_on(asset_attributes[:title])
+      expect(page).to have_content asset_attributes[:genre]
+    end
   end
 end

--- a/spec/features/pushes_spec.rb
+++ b/spec/features/pushes_spec.rb
@@ -4,71 +4,65 @@ RSpec.describe "Pushes features", type: :controller, js: true do
   include Warden::Test::Helpers
   include Devise::Test::ControllerHelpers
 
-  if App.rails_5_1?
-    # let it bang
-    let!(:user) { create :admin_user }
-    let!(:asset) { create(:asset, user: user, program_title: ['foo'], validation_status_for_aapb: [Asset::VALIDATION_STATUSES[:valid]]) }
-    let!(:asset2) { create(:asset, user: user, program_title: ['foo bar'], validation_status_for_aapb: [Asset::VALIDATION_STATUSES[:valid]]) }
-    let!(:asset3) { create(:asset, user: user, needs_update: true, validation_status_for_aapb: [Asset::VALIDATION_STATUSES[:valid]]) }
+  # let it bang
+  let!(:user) { create :admin_user }
+  let!(:asset) { create(:asset, user: user, program_title: ['foo'], validation_status_for_aapb: [Asset::VALIDATION_STATUSES[:valid]]) }
+  let!(:asset2) { create(:asset, user: user, program_title: ['foo bar'], validation_status_for_aapb: [Asset::VALIDATION_STATUSES[:valid]]) }
+  let!(:asset3) { create(:asset, user: user, needs_update: true, validation_status_for_aapb: [Asset::VALIDATION_STATUSES[:valid]]) }
 
-    # Login/logout before/after each test.
-    before { login_as(user) }
-    after { Warden.test_reset! }
+  # Login/logout before/after each test.
+  before { login_as(user) }
+  after { Warden.test_reset! }
 
-    context '#pushes' do
+  context '#pushes' do
 
-      it 'gives validation error when invalid GUID input data' do
-        visit '/pushes/new'
-        bad_ids = [ 'blerg', 'cpb-aacip-11111111111' ]
-        fill_in(id: 'id_field', with: bad_ids.join("\n") )
-        expect(page).to have_text "The following IDs are not found"
-        bad_ids.each do |bad_id|
-          expect(page).to have_text bad_id
-        end
-      end
-
-      it 'gives all clear for valid GUID input data' do
-        visit '/pushes/new'
-        fill_in(id: 'id_field', with: asset.id )
-        expect(page).to have_text('All GUIDs are valid!')
-      end
-
-      it 'gets the correct record set for needs_updating' do
-        # this i do
-        # just for u
-        visit '/pushes/needs_updating'
-        expect(page.find('textarea')).to have_text(asset3.id)
-      end
-
-      it 'gets the correct record set when navigating from a catalog search' do
-        # uri = %(/catalog?q=foo)
-        # visit uri
-        visit '/catalog'
-        fill_in(id: 'q', with: 'foo')
-        click_button(id: 'search-submit-header')
-        click_link('Push To AAPB', class: 'aapb-push-button')
-
-        expect(page.find('textarea')).to have_text(asset.id)
-        expect(page.find('textarea')).to have_text(asset2.id)
-      end
-
-      it 'can submit a push successfully' do
-        allow(PushToAAPBJob).to receive(:perform_later)
-        visit '/pushes/new'
-        fill_in('id_field', with: asset.id )
-        click_button(id: 'push-submit')
-
-        # this will have the output mail
-        # output_mail = ActionMailer::Base.deliveries.last
-        expect(PushToAAPBJob).to have_received(:perform_later)
-        push = Push.last
-        expect(push.user_id).to eq(user.id)
-        expect(push.pushed_id_csv).to eq(asset.id)
+    it 'gives validation error when invalid GUID input data' do
+      visit '/pushes/new'
+      bad_ids = [ 'blerg', 'cpb-aacip-11111111111' ]
+      fill_in(id: 'id_field', with: bad_ids.join("\n") )
+      expect(page).to have_text "The following IDs are not found"
+      bad_ids.each do |bad_id|
+        expect(page).to have_text bad_id
       end
     end
-  else
-    skip 'Skipping tests until bootstrap upgrade is complete'
-    # ref: https://github.com/scientist-softserv/ams/issues/28
-    # ref: https://github.com/scientist-softserv/ams/issues/32
+
+    it 'gives all clear for valid GUID input data' do
+      visit '/pushes/new'
+      fill_in(id: 'id_field', with: asset.id )
+      expect(page).to have_text('All GUIDs are valid!')
+    end
+
+    it 'gets the correct record set for needs_updating' do
+      # this i do
+      # just for u
+      visit '/pushes/needs_updating'
+      expect(page.find('textarea')).to have_text(asset3.id)
+    end
+
+    it 'gets the correct record set when navigating from a catalog search' do
+      # uri = %(/catalog?q=foo)
+      # visit uri
+      visit '/catalog'
+      fill_in(name: 'q', with: 'foo')
+      click_button(id: 'search-submit-header')
+      find('.aapb-push-button').click
+
+      expect(page.find('textarea')).to have_text(asset.id)
+      expect(page.find('textarea')).to have_text(asset2.id)
+    end
+
+    it 'can submit a push successfully' do
+      allow(PushToAAPBJob).to receive(:perform_later)
+      visit '/pushes/new'
+      fill_in('id_field', with: asset.id )
+      click_button(id: 'push-submit')
+
+      # this will have the output mail
+      # output_mail = ActionMailer::Base.deliveries.last
+      expect(PushToAAPBJob).to have_received(:perform_later)
+      push = Push.last
+      expect(push.user_id).to eq(user.id)
+      expect(push.pushed_id_csv).to eq(asset.id)
+    end
   end
 end


### PR DESCRIPTION
# Story

This PR will fix the remaining spec failures on the Rails 6.1 boot.

Ref:
- https://github.com/scientist-softserv/ams/issues/68

# Acceptance Criteria

- [ ] Remaining specs pass

# Notes

<details><summary>Rspec output</summary>

```rb
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) InstantiationAdminData add some examples to (or delete) /app/samvera/hyrax-webapp/spec/models/instantiation_admin_data_spec.rb
     # Not yet implemented
     # ./spec/models/instantiation_admin_data_spec.rb:4

  2) Hyrax::DigitalInstantiationPresenter has tests
     # Add your tests here
     # ./spec/presenters/hyrax/digital_instantiation_presenter_spec.rb:6

  3) Hyrax::Actors::DigitalInstantiationActor has tests
     # Add your tests here
     # ./spec/actors/hyrax/actors/digital_instantiation_actor_spec.rb:6

  4) Hyrax::DigitalInstantiationForm has tests
     # Add your tests here
     # ./spec/forms/hyrax/digital_instantiation_form_spec.rb:6

  5) Admin::UsersController Skipping tests until bootstrap upgrade is complete
     # No reason given
     # ./spec/controllers/admin/users_controller_spec.rb:26

  6) Hyrax::PhysicalInstantiationsController has tests
     # Add your tests here
     # ./spec/controllers/hyrax/physical_instantiations_controller_spec.rb:6

  7) Hyrax::EssenceTrackForm has tests
     # Add your tests here
     # ./spec/forms/hyrax/essence_track_form_spec.rb:6

  8) Hyrax::PhysicalInstantiationPresenter has tests
     # Add your tests here
     # ./spec/presenters/hyrax/physical_instantiation_presenter_spec.rb:6

  9) PushesController Skipping tests until bootstrap upgrade is complete
     # No reason given
     # ./spec/controllers/pushes_controller_spec.rb:108

  10) Hyrax::EssenceTrackPresenter has tests
     # Add your tests here
     # ./spec/presenters/hyrax/essence_track_presenter_spec.rb:6

  11) Hyrax::Actors::EssenceTrackActor has tests
     # Add your tests here
     # ./spec/actors/hyrax/actors/essence_track_actor_spec.rb:6

  12) Collection has tests
     # Add your tests here
     # ./spec/models/collection_spec.rb:4

  13) FileSet has tests
     # Add your tests here
     # ./spec/models/file_set_spec.rb:4

  14) Hyrax::EssenceTracksController has tests
     # Add your tests here
     # ./spec/controllers/hyrax/essence_tracks_controller_spec.rb:6

  15) Hyrax::Actors::PhysicalInstantiationActor has tests
     # Add your tests here
     # ./spec/actors/hyrax/actors/physical_instantiation_actor_spec.rb:6

  16) Bulkrax::CsvEntry exporting by Asset worktype writes the csv file with the asset and its children in a single row
     # Temporarily skipped with xit
     # ./spec/models/bulkrax/csv_entry_spec.rb:195

  17) Hyrax::DigitalInstantiationsController has tests
     # Add your tests here
     # ./spec/controllers/hyrax/digital_instantiations_controller_spec.rb:6

  18) Hyrax::PhysicalInstantiationForm has tests
     # Add your tests here
     # ./spec/forms/hyrax/physical_instantiation_form_spec.rb:6

  19) Hyrax::AssetForm has tests
     # Add your tests here
     # ./spec/forms/hyrax/asset_form_spec.rb:6

  20) Qa::LocalAuthorityEntry add some examples to (or delete) /app/samvera/hyrax-webapp/spec/models/qa/local_authority_entry_spec.rb
     # Not yet implemented
     # ./spec/models/qa/local_authority_entry_spec.rb:4

  21) Hyrax::AssetsController has tests
     # Add your tests here
     # ./spec/controllers/hyrax/assets_controller_spec.rb:6

  22) Qa::LocalAuthority add some examples to (or delete) /app/samvera/hyrax-webapp/spec/models/qa/local_authority_spec.rb
     # Not yet implemented
     # ./spec/models/qa/local_authority_spec.rb:4

  23) Search by dates Exact YYYY-MM-DD returns all assets with a date on that exact day
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:70

  24) Search by dates Range YYYY TO YYYY-MM-DD returns all assets with a date on or after the first day of the earlier year, and on or before the last year/month/day
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:145

  25) Search by dates Range YYYY-MM-DD TO YYYY-MM-DD returns all assets with a date on or after the first year/month/day and on or before the later year/month/day
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:214

  26) Search by dates with exact YYYY-MM returns all assets with at least one date for that year and month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:62

  27) Search by dates Range YYYY-MM TO * returns all assets with a date after the first of the specified year and month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:86

  28) Search by dates Range YYYY TO * returns all assets with a date after the first day of the specified year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:77

  29) Search by dates Range YYYY TO YYYY-MM returns all assets with a date on or after the first day of the earlier year, and on or before the last day of the later year/month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:135

  30) Search by dates Range * TO YYYY-MM returns all assets with a date on or before the last day of the specified year and month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:110

  31) Search by dates Range YYYY TO YYYY returns all assets with a date on or after the first day of the earlier year, and on or before the last day of the later year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:125

  32) Search by dates Range * TO YYYY-MM-DD returns all assets with a date on or before the last day of the specified year and month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:118

  33) Search by dates Range YYYY-MM-DD TO YYYY returns all assets with a date on or after the first year/month/day and on or before the last day of the later year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:191

  34) Search by dates Range YYYY-MM-DD TO YYYY-MM returns all assets with a date on or after the first year/month/day and on or before the last day of the later year/month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:203

  35) Search by dates Range YYYY-MM TO YYYY-MM returns all assets with a date on or after the first day of the earlier year/month, and on or before the last day of the later year/month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:167

  36) Search by dates Range YYYY-MM TO YYYY returns all assets with a date on or after the first day of the earlier year/month, and on or before the last day of the later year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:154

  37) Search by dates with exact YYYY returns all assets with at least one date within that year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:53

  38) Search by dates Range * TO YYYY returns all assets with a date on or before the last day of the specified year
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:101

  39) Search by dates Range YYYY-MM TO YYYY-MM-DD returns all assets with a date on or after the first day of the earlier year/month, and on or before the later year/month/day
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:180

  40) Search by dates Range YYYY-MM-DD TO * returns all assets with a date after the first of the specified year and month
     # No reason given
     # ./spec/features/search_by_dates_spec.rb:94


Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /app/samvera/hyrax-webapp/spec/services/aapb/batch_ingest/zipped_pbcore_digital_instantiation_reader_spec.rb:26:in `block (4 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 13 minutes 38 seconds (files took 8.79 seconds to load)
623 examples, 0 failures, 40 pending

Randomized with seed 41517
```
</details>

After this PR these are the only failing specs left (currently marked pending)

<details><summary>Remaining failures</summary>

```rb
Failures:

  1) PushesController GET /pushes/:id assign @push to the Push instance for the ID given
     Failure/Error: before { get :show, params: { id: push.id } }

     NoMethodError:
       undefined method `formats' for #<ActionView::Template:0x0000ffff7a06b2e0>
       Did you mean?  format
     # /usr/local/bundle/gems/react-rails-2.7.1/lib/react/rails/controller_lifecycle.rb:31:in `use_react_component_helper'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/template_assertions.rb:62:in `process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `block in process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `catch'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `_catch_warden'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `process'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/integration.rb:16:in `block (2 levels) in <module:Integration>'
     # ./spec/controllers/pushes_controller_spec.rb:24:in `block (3 levels) in <top (required)>'

  2) PushesController GET /pushes/index assigns @pushes to all Push model instances
     Failure/Error: before { get :index }

     NoMethodError:
       undefined method `formats' for #<ActionView::Template:0x0000ffff7a06b2e0>
       Did you mean?  format
     # /usr/local/bundle/gems/react-rails-2.7.1/lib/react/rails/controller_lifecycle.rb:31:in `use_react_component_helper'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/template_assertions.rb:62:in `process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `block in process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `catch'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `_catch_warden'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `process'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/integration.rb:16:in `block (2 levels) in <module:Integration>'
     # ./spec/controllers/pushes_controller_spec.rb:16:in `block (3 levels) in <top (required)>'

  3) Admin::UsersController GET #new returns a success response
     Failure/Error: get :new

     NoMethodError:
       undefined method `formats' for #<ActionView::Template:0x0000ffff79c899b0>
       Did you mean?  format
     # /usr/local/bundle/gems/react-rails-2.7.1/lib/react/rails/controller_lifecycle.rb:31:in `use_react_component_helper'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/template_assertions.rb:62:in `process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `block in process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `catch'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `_catch_warden'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `process'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/integration.rb:16:in `block (2 levels) in <module:Integration>'
     # ./spec/controllers/admin/users_controller_spec.rb:10:in `block (3 levels) in <top (required)>'

Finished in 30.78 seconds (files took 7.91 seconds to load)
9 examples, 3 failures

Failed examples:

rspec ./spec/controllers/pushes_controller_spec.rb:25 # PushesController GET /pushes/:id assign @push to the Push instance for the ID given
rspec ./spec/controllers/pushes_controller_spec.rb:17 # PushesController GET /pushes/index assigns @pushes to all Push model instances
rspec ./spec/controllers/admin/users_controller_spec.rb:9 # Admin::UsersController GET #new returns a success response

Randomized with seed 52131
```