### PR TITLE
Update ENV value of bravo and charlie-deploy.tmpl.yaml

### DIFF
--- a/ops/bravo-deploy.tmpl.yaml
+++ b/ops/bravo-deploy.tmpl.yaml
@@ -106,7 +106,7 @@ extraEnvVars: &envVars
   - name: SENTRY_TRACES_SAMPLE_RATE
     value: "1.0"
   - name: SETTINGS__BULKRAX__ENABLED
-    value: "false"
+    value: "true"
   - name: SOLR_HOST
     value: 10.0.4.93
   - name: SOLR_PORT

--- a/ops/charlie-deploy.tmpl.yaml
+++ b/ops/charlie-deploy.tmpl.yaml
@@ -81,7 +81,7 @@ extraEnvVars: &envVars
   - name: LD_LIBRARY_PATH
     value: /app/fits/tools/mediainfo/linux
   - name: RAILS_CACHE_STORE_URL
-    value: redis://:demo@ams-demo-redis-master:6379/ams-demo
+    value: redis://:demo@ams-demo-redis-master.ams-demo.svc.cluster.local:6379/ams-demo
   - name: RAILS_ENV
     value: production
   - name: RAILS_LOG_TO_STDOUT
@@ -91,11 +91,11 @@ extraEnvVars: &envVars
   - name: RAILS_SERVE_STATIC_FILES
     value: "true"
   - name: REDIS_HOST
-    value: ams-demo-redis-master
+    value: ams-demo-redis-master.ams-demo.svc.cluster.local
   - name: REDIS_PREFIX
     value: ams-demo
   - name: REDIS_SERVER
-    value: redis://:demo@ams-demo-redis-master:6379
+    value: redis://:demo@ams-demo-redis-master.ams-demo.svc.cluster.local:6379
   - name: SENTRY_DSN
     value: https://6f6e6b5f54234b5bb2218786c3493a37@o1008683.ingest.sentry.io/6745030 
   - name: SENTRY_ENVIRONMENT


### PR DESCRIPTION
The previous implementation's deploy failed because it wasn't able to connect to redis. This is a follow up to PR: https://github.com/WGBH-MLA/ams/pull/790#discussion_r1307782497

CONFIRMED that this branch successfully deploys: 

<img width="996" alt="image" src="https://github.com/WGBH-MLA/ams/assets/10081604/274f51ae-07f7-4486-8fa0-f6653485b24e">
<img width="1350" alt="Screenshot 2023-08-28 at 3 27 34 PM" src="https://github.com/WGBH-MLA/ams/assets/10081604/50202b80-4ba9-4249-9fb1-836fc084f6f0">

Additionally I am also turning bulkrax on for the bravo environment.
