### PR TITLE
i16 Expand AssetDestroyer to also destroy AssetResources

### DIFF
--- a/app/services/ams/asset_destroyer.rb
+++ b/app/services/ams/asset_destroyer.rb
@@ -64,6 +64,8 @@ module AMS
           .with_step_args('work_resource.delete' => { user: user },
                           'work_resource.delete_all_file_sets' => { user: user })
           .call(asset_resource).value!
+      rescue Valkyrie::Persistence::ObjectNotFoundError
+        puts "No AssetResource found with ID #{asset_id}"
       end
 
       def actor

--- a/app/services/ams/asset_destroyer.rb
+++ b/app/services/ams/asset_destroyer.rb
@@ -5,7 +5,7 @@ module AMS
     def initialize(asset_ids: [], user_email: nil)
       @asset_ids = Array(asset_ids)
       @user_email = user_email
-      @logger = Logger.new(Rails.root.join('tmp', 'imports', 'asset_destroyer.log'))
+      @logger = setup_logger
     end
 
     def destroy(asset_ids)
@@ -116,6 +116,13 @@ module AMS
         msg = error.class.to_s
         msg += ": #{error.message}" unless error.message.empty?
         logger.error "Error destroying '#{object_type}' for '#{id}'. #{msg}"
+      end
+
+      def setup_logger
+        logger_path = Rails.root.join('tmp', 'imports', 'asset_destroyer.log')
+        FileUtils.mkdir_p(logger_path.dirname)
+
+        Logger.new(logger_path)
       end
   end
 end

--- a/app/services/listeners/validate_aapb_listener.rb
+++ b/app/services/listeners/validate_aapb_listener.rb
@@ -41,6 +41,9 @@ module Listeners
     end
 
     def on_object_deleted(event)
+      # Not concerned with validation status if the Asset itself is being deleted
+      return if event[:object].is_a?(AssetResource)
+
       on_object_membership_updated(event)
     end
 


### PR DESCRIPTION
## expand AssetDestroyer to also delete AssetResources

ef949bb1b5e5f151882036e2fe6a14bfdee76b5f


## don't set validation status on deleted Asset

ae13cd12b1fe53595fed7eb545013187f848df07

Prevents the following error when deleting an AssetResource via the
Valkyrie Transactions:

`SolrDocument#get_members: undefined method 'members' for AssetResource`

Setting the validation status required looking up the Asset's members
recursively. But since we're in the middle of deleting things:

1. Expected data was missing, and more importantly,
2. We don't care about setting the Asset's validation status because
   it's being deleted

## use transaction to thoroughly delete members

1a0a4a65bce727a873d9cb784aea9bf9b33e1615

The Transaction ensures the members will be deleted thoroughly. For
example, using the transaction means all the related Sipity records will
be destroyed, which is what we want
