### PR TITLE
✅ Fix asset spec

### DIFF
--- a/spec/support/asset_form_helpers.rb
+++ b/spec/support/asset_form_helpers.rb
@@ -101,7 +101,7 @@ module AssetFormHelpers
   #  `index` to specify which description you want to set. If no index is given
   #  it will set the last one found.
   def fill_in_description(description, index: nil)
-    description_value_input(index).set description
+    description_value_input(index).send_keys description
   end
 
   # Selects a description type.


### PR DESCRIPTION
This commit will favor the #send_keys method over the #set method for filling in the asset form. This is because the #set method was causing a weird error.