### PR TITLE
i16 missing instantiations locator script

### DIFF
--- a/app/services/ams/missing_instantiations_locator.rb
+++ b/app/services/ams/missing_instantiations_locator.rb
@@ -2,6 +2,7 @@
 require 'ruby-progressbar'
 
 module AMS
+  # @see https://github.com/scientist-softserv/ams/issues/16
   class MissingInstantiationsLocator
     WORKING_DIR = Rails.root.join('tmp', 'imports')
 
@@ -15,8 +16,7 @@ module AMS
       )
     end
 
-    # TODO: better method name
-    def locate_within_dirs
+    def map_all_instantiation_identifiers
       search_dirs.each do |current_dir|
         @current_dir = current_dir
         @truncated_dir_name = truncate_path(current_dir)
@@ -29,7 +29,7 @@ module AMS
         logger.info("Starting #{truncated_dir_name}")
 
         xml_files.each do |f|
-          locate(f)
+          map_asset_id_to_inst_ids(f)
           progressbar.increment
         end
 
@@ -39,8 +39,9 @@ module AMS
       end
     end
 
-    # TODO: better method name
-    def locate(xml_file)
+    private
+
+    def map_asset_id_to_inst_ids(xml_file)
       xml = File.read(xml_file)
       current_file_path = "#{truncated_dir_name}/#{truncate_path(xml_file)}"
 

--- a/app/services/ams/missing_instantiations_locator.rb
+++ b/app/services/ams/missing_instantiations_locator.rb
@@ -19,7 +19,7 @@ module AMS
     def map_all_instantiation_identifiers
       search_dirs.each do |current_dir|
         @current_dir = current_dir
-        @truncated_dir_name = truncate_path(current_dir)
+        @truncated_dir_name = File.basename(current_dir)
         @results_path = WORKING_DIR.join("i16-#{truncated_dir_name}.json")
         @results = initialize_results
         xml_files = Dir.glob(current_dir.join('*.xml'))
@@ -43,7 +43,7 @@ module AMS
 
     def map_asset_id_to_inst_ids(xml_file)
       xml = File.read(xml_file)
