### PR TITLE
:gear: add sentry-ruby to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,12 @@ group :development do
   # gem 'spring-watcher-listen', '~> 2.0.0'
   gem "letter_opener"
   gem 'faker'
+  # Sentry-ruby for error handling
+  gem "sentry-ruby"
+  gem "sentry-rails"
+  gem "sentry-sidekiq"
+  gem "sentry-resque"
+  gem "sentry-opentelemetry"
   # gem 'xray-rails' should be commented out when actively using sidekiq.
 end
 
@@ -123,12 +129,6 @@ gem 'database_cleaner'
 gem 'redlock', '~> 1.0'
 gem 'httparty', '~> 0.21'
 
-# Sentry-ruby for error handling
-gem "sentry-ruby"
-gem "sentry-rails"
-gem "sentry-sidekiq"
-gem "sentry-resque"
-gem "sentry-opentelemetry"
 # Adding pry to all environments, because it's very useful for debugging
 # production environments on demo instances.
 gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -123,7 +123,7 @@ gem 'database_cleaner'
 gem 'redlock', '~> 1.0'
 gem 'httparty', '~> 0.21'
 
-# Sentry-raven for error handling
+# Sentry-ruby for error handling
 gem "sentry-ruby"
 
 # Adding pry to all environments, because it's very useful for debugging

--- a/Gemfile
+++ b/Gemfile
@@ -127,7 +127,6 @@ gem 'httparty', '~> 0.21'
 gem "sentry-ruby"
 gem "sentry-rails"
 gem "sentry-sidekiq"
-gem "sentry-resque"
 
 # Adding pry to all environments, because it's very useful for debugging
 # production environments on demo instances.

--- a/Gemfile
+++ b/Gemfile
@@ -98,11 +98,6 @@ group :development do
   # gem 'spring-watcher-listen', '~> 2.0.0'
   gem "letter_opener"
   gem 'faker'
-  # Sentry-ruby for error handling
-  gem "sentry-ruby"
-  gem "sentry-rails"
-  gem "sentry-sidekiq"
-  gem "sentry-resque"
   # gem 'xray-rails' should be commented out when actively using sidekiq.
 end
 
@@ -127,6 +122,12 @@ gem 'react-rails'
 gem 'database_cleaner'
 gem 'redlock', '~> 1.0'
 gem 'httparty', '~> 0.21'
+
+# Sentry-ruby for error handling
+gem "sentry-ruby"
+gem "sentry-rails"
+gem "sentry-sidekiq"
+gem "sentry-resque"
 
 # Adding pry to all environments, because it's very useful for debugging
 # production environments on demo instances.

--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,10 @@ gem 'httparty', '~> 0.21'
 
 # Sentry-ruby for error handling
 gem "sentry-ruby"
-
+gem "sentry-rails"
+gem "sentry-sidekiq"
+gem "sentry-resque"
+gem "sentry-opentelemetry"
 # Adding pry to all environments, because it's very useful for debugging
 # production environments on demo instances.
 gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,6 @@ group :development do
   gem "sentry-rails"
   gem "sentry-sidekiq"
   gem "sentry-resque"
-  gem "sentry-opentelemetry"
   # gem 'xray-rails' should be commented out when actively using sidekiq.
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,9 @@ gem 'database_cleaner'
 gem 'redlock', '~> 1.0'
 gem 'httparty', '~> 0.21'
 
+# Sentry-raven for error handling
+gem "sentry-ruby"
+
 # Adding pry to all environments, because it's very useful for debugging
 # production environments on demo instances.
 gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -624,12 +624,9 @@ GEM
     mini_mime (1.1.1)
     mini_portile2 (2.8.0)
     minitest (5.17.0)
-    mono_logger (1.1.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    mustermann (3.0.0)
-      ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.3)
     nest (3.2.0)
       redic
@@ -690,8 +687,6 @@ GEM
       rdf
     racc (1.6.1)
     rack (2.2.4)
-    rack-protection (3.1.0)
-      rack (~> 2.2, >= 2.2.4)
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -809,11 +804,6 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    resque (2.6.0)
-      mono_logger (~> 1.0)
-      multi_json (~> 1.0)
-      redis-namespace (~> 1.6)
-      sinatra (>= 0.9.2)
     retriable (3.1.2)
     rexml (3.2.5)
     roo (2.7.1)
