### PR TITLE
🐛 Handle grouped input fields

### DIFF
--- a/app/forms/asset_resource_form.rb
+++ b/app/forms/asset_resource_form.rb
@@ -16,12 +16,6 @@ class AssetResourceForm < Hyrax::Forms::ResourceForm(AssetResource)
 
   admin_data_attributes = (AdminData.attribute_names.dup - ['id', 'created_at', 'updated_at']).map &:to_sym
 
-  # Add fields that we want to be required
-  self.required_fields += [:titles_with_types, :descriptions_with_types]
-
-  # Remove fields that we don't want to be required.
-  self.required_fields -= [:creator, :keyword, :rights_statement, :title, :description]
-
   self.field_groups = {
     identifying_info: [:titles_with_types, :producing_organization, :local_identifier, :pbs_nola_code, :eidr_id, :asset_types, :dates_with_types, :descriptions_with_types],
     subject_info: [:genre, :topics, :subject, :spatial_coverage, :temporal_coverage, :audience_level, :audience_rating, :annotation],
@@ -106,7 +100,7 @@ class AssetResourceForm < Hyrax::Forms::ResourceForm(AssetResource)
     child_annotations
   end
 
-  property :titles_with_types, virtual: true
+  property :titles_with_types, virtual: true, required: true
   def titles_with_types
     titles_with_types = []
     title_type_service = TitleTypesService.new
@@ -119,7 +113,7 @@ class AssetResourceForm < Hyrax::Forms::ResourceForm(AssetResource)
     titles_with_types
   end
 
-  property :descriptions_with_types, virtual: true
+  property :descriptions_with_types, virtual: true, required: true
   def descriptions_with_types
     descriptions_with_types = []
     description_type_service = DescriptionTypesService.new

--- a/app/transactions/ams/work_create.rb
+++ b/app/transactions/ams/work_create.rb
@@ -14,7 +14,7 @@ module Ams
     ##
     # @see Hyrax::Transactions::Transaction
     def initialize(container: Container, steps: DEFAULT_STEPS)
-      super
+      super(steps: steps)
     end
   end
 end

--- a/config/metadata/asset_resource.yaml
+++ b/config/metadata/asset_resource.yaml
@@ -355,15 +355,3 @@ attributes:
       required: false
       primary: false
       multiple: true
-  titles_with_types:
-    type: string
-    form:
-      required: true
-      primary: false
-      multiple: false
-  descriptions_with_types:
-    type: string
-    form:
-      required: true
-      primary: false
-      multiple: false

--- a/lib/hyrax/transactions/steps/create_aapb_admin_data.rb
+++ b/lib/hyrax/transactions/steps/create_aapb_admin_data.rb
@@ -122,36 +122,24 @@ module Hyrax
           end
 
           def add_title_types(change_set)
-            return unless change_set.fields[:titles_with_types].present?
+            return unless change_set.fields["titles_with_types"].present?
 
             title_type_service = TitleTypesService.new
-            fill_attributes_from_typed_values(title_type_service, change_set, change_set.fields[:titles_with_types])
-
-            # Now that we're done with these attributes, remove them from the
-            # environment to avoid errors later in the save process.
-            change_set.fields.delete(:titles_with_types)
+            fill_attributes_from_typed_values(title_type_service, change_set, change_set.fields["titles_with_types"])
           end
 
           def add_description_types(change_set)
-            return unless change_set.fields[:descriptions_with_types].present?
+            return unless change_set.fields["descriptions_with_types"].present?
 
             description_type_service = DescriptionTypesService.new
-            fill_attributes_from_typed_values(description_type_service, change_set, change_set.fields[:descriptions_with_types])
-
-            # Now that we're done with these attributes, remove them from the
-            # environment to avoid errors later in the save process.
-            change_set.fields.delete(:descriptions_with_types)
+            fill_attributes_from_typed_values(description_type_service, change_set, change_set.fields["descriptions_with_types"])
           end
 
           def add_date_types(change_set)
-            return unless change_set.fields[:dates_with_types].present?
+            return unless change_set.fields["dates_with_types"].present?
 
             date_type_service = DateTypesService.new
-            fill_attributes_from_typed_values(date_type_service, change_set, change_set.fields[:dates_with_types])
-
-            # Now that we're done with these attributes, remove them from the
-            # environment to avoid errors later in the save process.
-            change_set.fields.delete(:dates_with_types)
+            fill_attributes_from_typed_values(date_type_service, change_set, change_set.fields["dates_with_types"])
           end
 
           # @param child of [AMS::TypedFieldService] type_service


### PR DESCRIPTION
Corrects loading & saving of titles_with_types, descriptions_with_types, and dates_with_types.

Marks title and description fields with "required", but does not validate that they are in, as validation messes up the format of the form and errors do not report correctly on re-display.