### PR TITLE
:gear: remove sentry-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,9 +124,9 @@ gem 'redlock', '~> 1.0'
 gem 'httparty', '~> 0.21'
 
 # Sentry-ruby for error handling
-gem "sentry-ruby"
-gem "sentry-rails"
-gem "sentry-sidekiq"
+gem "sentry-ruby", "5.4.2"
+gem "sentry-rails", "5.4.2"
+gem "sentry-sidekiq", "5.4.2"
 
 # Adding pry to all environments, because it's very useful for debugging
 # production environments on demo instances.

--- a/Gemfile
+++ b/Gemfile
@@ -124,9 +124,9 @@ gem 'redlock', '~> 1.0'
 gem 'httparty', '~> 0.21'
 
 # Sentry-ruby for error handling
-gem "sentry-ruby", "5.4.2"
-gem "sentry-rails", "5.4.2"
-gem "sentry-sidekiq", "5.4.2"
+gem "sentry-ruby"
+# gem "sentry-rails"
+# gem "sentry-sidekiq"
 
 # Adding pry to all environments, because it's very useful for debugging
 # production environments on demo instances.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -891,14 +891,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-rails (5.4.2)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.4.2)
     sentry-ruby (5.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.4.2)
-      sentry-ruby (~> 5.4.2)
-      sidekiq (>= 3.0)
     shex (0.6.3)
       ebnf (~> 2.1, >= 2.2)
       htmlentities (~> 4.3)
@@ -1059,9 +1053,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   selenium-webdriver
-  sentry-rails (= 5.4.2)
-  sentry-ruby (= 5.4.2)
-  sentry-sidekiq (= 5.4.2)
+  sentry-ruby
   shoulda-matchers
   sidekiq
   simple_form (= 5.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -891,13 +891,13 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-rails (5.10.0)
+    sentry-rails (5.4.2)
       railties (>= 5.0)
-      sentry-ruby (~> 5.10.0)
-    sentry-ruby (5.10.0)
+      sentry-ruby (~> 5.4.2)
+    sentry-ruby (5.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.10.0)
-      sentry-ruby (~> 5.10.0)
+    sentry-sidekiq (5.4.2)
+      sentry-ruby (~> 5.4.2)
       sidekiq (>= 3.0)
     shex (0.6.3)
       ebnf (~> 2.1, >= 2.2)
@@ -1059,9 +1059,9 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   selenium-webdriver
-  sentry-rails
-  sentry-ruby
-  sentry-sidekiq
+  sentry-rails (= 5.4.2)
+  sentry-ruby (= 5.4.2)
+  sentry-sidekiq (= 5.4.2)
   shoulda-matchers
   sidekiq
   simple_form (= 5.0.0)

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -672,7 +672,7 @@ GEM
     noid-rails (3.1.0)
       actionpack (>= 5.0.0, < 7.1)
       noid (~> 0.9)
-    nokogiri (1.15.3)
+    nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oai (1.2.1)
@@ -971,13 +971,13 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
-    sentry-rails (5.10.0)
+    sentry-rails (5.4.2)
       railties (>= 5.0)
-      sentry-ruby (~> 5.10.0)
-    sentry-ruby (5.10.0)
+      sentry-ruby (~> 5.4.2)
+    sentry-ruby (5.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.10.0)
-      sentry-ruby (~> 5.10.0)
+    sentry-sidekiq (5.4.2)
+      sentry-ruby (~> 5.4.2)
       sidekiq (>= 3.0)
     shacl (0.3.0)
       json-ld (~> 3.2)
@@ -1178,9 +1178,9 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 6.0)
   selenium-webdriver
-  sentry-rails
-  sentry-ruby
-  sentry-sidekiq
+  sentry-rails (= 5.4.2)
+  sentry-ruby (= 5.4.2)
+  sentry-sidekiq (= 5.4.2)
   shoulda-matchers
   sidekiq (~> 6.5.6)
   simple_form (= 5.0.0)

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -971,14 +971,8 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
-    sentry-rails (5.4.2)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.4.2)
     sentry-ruby (5.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.4.2)
-      sentry-ruby (~> 5.4.2)
-      sidekiq (>= 3.0)
     shacl (0.3.0)
       json-ld (~> 3.2)
       rdf (~> 3.2, >= 3.2.8)
@@ -1178,9 +1172,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 6.0)
   selenium-webdriver
-  sentry-rails (= 5.4.2)
-  sentry-ruby (= 5.4.2)
-  sentry-sidekiq (= 5.4.2)
+  sentry-ruby
   shoulda-matchers
   sidekiq (~> 6.5.6)
   simple_form (= 5.0.0)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -8,7 +8,7 @@ Sentry.init do |config|
 
   # report exceptions rescued by ActionDispatch::ShowExceptions or ActionDispatch::DebugExceptions middlewares
   # the default value is true
-  config.rails.report_rescued_exceptions = true
+  # config.rails.report_rescued_exceptions = true
 
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for performance monitoring.

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,6 +6,10 @@ Sentry.init do |config|
   config.environment = ENV['SENTRY_ENVIRONMENT']
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
+  # report exceptions rescued by ActionDispatch::ShowExceptions or ActionDispatch::DebugExceptions middlewares
+  # the default value is true
+  config.rails.report_rescued_exceptions = true
+
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production.


### PR DESCRIPTION
We are noticing weird behavior with bulkrax imports that is related to sentry-rails beings installed. ~I rolled back to version 5.4.2 to match the version of our other hyrax x bulkrax projects.~ I am reverting this for now and will get help for this later. Additionally, I tried to roll it back to the deprecated sentry-raven gem but that caused conflicts with the other upgrades.