### PR TITLE
i139-actually-delete-annotations

### DIFF
--- a/app/transactions/ams/steps/create_aapb_admin_data.rb
+++ b/app/transactions/ams/steps/create_aapb_admin_data.rb
@@ -42,9 +42,9 @@ module Ams
         find_or_create_admin_data(change_set)
         set_admin_data_attributes(change_set.model.admin_data, change_set)
         change_set.model.admin_data.save!
-        set_annotations_attributes(change_set.model.admin_data, change_set)
         remove_admin_data_from_env_attributes(change_set)
         delete_removed_annotations(change_set.model.admin_data, change_set)
+        set_annotations_attributes(change_set.model.admin_data, change_set)
         remove_annotations_from_env_attributes(change_set)
 
         !!change_set.model.admin_data

--- a/app/transactions/ams/steps/create_aapb_admin_data.rb
+++ b/app/transactions/ams/steps/create_aapb_admin_data.rb
@@ -61,10 +61,10 @@ module Ams
 
       def delete_removed_annotations(admin_data, change_set)
         return if admin_data.annotations.empty?
-        return if change_set.annotations.blank?
-        ids_in_env = change_set.annotations.map(&:id)
+        return if change_set.attributes["annotations"].nil?
+        ids_in_change_set = change_set.attributes["annotations"].select{ |ann| ann["id"].present? }.map{ |ann| ann["id"].to_i }
         admin_data.annotations.each do |annotation|
-          annotation.destroy unless ids_in_env.include?(annotation.id)
+          annotation.destroy unless ids_in_change_set.include?(annotation.id)
         end
       end
 

--- a/app/transactions/ams/steps/create_aapb_admin_data.rb
+++ b/app/transactions/ams/steps/create_aapb_admin_data.rb
@@ -42,9 +42,9 @@ module Ams
         find_or_create_admin_data(change_set)
         set_admin_data_attributes(change_set.model.admin_data, change_set)
         change_set.model.admin_data.save!
+        set_annotations_attributes(change_set.model.admin_data, change_set)
         remove_admin_data_from_env_attributes(change_set)
         delete_removed_annotations(change_set.model.admin_data, change_set)
-        set_annotations_attributes(change_set.model.admin_data, change_set)
         remove_annotations_from_env_attributes(change_set)
 
         !!change_set.model.admin_data
@@ -61,8 +61,8 @@ module Ams
 
       def delete_removed_annotations(admin_data, change_set)
         return if admin_data.annotations.empty?
-        return if change_set.attributes["annotations"].nil?
-        ids_in_change_set = change_set.attributes["annotations"].select{ |ann| ann["id"].present? }.map{ |ann| ann["id"].to_i }
+        return if change_set.fields["annotations"].nil?
+        ids_in_change_set = change_set.fields["annotations"].select{ |ann| ann["id"].present? }.map{ |ann| ann["id"].to_i }
         admin_data.annotations.each do |annotation|
           annotation.destroy unless ids_in_change_set.include?(annotation.id)
         end

--- a/app/transactions/ams/steps/create_aapb_admin_data.rb
+++ b/app/transactions/ams/steps/create_aapb_admin_data.rb
@@ -43,8 +43,8 @@ module Ams
         set_admin_data_attributes(change_set.model.admin_data, change_set)
         change_set.model.admin_data.save!
         remove_admin_data_from_env_attributes(change_set)
-        set_annotations_attributes(change_set.model.admin_data, change_set)
         delete_removed_annotations(change_set.model.admin_data, change_set)
+        set_annotations_attributes(change_set.model.admin_data, change_set)
         remove_annotations_from_env_attributes(change_set)
 
         !!change_set.model.admin_data
@@ -62,9 +62,9 @@ module Ams
       def delete_removed_annotations(admin_data, change_set)
         return if admin_data.annotations.empty?
         return if change_set.annotations.blank?
-        ids_in_env = change_set.fields["annotations"].map { |a| a["id"] }
+        ids_in_env = change_set.annotations.map(&:id)
         admin_data.annotations.each do |annotation|
-          annotation.destroy unless ids_in_env.include?(annotation.id.to_s)
+          annotation.destroy unless ids_in_env.include?(annotation.id)
         end
       end
 

--- a/app/transactions/ams/steps/create_aapb_admin_data.rb
+++ b/app/transactions/ams/steps/create_aapb_admin_data.rb
@@ -43,8 +43,8 @@ module Ams
         set_admin_data_attributes(change_set.model.admin_data, change_set)
         change_set.model.admin_data.save!
         remove_admin_data_from_env_attributes(change_set)
-        delete_removed_annotations(change_set.model.admin_data, change_set)
         set_annotations_attributes(change_set.model.admin_data, change_set)
+        delete_removed_annotations(change_set.model.admin_data, change_set)
         remove_annotations_from_env_attributes(change_set)
 
         !!change_set.model.admin_data
@@ -62,9 +62,9 @@ module Ams
       def delete_removed_annotations(admin_data, change_set)
         return if admin_data.annotations.empty?
         return if change_set.annotations.blank?
-        ids_in_env = change_set.annotations.map(&:id)
+        ids_in_env = change_set.fields["annotations"].map { |a| a["id"] }
         admin_data.annotations.each do |annotation|
-          annotation.destroy unless ids_in_env.include?(annotation.id)
+          annotation.destroy unless ids_in_env.include?(annotation.id.to_s)
         end
       end
 


### PR DESCRIPTION
Ticket from Maint Board: https://github.com/scientist-softserv/ams/issues/139

Updates the delete_removed_annotations method to ensure handling of change_set.annotations:

- checks for the presence of change_set.fields["annotations"] to avoid nil errors.
- filters out invalid annotations without ids before mapping valid IDs.
- ensures annotations not in the change_set are properly deleted while preventing errors from missing or invalid data.

### Video in local dev: https://share.zight.com/P8uOLQkx
