### PR TITLE
Give redis time to read AOF during startup (deploy)

### DIFF
--- a/ops/prod-deploy.tmpl.yaml
+++ b/ops/prod-deploy.tmpl.yaml
@@ -191,8 +191,11 @@ redis:
   cluster:
     enabled: false
   password: prod
-  healthCheck:
-    initialDelay: 120
+  master:
+    livenessProbe:
+      initialDelaySeconds: 120
+    readinessProbe:
+      initialDelaySeconds: 120
 
 solr:
   enabled: false


### PR DESCRIPTION
When deployed, the redis pod currently restarts over and over because it fails the health check before the state can be restored from the AOF file. The health checks need to be delayed to give time for this to happen.

This change fixes the syntax to set the initial delay value; confusingly, it's different from fcrepo (which uses `healthCheck.initialDelay`) 