### PR TITLE
🧹 Upgrade Sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ if ENV['DEPENDENCIES_NEXT'] && !ENV['DEPENDENCIES_NEXT'].empty?
     gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', branch: 'gbh-patch'
     gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
   end
-  gem 'sidekiq', '~> 6.4.0'
+  gem 'sidekiq', '~> 6.5.6'
 else
   # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
   gem 'rails', '~> 5.1.5'
@@ -98,7 +98,7 @@ group :development do
   # gem 'spring-watcher-listen', '~> 2.0.0'
   gem "letter_opener"
   gem 'faker'
-  # gem 'xray-rails' should be commented out when actively using sidekiq.
+  # gem 'xray-rails' # should be commented out when actively using sidekiq.
 end
 
 gem 'rsolr', '>= 1.0'

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -987,10 +987,10 @@ GEM
       sxp (~> 1.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.4.2)
-      connection_pool (>= 2.2.2)
+    sidekiq (6.5.9)
+      connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
-      redis (>= 4.2.0)
+      redis (>= 4.5.0, < 5)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -1171,7 +1171,7 @@ DEPENDENCIES
   sass-rails (~> 6.0)
   selenium-webdriver
   shoulda-matchers
-  sidekiq (~> 6.4.0)
+  sidekiq (~> 6.5.6)
   simple_form (= 5.0.0)
   solr_wrapper (~> 2.1)
   sony_ci_api!


### PR DESCRIPTION
This commit will upgrade Sidekiq to 6.5.9 to remove the deprecation warning spam.

Ref:
  - https://github.com/scientist-softserv/ams/issues/88