-      current_file_path = "#{truncated_dir_name}/#{truncate_path(xml_file)}"
+      current_file_path = "#{truncated_dir_name}/#{File.basename(xml_file)}"
 
       pbcore_id = xml.scan(/(cpb-aacip\/.+?)<\//).flatten.first
       if pbcore_id.blank?
@@ -77,10 +77,6 @@ module AMS
 
     def normalize_date(date)
       date.to_datetime.strftime('%Y-%m-%d %H:%M')
-    end
-
-    def truncate_path(path)
-      path.to_s.split('/').last
     end
 
     def initialize_results

--- a/app/services/ams/missing_instantiations_locator.rb
+++ b/app/services/ams/missing_instantiations_locator.rb
@@ -5,23 +5,28 @@ module AMS
   class MissingInstantiationsLocator
     WORKING_DIR = Rails.root.join('tmp', 'imports')
 
-    attr_reader :search_dirs, :current_dir, :truncated_dir_name, :results_path, :results, :progressbar
+    attr_reader :search_dirs, :current_dir, :truncated_dir_name, :results_path, :results, :progressbar, :logger
 
     # @param [Array<String>] search_dirs
     def initialize(search_dirs)
       @search_dirs = search_dirs.map { |dir| WORKING_DIR.join(dir) }
+      @logger = ActiveSupport::Logger.new(
+        WORKING_DIR.join('i16-missing-instantiations-locator.log')
+      )
     end
 
     # TODO: better method name
     def locate_within_dirs
       search_dirs.each do |current_dir|
         @current_dir = current_dir
-        @truncated_dir_name = current_dir.to_s.split('/').last
+        @truncated_dir_name = truncate_path(current_dir)
         @results_path = WORKING_DIR.join("i16-#{truncated_dir_name}.json")
         @results = initialize_results
         xml_files = Dir.glob(current_dir.join('*.xml'))
         progressbar_format = "#{truncated_dir_name} -- %a %e %P% Processed: %c from %C"
         @progressbar = ProgressBar.create(total: xml_files.size, format: progressbar_format)
+
+        logger.info("Starting #{truncated_dir_name}")
 
         xml_files.each do |f|
           locate(f)
@@ -29,16 +34,27 @@ module AMS
         end
 
         write_results
+      rescue => e
+        logger.error("#{e.class} (#{truncated_dir_name}) - #{e.message}")
       end
     end
 
     # TODO: better method name
     def locate(xml_file)
       xml = File.read(xml_file)
+      current_file_path = "#{truncated_dir_name}/#{truncate_path(xml_file)}"
 
       pbcore_id = xml.scan(/(cpb-aacip\/.+?)<\//).flatten.first
+      if pbcore_id.blank?
+        logger.debug("No pbcore_id found within #{current_file_path}")
+        return
+      end
       asset_id = pbcore_id.tr('/', '-')
       instantiation_identifiers = xml.scan(/<instantiationIdentifier .+?>(.+?)<\/instantiationIdentifier>/mi).flatten
+      if instantiation_identifiers.blank?
+        logger.debug("No instantiation identifier(s) found within #{current_file_path}")
+        return
+      end
 
       instantiation_identifiers.each do |inst_id|
         instantiation_class = xml.match?('instantiationPhysical') ? PhysicalInstantiation : DigitalInstantiation
@@ -51,11 +67,19 @@ module AMS
 
         results[inst_id] ||= []
         results[inst_id] |= Array.wrap("#{truncated_dir_name}/#{asset_id}")
+      rescue => e
+        logger.error("#{e.class} (#{current_file_path}) (Inst: #{inst_id}) - #{e.message}")
       end
+    rescue => e
+      logger.error("#{e.class} (#{current_file_path}) - #{e.message}")
     end
 
     def normalize_date(date)
       date.to_datetime.strftime('%Y-%m-%d %H:%M')
+    end
+
+    def truncate_path(path)
+      path.to_s.split('/').last
     end
 
     def initialize_results

--- a/app/services/ams/missing_instantiations_locator.rb
+++ b/app/services/ams/missing_instantiations_locator.rb
@@ -5,7 +5,7 @@ module AMS
   class MissingInstantiationsLocator
     WORKING_DIR = Rails.root.join('tmp', 'imports')
 
-    attr_reader :search_dirs, :current_dir, :results_path, :results, :progressbar
+    attr_reader :search_dirs, :current_dir, :truncated_dir_name, :results_path, :results, :progressbar
 
     # @param [Array<String>] search_dirs
     def initialize(search_dirs)
@@ -16,10 +16,11 @@ module AMS
     def locate_within_dirs
       search_dirs.each do |current_dir|
         @current_dir = current_dir
-        @results_path = WORKING_DIR.join("i16-#{truncated_dir_name(current_dir)}.json")
+        @truncated_dir_name = current_dir.to_s.split('/').last
+        @results_path = WORKING_DIR.join("i16-#{truncated_dir_name}.json")
         @results = initialize_results
         xml_files = Dir.glob(current_dir.join('*.xml'))
-        progressbar_format = "#{truncated_dir_name(current_dir)} -- %a %e %P% Processed: %c from %C"
+        progressbar_format = "#{truncated_dir_name} -- %a %e %P% Processed: %c from %C"
         @progressbar = ProgressBar.create(total: xml_files.size, format: progressbar_format)
 
         xml_files.each do |f|
@@ -49,16 +50,12 @@ module AMS
         next unless broken
 
         results[inst_id] ||= []
-        results[inst_id] |= Array.wrap("#{truncated_dir_name(current_dir)}/#{asset_id}")
+        results[inst_id] |= Array.wrap("#{truncated_dir_name}/#{asset_id}")
       end
     end
 
     def normalize_date(date)
       date.to_datetime.strftime('%Y-%m-%d %H:%M')
-    end
-
-    def truncated_dir_name(dir)
-      dir.to_s.split('/').last
     end
 
     def initialize_results

--- a/app/services/ams/missing_instantiations_locator.rb
+++ b/app/services/ams/missing_instantiations_locator.rb
@@ -5,7 +5,7 @@ module AMS
   class MissingInstantiationsLocator
     WORKING_DIR = Rails.root.join('tmp', 'imports')
 
-    attr_reader :search_dirs, :current_dir, :results_path, :results
+    attr_reader :search_dirs, :current_dir, :results_path, :results, :progressbar
 
     # @param [Array<String>] search_dirs
     def initialize(search_dirs)
@@ -19,9 +19,12 @@ module AMS
         @results_path = WORKING_DIR.join("i16-#{truncated_dir_name(current_dir)}.json")
         @results = initialize_results
         xml_files = Dir.glob(current_dir.join('*.xml'))
+        progressbar_format = "#{truncated_dir_name(current_dir)} -- %a %e %P% Processed: %c from %C"
+        @progressbar = ProgressBar.create(total: xml_files.size, format: progressbar_format)
 
         xml_files.each do |f|
           locate(f)
+          progressbar.increment
         end
 
         write_results

--- a/app/services/ams/missing_instantiations_locator.rb
+++ b/app/services/ams/missing_instantiations_locator.rb
@@ -42,8 +42,9 @@ module AMS
         end
         next unless broken
 
+        truncated_search_dir = search_dir.to_s.split('/').last
         results[inst_id] ||= []
-        results[inst_id] |= Array.wrap(asset_id)
+        results[inst_id] |= Array.wrap("#{truncated_search_dir}/#{asset_id}")
       end
     end
 

--- a/app/services/ams/missing_instantiations_locator.rb
+++ b/app/services/ams/missing_instantiations_locator.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'ruby-progressbar'
+
+module AMS
+  class MissingInstantiationsLocator
+    WORKING_DIR = Rails.root.join('tmp', 'imports')
+
+    attr_reader :search_dir, :results_path, :results
+
+    # TODO: take array of directory paths?
+    def initialize(search_dir:)
+      @search_dir = WORKING_DIR.join(search_dir)
+      @results_path = WORKING_DIR.join("i16-#{search_dir}.json")
+      @results = initialize_results
+    end
+
+    # TODO: better method name
+    def locate_within_dir
+      xml_files = Dir.glob(search_dir.join('*.xml'))
+
+      xml_files.each do |f|
+        locate(f)
+      end
+
+      write_results
+    end
+
+    # TODO: better method name
+    def locate(xml_file)
+      xml = File.read(xml_file)
+
+      pbcore_id = xml.scan(/(cpb-aacip\/.+?)<\//).flatten.first
+      asset_id = pbcore_id.tr('/', '-')
+      instantiation_identifiers = xml.scan(/<instantiationIdentifier .+?>(.+?)<\/instantiationIdentifier>/mi).flatten
+
+      instantiation_identifiers.each do |inst_id|
+        instantiation_class = xml.match?('instantiationPhysical') ? PhysicalInstantiation : DigitalInstantiation
+        af_instantiations = instantiation_class.where(local_instantiation_identifier: inst_id)
+
+        broken = af_instantiations.any? do |af_inst|
+          normalize_date(af_inst.date_uploaded) != normalize_date(af_inst.date_modified)
+        end
+        next unless broken
+
+        results[inst_id] ||= []
+        results[inst_id] |= Array.wrap(asset_id)
+      end
+    end
+
+    def normalize_date(date)
+      date.to_datetime.strftime('%Y-%m-%d %H:%M')
+    end
+
+    def initialize_results
+      if File.exist?(results_path)
+        JSON.parse(File.read(results_path))
+      else
+        {}
+      end
+    end
+
+    def write_results
+      File.open(results_path, 'w') do |f|
+        f.puts results.to_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref
- https://github.com/scientist-softserv/ams/issues/16

Add service that will help in locating all the missing child instantiations. Currently, it's sole purpose is mapping all possible Asset IDs to each unique instantiation identifier. For example: 

```ruby
{ "inst_id_a" => ["asset id 1", "asset id 2"] }
```

The results are written to JSON files. Each provided "search directory" gets its own JSON file so that multiple directories can be searched at once without trying to write to the same file. In the future, all the resulting JSON files should be merged into a single file since the same instantiation identifier could appear multiple times across different search directories. 