### PR TITLE
dont-rush-redis-healthchecks

### DIFF
--- a/ops/prod-deploy.tmpl.yaml
+++ b/ops/prod-deploy.tmpl.yaml
@@ -193,9 +193,9 @@ redis:
   password: prod
   master:
     livenessProbe:
-      initialDelaySeconds: 180
+      initialDelaySeconds: 300
     readinessProbe:
-      initialDelaySeconds: 180
+      initialDelaySeconds: 300
 
 solr:
   enabled: false


### PR DESCRIPTION
Add more time to initial delay for the readiness and liveness probes for redis to get the aof file into memory