### PR TITLE
:gear: configure sentry

### DIFF
--- a/ops/alpha-deploy.tmpl.yaml
+++ b/ops/alpha-deploy.tmpl.yaml
@@ -97,6 +97,10 @@ extraEnvVars: &envVars
     value: prod
   - name: REDIS_SERVER
     value: redis://:prod@ams-prod-redis-master.ams-prod.svc.cluster.local:6379
+  - name: SENTRY_DSN
+    value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
+  - name: SENTRY_ENVIRONMENT
+    value: "alpha"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/bravo-deploy.tmpl.yaml
+++ b/ops/bravo-deploy.tmpl.yaml
@@ -99,6 +99,10 @@ extraEnvVars: &envVars
     value: prod
   - name: REDIS_SERVER
     value: redis://:prod@ams-prod-redis-master.ams-prod.svc.cluster.local:6379
+  - name: SENTRY_DSN
+    value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
+  - name: SENTRY_ENVIRONMENT
+    value: "bravo"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/charlie-deploy.tmpl.yaml
+++ b/ops/charlie-deploy.tmpl.yaml
@@ -85,6 +85,10 @@ extraEnvVars: &envVars
     value: ams-prod
   - name: REDIS_SERVER
     value: redis://:prod@ams-charlie-redis-master:6379
+  - name: SENTRY_DSN
+    value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
+  - name: SENTRY_ENVIRONMENT
+    value: "charlie"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/delta-deploy.tmpl.yaml
+++ b/ops/delta-deploy.tmpl.yaml
@@ -85,6 +85,10 @@ extraEnvVars: &envVars
     value: ams-prod
   - name: REDIS_SERVER
     value: redis://:prod@ams-delta-redis-master:6379
+  - name: SENTRY_DSN
+    value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
+  - name: SENTRY_ENVIRONMENT
+    value: "delta"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -96,6 +96,10 @@ extraEnvVars: &envVars
     value: ams-demo
   - name: REDIS_SERVER
     value: redis://:demo@ams-demo-redis-master:6379
+  - name: SENTRY_DSN
+    value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
+  - name: SENTRY_ENVIRONMENT
+    value: "staging"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -99,7 +99,7 @@ extraEnvVars: &envVars
   - name: SENTRY_DSN
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
-    value: "staging"
+    value: "demo"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/prod-deploy.tmpl.yaml
+++ b/ops/prod-deploy.tmpl.yaml
@@ -95,6 +95,10 @@ extraEnvVars: &envVars
     value: ams-prod
   - name: REDIS_SERVER
     value: redis://:prod@ams-prod-redis-master:6379
+  - name: SENTRY_DSN
+    value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
+  - name: SENTRY_ENVIRONMENT
+    value: "production"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "false"
   - name: SOLR_HOST

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -84,6 +84,10 @@ extraEnvVars: &envVars
     value: gbh
   - name: REDIS_SERVER
     value: redis://:staging@gbh-staging-redis-master:6379
+  - name: SENTRY_DSN
+    value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
+  - name: SENTRY_ENVIRONMENT
+    value: "staging"
   - name: SETTINGS__ACTIVE_JOB__QUEUE_ADAPTER
     value: sidekiq
   - name: SETTINGS__BULKRAX__ENABLED
@@ -116,8 +120,6 @@ extraEnvVars: &envVars
     value: http://admin:$SOLR_PASSWORD@solr.staging-solr.svc.cluster.local:8983/solr/ams-staging
   - name: SIDEKIQ_CONCURRENCY
     value: "10"
-  - name: SENTRY_DSN
-    value: $SENTRY_DSN
 
 worker:
   replicaCount: 1


### PR DESCRIPTION
We did not have this application configured to report errors. This PR sets up sentry reporting for all environments so we can monitor our rails 6 upgrade.

Issue:
- https://github.com/scientist-softserv/ams/issues/76