@@ -904,9 +894,6 @@ GEM
     sentry-rails (5.10.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.10.0)
-    sentry-resque (5.10.0)
-      resque (>= 1.24)
-      sentry-ruby (~> 5.10.0)
     sentry-ruby (5.10.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     sentry-sidekiq (5.10.0)
@@ -935,11 +922,6 @@ GEM
     simple_form (5.0.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
-    sinatra (3.1.0)
-      mustermann (~> 3.0)
-      rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.1.0)
-      tilt (~> 2.0)
     slop (4.9.1)
     solr_wrapper (2.2.0)
       faraday
@@ -1078,7 +1060,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   sentry-rails
-  sentry-resque
   sentry-ruby
   sentry-sidekiq
   shoulda-matchers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -624,9 +624,12 @@ GEM
     mini_mime (1.1.1)
     mini_portile2 (2.8.0)
     minitest (5.17.0)
+    mono_logger (1.1.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    mustermann (3.0.0)
+      ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.3)
     nest (3.2.0)
       redic
@@ -655,6 +658,18 @@ GEM
       rack (>= 1.2, < 3)
     openseadragon (0.6.0)
       rails (> 3.2.0)
+    opentelemetry-api (1.1.0)
+    opentelemetry-common (0.19.7)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-registry (0.2.0)
+      opentelemetry-api (~> 1.1)
+    opentelemetry-sdk (1.2.1)
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.19.3)
+      opentelemetry-registry (~> 0.2)
+      opentelemetry-semantic_conventions
+    opentelemetry-semantic_conventions (1.10.0)
+      opentelemetry-api (~> 1.0)
     orm_adapter (0.5.0)
     os (1.1.1)
     parallel (1.21.0)
@@ -687,6 +702,8 @@ GEM
       rdf
     racc (1.6.1)
     rack (2.2.4)
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -804,6 +821,11 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    resque (2.6.0)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 0.9.2)
     retriable (3.1.2)
     rexml (3.2.5)
     roo (2.7.1)
@@ -891,11 +913,20 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sentry-opentelemetry (5.10.0)
+      opentelemetry-sdk (~> 1.0)
+      sentry-ruby (~> 5.10.0)
     sentry-rails (5.10.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.10.0)
+    sentry-resque (5.10.0)
+      resque (>= 1.24)
+      sentry-ruby (~> 5.10.0)
     sentry-ruby (5.10.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.10.0)
+      sentry-ruby (~> 5.10.0)
+      sidekiq (>= 3.0)
     shex (0.6.3)
       ebnf (~> 2.1, >= 2.2)
       htmlentities (~> 4.3)
