### PR TITLE
i123 Index Bulkrax identifier to speed up query

### DIFF
--- a/db/migrate/20240307194231_add_index_to_metadata_bulkrax_identifier.rb
+++ b/db/migrate/20240307194231_add_index_to_metadata_bulkrax_identifier.rb
@@ -1,0 +1,6 @@
+class AddIndexToMetadataBulkraxIdentifier < ActiveRecord::Migration[6.1]
+  def change
+    # This creates an expression index on the first element of the bulkrax_identifier array
+    add_index :orm_resources, "(metadata -> 'bulkrax_identifier' ->> 0)", name: 'index_on_bulkrax_identifier', where: "metadata -> 'bulkrax_identifier' IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_30_155065) do
+ActiveRecord::Schema.define(version: 2024_03_07_194231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -414,6 +414,7 @@ ActiveRecord::Schema.define(version: 2023_08_30_155065) do
     t.datetime "updated_at", null: false
     t.string "internal_resource"
     t.integer "lock_version"
+    t.index "(((metadata -> 'bulkrax_identifier'::text) ->> 0))", name: "index_on_bulkrax_identifier", where: "((metadata -> 'bulkrax_identifier'::text) IS NOT NULL)"
     t.index ["internal_resource"], name: "index_orm_resources_on_internal_resource"
     t.index ["metadata"], name: "index_orm_resources_on_metadata", using: :gin
     t.index ["metadata"], name: "index_orm_resources_on_metadata_jsonb_path_ops", opclass: :jsonb_path_ops, using: :gin


### PR DESCRIPTION
Ref:
- https://github.com/scientist-softserv/ams/issues/123

Before this change, Hyrax::CustomQueries::FindByBulkraxIdentifier would take 90+ seconds to run on production which currently has 1.75 million works.