### PR TITLE
:broom: fix typo for env var

### DIFF
--- a/ops/alpha-deploy.tmpl.yaml
+++ b/ops/alpha-deploy.tmpl.yaml
@@ -101,7 +101,7 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "alpha"
-  - name: SENTRY_TRACES_SAMPLE_RATE`
+  - name: SENTRY_TRACES_SAMPLE_RATE
     value: "0.1"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"

--- a/ops/bravo-deploy.tmpl.yaml
+++ b/ops/bravo-deploy.tmpl.yaml
@@ -103,7 +103,7 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "bravo"
-  - name: SENTRY_TRACES_SAMPLE_RATE`
+  - name: SENTRY_TRACES_SAMPLE_RATE
     value: "1.0"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"

--- a/ops/charlie-deploy.tmpl.yaml
+++ b/ops/charlie-deploy.tmpl.yaml
@@ -89,7 +89,7 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "charlie"
-  - name: SENTRY_TRACES_SAMPLE_RATE`
+  - name: SENTRY_TRACES_SAMPLE_RATE
     value: "0.1"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"

--- a/ops/delta-deploy.tmpl.yaml
+++ b/ops/delta-deploy.tmpl.yaml
@@ -89,7 +89,7 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "delta"
-  - name: SENTRY_TRACES_SAMPLE_RATE`
+  - name: SENTRY_TRACES_SAMPLE_RATE
     value: "0.1"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -100,7 +100,7 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "demo"
-  - name: SENTRY_TRACES_SAMPLE_RATE`
+  - name: SENTRY_TRACES_SAMPLE_RATE
     value: "1.0"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "true"

--- a/ops/prod-deploy.tmpl.yaml
+++ b/ops/prod-deploy.tmpl.yaml
@@ -99,7 +99,7 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "production"
-  - name: SENTRY_TRACES_SAMPLE_RATE`
+  - name: SENTRY_TRACES_SAMPLE_RATE
     value: "0.1"
   - name: SETTINGS__BULKRAX__ENABLED
     value: "false"

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -88,7 +88,7 @@ extraEnvVars: &envVars
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT
     value: "staging"
-  - name: SENTRY_TRACES_SAMPLE_RATE`
+  - name: SENTRY_TRACES_SAMPLE_RATE
     value: "1.0"
   - name: SETTINGS__ACTIVE_JOB__QUEUE_ADAPTER
     value: sidekiq


### PR DESCRIPTION
Deploys failed because of an accidental typo in SENTRY_TRACES_SAMPLE_RATE