### PR TITLE
:gear: set bravo env var to use the batches endpoint

### DIFF
--- a/ops/bravo-deploy.tmpl.yaml
+++ b/ops/bravo-deploy.tmpl.yaml
@@ -106,7 +106,7 @@ extraEnvVars: &envVars
   - name: SENTRY_TRACES_SAMPLE_RATE`
     value: "1.0"
   - name: SETTINGS__BULKRAX__ENABLED
-    value: "true"
+    value: "false"
   - name: SOLR_HOST
     value: 10.0.4.93
   - name: SOLR_PORT


### PR DESCRIPTION
This sets SETTINGS__BULKRAX__ENABLED to false on deploys to bravo.