### PR TITLE
🐛 Fix `hyrax_batch_ingest_batch_id` facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -75,6 +75,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "language_ssim", label: "Language", limit: 5, collapse: true
     config.add_facet_field "level_of_user_access_ssim", label: "Level of user access", limit: 5, collapse: true
     config.add_facet_field "transcript_status_ssim", label: "Transcript Status", limit: 5, collapse: true
+    config.add_facet_field "hyrax_batch_ingest_batch_id_tesim"
 
     config.add_facet_field 'cataloging_status_ssim', query: {
         yes: { label: 'Yes', fq: 'cataloging_status_ssim:Yes' },


### PR DESCRIPTION
This commit will add the `hyrax_batch_ingest_batch_id` facet to the `CatalogController` so that it can be used in the UI.  It was not working when it was simply added in the `Hyrax::MyController`, so it maybe not be relevant anymore and can be removed from there.

Ref:
  - https://github.com/scientist-softserv/ams/issues/100

<img width="1209" alt="Pasted image 20230828154716" src="https://github.com/WGBH-MLA/ams/assets/19597776/4773d1db-18bf-4f2f-883a-da958e52c947">
