### PR TITLE
🐛 Fix divider in `user_util_links`

### DIFF
--- a/app/views_rails_6_1/_user_util_links.html.erb
+++ b/app/views_rails_6_1/_user_util_links.html.erb
@@ -22,8 +22,8 @@
         <%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path, class: "dropdown-item" %>
         <div class="dropdown-divider"></div>
         <%= link_to t("ams.toolbar.profile.edit_registration"), main_app.edit_user_registration_path, class: "dropdown-item" %>
-        <div class="dropdown-divider"></div>
         <% if current_user.ability.admin? %>
+          <div class="dropdown-divider"></div>
           <%= link_to t("ams.toolbar.profile.create_user"), main_app.new_admin_user_path, class: "dropdown-item" %>
         <% end %>
         <div class="dropdown-divider"></div>


### PR DESCRIPTION
This commit will put the divider within the conditional so it won't show up for regular users.

Ref:
  - https://github.com/scientist-softserv/ams/issues/83

Before:
<img width="234" alt="image" src="https://github.com/WGBH-MLA/ams/assets/19597776/b1b8ee74-5cc7-48e4-aac3-5cb07bfb3153">

After:
<img width="227" alt="image" src="https://github.com/WGBH-MLA/ams/assets/19597776/5632c4de-0da1-4a1f-be67-54a0f2954443">