@@ -919,6 +950,11 @@ GEM
     simple_form (5.0.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
+    sinatra (3.1.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.1.0)
+      tilt (~> 2.0)
     slop (4.9.1)
     solr_wrapper (2.2.0)
       faraday
@@ -1056,8 +1092,11 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   selenium-webdriver
+  sentry-opentelemetry
   sentry-rails
+  sentry-resque
   sentry-ruby
+  sentry-sidekiq
   shoulda-matchers
   sidekiq
   simple_form (= 5.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -891,6 +891,9 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sentry-rails (5.10.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.10.0)
     sentry-ruby (5.10.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shex (0.6.3)
@@ -1053,6 +1056,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   selenium-webdriver
+  sentry-rails
   sentry-ruby
   shoulda-matchers
   sidekiq

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -891,6 +891,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sentry-ruby (5.10.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     shex (0.6.3)
       ebnf (~> 2.1, >= 2.2)
       htmlentities (~> 4.3)
@@ -1051,6 +1053,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   selenium-webdriver
+  sentry-ruby
   shoulda-matchers
   sidekiq
   simple_form (= 5.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -658,18 +658,6 @@ GEM
       rack (>= 1.2, < 3)
     openseadragon (0.6.0)
       rails (> 3.2.0)
-    opentelemetry-api (1.1.0)
-    opentelemetry-common (0.19.7)
-      opentelemetry-api (~> 1.0)
-    opentelemetry-registry (0.2.0)
-      opentelemetry-api (~> 1.1)
-    opentelemetry-sdk (1.2.1)
-      opentelemetry-api (~> 1.1)
-      opentelemetry-common (~> 0.19.3)
-      opentelemetry-registry (~> 0.2)
-      opentelemetry-semantic_conventions
-    opentelemetry-semantic_conventions (1.10.0)
-      opentelemetry-api (~> 1.0)
     orm_adapter (0.5.0)
     os (1.1.1)
     parallel (1.21.0)
@@ -913,9 +901,6 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-opentelemetry (5.10.0)
-      opentelemetry-sdk (~> 1.0)
-      sentry-ruby (~> 5.10.0)
     sentry-rails (5.10.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.10.0)
@@ -1092,7 +1077,6 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   selenium-webdriver
-  sentry-opentelemetry
   sentry-rails
   sentry-resque
   sentry-ruby

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -971,6 +971,9 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
+    sentry-rails (5.10.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.10.0)
     sentry-ruby (5.10.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shacl (0.3.0)
@@ -1172,6 +1175,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 6.0)
   selenium-webdriver
+  sentry-rails
   sentry-ruby
   shoulda-matchers
   sidekiq (~> 6.4.0)

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -694,18 +694,6 @@ GEM
       rack (>= 1.2, < 4)
     openseadragon (0.6.0)
       rails (> 3.2.0)
-    opentelemetry-api (1.1.0)
-    opentelemetry-common (0.19.7)
-      opentelemetry-api (~> 1.0)
-    opentelemetry-registry (0.2.0)
-      opentelemetry-api (~> 1.1)
-    opentelemetry-sdk (1.2.1)
-      opentelemetry-api (~> 1.1)
-      opentelemetry-common (~> 0.19.3)
-      opentelemetry-registry (~> 0.2)
-      opentelemetry-semantic_conventions
-    opentelemetry-semantic_conventions (1.10.0)
-      opentelemetry-api (~> 1.0)
     orm_adapter (0.5.0)
     os (1.1.4)
     ostruct (0.5.5)
@@ -989,9 +977,6 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
-    sentry-opentelemetry (5.10.0)
-      opentelemetry-sdk (~> 1.0)
-      sentry-ruby (~> 5.10.0)
     sentry-rails (5.10.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.10.0)
@@ -1202,7 +1187,6 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 6.0)
   selenium-webdriver
-  sentry-opentelemetry
   sentry-rails
   sentry-resque
   sentry-ruby

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -648,7 +648,6 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
     minitest (5.19.0)
-    mono_logger (1.1.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
@@ -887,11 +886,6 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    resque (2.6.0)
-      mono_logger (~> 1.0)
-      multi_json (~> 1.0)
-      redis-namespace (~> 1.6)
-      sinatra (>= 0.9.2)
     retriable (3.1.2)
     rexml (3.2.6)
     roo (2.7.1)
@@ -979,9 +973,6 @@ GEM
     semantic_range (3.0.0)
     sentry-rails (5.10.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.10.0)
-    sentry-resque (5.10.0)
-      resque (>= 1.24)
       sentry-ruby (~> 5.10.0)
     sentry-ruby (5.10.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -1188,7 +1179,6 @@ DEPENDENCIES
   sass-rails (~> 6.0)
   selenium-webdriver
   sentry-rails
-  sentry-resque
   sentry-ruby
   sentry-sidekiq
   shoulda-matchers

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -971,6 +971,8 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
+    sentry-ruby (5.10.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     shacl (0.3.0)
       json-ld (~> 3.2)
       rdf (~> 3.2, >= 3.2.8)
@@ -1170,6 +1172,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 6.0)
   selenium-webdriver
+  sentry-ruby
   shoulda-matchers
   sidekiq (~> 6.4.0)
   simple_form (= 5.0.0)

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -648,6 +648,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
     minitest (5.19.0)
+    mono_logger (1.1.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
@@ -693,6 +694,18 @@ GEM
       rack (>= 1.2, < 4)
     openseadragon (0.6.0)
       rails (> 3.2.0)
+    opentelemetry-api (1.1.0)
+    opentelemetry-common (0.19.7)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-registry (0.2.0)
+      opentelemetry-api (~> 1.1)
+    opentelemetry-sdk (1.2.1)
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.19.3)
+      opentelemetry-registry (~> 0.2)
+      opentelemetry-semantic_conventions
+    opentelemetry-semantic_conventions (1.10.0)
+      opentelemetry-api (~> 1.0)
     orm_adapter (0.5.0)
     os (1.1.4)
     ostruct (0.5.5)
@@ -886,6 +899,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    resque (2.6.0)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 0.9.2)
     retriable (3.1.2)
     rexml (3.2.6)
     roo (2.7.1)
@@ -971,11 +989,20 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
+    sentry-opentelemetry (5.10.0)
+      opentelemetry-sdk (~> 1.0)
+      sentry-ruby (~> 5.10.0)
     sentry-rails (5.10.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.10.0)
+    sentry-resque (5.10.0)
+      resque (>= 1.24)
+      sentry-ruby (~> 5.10.0)
     sentry-ruby (5.10.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.10.0)
+      sentry-ruby (~> 5.10.0)
+      sidekiq (>= 3.0)
     shacl (0.3.0)
       json-ld (~> 3.2)
       rdf (~> 3.2, >= 3.2.8)
@@ -1175,8 +1202,11 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 6.0)
   selenium-webdriver
+  sentry-opentelemetry
   sentry-rails
+  sentry-resque
   sentry-ruby
+  sentry-sidekiq
   shoulda-matchers
   sidekiq (~> 6.4.0)
   simple_form (= 5.0.0)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,5 @@
+require 'sentry-ruby'
+
 # in Rails, this might be in config/initializers/sentry.rb
 Sentry.init do |config|
   config.dsn = ENV['SENTRY_DSN']

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -12,4 +12,4 @@ Sentry.init do |config|
   config.traces_sampler = lambda do |context|
     true
   end
-end
+end unless Rails.env.test?

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,7 +9,7 @@ Sentry.init do |config|
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production.
-  config.traces_sample_rate = 1.0
+  config.traces_sample_rate = ENV['SENTRY_TRACES_SAMPLE_RATE'].to_f
   # or
   # config.traces_sampler = lambda do |context|
   #   true

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,15 @@
+# in Rails, this might be in config/initializers/sentry.rb
+Sentry.init do |config|
+  config.dsn = ENV['SENTRY_DSN']
+  config.environment = ENV['SENTRY_ENVIRONMENT']
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+
+  # Set traces_sample_rate to 1.0 to capture 100%
+  # of transactions for performance monitoring.
+  # We recommend adjusting this value in production.
+  config.traces_sample_rate = 1.0
+  # or
+  config.traces_sampler = lambda do |context|
+    true
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,7 +9,7 @@ Sentry.init do |config|
   # We recommend adjusting this value in production.
   config.traces_sample_rate = 1.0
   # or
-  config.traces_sampler = lambda do |context|
-    true
-  end
+  # config.traces_sampler = lambda do |context|
+  #   true
+  # end
 end unless Rails.env.test?

--- a/ops/alpha-deploy.tmpl.yaml
+++ b/ops/alpha-deploy.tmpl.yaml
@@ -101,6 +101,8 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "alpha"
+  - name: SENTRY_TRACES_SAMPLE_RATE`
+    value: "0.1"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/bravo-deploy.tmpl.yaml
+++ b/ops/bravo-deploy.tmpl.yaml
@@ -104,7 +104,7 @@ extraEnvVars: &envVars
   - name: SENTRY_ENVIRONMENT
     value: "bravo"
   - name: SENTRY_TRACES_SAMPLE_RATE`
-    value: "0.1"
+    value: "1.0"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/bravo-deploy.tmpl.yaml
+++ b/ops/bravo-deploy.tmpl.yaml
@@ -103,6 +103,8 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "bravo"
+  - name: SENTRY_TRACES_SAMPLE_RATE`
+    value: "0.1"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/charlie-deploy.tmpl.yaml
+++ b/ops/charlie-deploy.tmpl.yaml
@@ -89,6 +89,8 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "charlie"
+  - name: SENTRY_TRACES_SAMPLE_RATE`
+    value: "0.1"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/delta-deploy.tmpl.yaml
+++ b/ops/delta-deploy.tmpl.yaml
@@ -89,6 +89,8 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "delta"
+  - name: SENTRY_TRACES_SAMPLE_RATE`
+    value: "0.1"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -101,7 +101,7 @@ extraEnvVars: &envVars
   - name: SENTRY_ENVIRONMENT
     value: "demo"
   - name: SENTRY_TRACES_SAMPLE_RATE`
-    value: "0.1"
+    value: "1.0"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -100,6 +100,8 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "demo"
+  - name: SENTRY_TRACES_SAMPLE_RATE`
+    value: "0.1"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"
   - name: SOLR_HOST

--- a/ops/prod-deploy.tmpl.yaml
+++ b/ops/prod-deploy.tmpl.yaml
@@ -99,6 +99,8 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "production"
+  - name: SENTRY_TRACES_SAMPLE_RATE`
+    value: "0.1"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "false"
   - name: SOLR_HOST

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -89,7 +89,7 @@ extraEnvVars: &envVars
   - name: SENTRY_ENVIRONMENT
     value: "staging"
   - name: SENTRY_TRACES_SAMPLE_RATE`
-    value: "0.1"
+    value: "1.0"
   - name: SETTINGS__ACTIVE_JOB__QUEUE_ADAPTER
     value: sidekiq
   - name: SETTINGS__BULKRAX__ENABLED

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -88,6 +88,8 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "staging"
+  - name: SENTRY_TRACES_SAMPLE_RATE`
+    value: "0.1"
   - name: SETTINGS__ACTIVE_JOB__QUEUE_ADAPTER
     value: sidekiq
   - name: SETTINGS__BULKRAX__ENABLED


### PR DESCRIPTION
I previously set the SENTRY_DSN for each environment but did not notice sentry wasn't part of the Gemfile. Our other projects use sentry-raven which is deprecated, so this commit installs [sentry-ruby](https://github.com/getsentry/sentry-ruby) to track errors in different enviornments.

Follow up for Issue:
- https://github.com/scientist-softserv/ams/issues/76

ref: 
- https://github.com/scientist-softserv/ams/issues/89

Sentry-ruby docs [recommends](https://github.com/getsentry/sentry-ruby#getting-started) installing the following. I added all but delayed_job and resque since we use sidekiq instead. I also excluded "sentry-opentelemetry". At a minimum, sentry-ruby and sentry-rails is required.

```ruby
gem "sentry-rails"
gem "sentry-sidekiq"
gem "sentry-delayed_job"
gem "sentry-resque"
gem "sentry-opentelemetry"
```

Do we need a config file? (tested locally, it seems like we do)

```ruby
# config/initializer/sentry.rb
Sentry.init do |config|
  config.dsn = ENV['SENTRY_DSN']
  config.environment = ENV['SENTRY_ENVIRONMENT']
end

```

I was able to successfully trigger and capture an error from my local environment after doing so: 

![image](https://github.com/WGBH-MLA/ams/assets/10081604/66090480-990a-43bd-ad13-308ed00045c0)

# Notes

FYI: performance monitoring and tracing systems like Sentry, the term ["traces sample rate"](https://docs.sentry.io/platforms/javascript/performance/#configure-the-sample-rate) refers to the proportion or percentage of requests or transactions that are actually captured and sent to the monitoring system for analysis. It's a way to manage the amount of data being collected and transmitted while still gaining insights into the performance of your application.

For example, if you have a traces sample rate of 10%, it means that only 10% of the requests your application receives will have their performance data (traces) collected and sent to the monitoring system like Sentry. The remaining 90% of requests will not be captured, reducing the overall data volume and potential impact on your application's performance and network resources.

A common approach could be to set the traces sample rate in staging to around 30-50% initially, and then monitor the performance impact. You can then adjust the sample rate up or down based on the factors (like: performance impact, budget, traffic volume, debugging needs, and resource usage) and how well your staging environment can handle the additional load.

So in staging I'm setting it to 100% for now. We can monitor and adjust the env variable. In prod I set it to 10% as requested by Rob.