### PR TITLE
🐛 Timeout when creating new work via UI

### DIFF
--- a/app/services/hyrax/admin_set_create_service_decorator.rb
+++ b/app/services/hyrax/admin_set_create_service_decorator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax 4.0.0 AdminSetCreateService to return first admin set (default)
+# until timeout issue is resolved
+module Hyrax
+  module AdminSetCreateServiceDecorator
+    private
+
+    def find_default_admin_set
+      if App.rails_5_1?
+        super
+      else
+        AdminSet.first
+      end
+    end
+  end
+end
+
+Hyrax::AdminSetCreateService.singleton_class.send(:prepend, Hyrax::AdminSetCreateServiceDecorator)

--- a/app/views_rails_6_1/records/edit_fields/_default.html.erb
+++ b/app/views_rails_6_1/records/edit_fields/_default.html.erb
@@ -1,6 +1,6 @@
 <% if f.object.class.multiple? key %>
   <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key), readonly:f.object.respond_to?(:readonly?) && f.object.readonly?(key) , required: f.object.required?(key) %>
-<% elsif f.object.class.hidden? key %>
+<% elsif f.object.class.try(:hidden?, key) %>
   <%= f.input key, required: f.object.required?(key), as: :hidden %>
 <% else %>
   <%= f.input key, required: f.object.required?(key), disabled:f.object.respond_to?(:disabled?) && f.object.disabled?(key),  readonly:f.object.respond_to?(:readonly?) && f.object.readonly?(key)  %>


### PR DESCRIPTION
🐛 Override AdminSetCreateService

refs 
- https://github.com/samvera/hyrax/issues/6171
- https://github.com/scientist-softserv/ams/issues/85

Finding the default admin set ID results in a timeout for large admin sets. Override to use the first admin set until Hyrax ticket above is completed.

🎁 Edit fields form exception workaround

Add try to view to prevent no-method exception on hidden? `f.object.class.try(:hidden?, key)`
