### PR TITLE
Removed duplicate item Radio Theater from genre authority list.

### DIFF
--- a/config/authorities/genre.yml
+++ b/config/authorities/genre.yml
@@ -44,9 +44,7 @@ terms:
   - id: Special
     term: Special
   - id: Stand-up
-    term: Stand-up
-  - id: Radio Theater
-    term: Radio Theater
+    term: Stand-up  
   - id: Talk Show
     term: Talk Show
   - id: Town Hall Meeting


### PR DESCRIPTION
The item "Radio Theater" appeared twice in the genre authority list.  The instance that was out of alphabetical order was removed.