### PR TITLE
PI format not required

### DIFF
--- a/app/forms/hyrax/physical_instantiation_form.rb
+++ b/app/forms/hyrax/physical_instantiation_form.rb
@@ -13,7 +13,7 @@ module Hyrax
                    :keyword, :license, :rights_statement, :publisher, :subject, :identifier, :based_near, :related_url,
                    :bibliographic_citation, :source]
     self.required_fields -= [:creator, :keyword, :rights_statement]
-    self.required_fields += [:format, :location, :media_type, :holding_organization]
+    self.required_fields += [:location, :media_type, :holding_organization]
 
     self.single_valued_fields = [:title]
 

--- a/app/forms/physical_instantiation_resource_form.rb
+++ b/app/forms/physical_instantiation_resource_form.rb
@@ -16,7 +16,7 @@ class PhysicalInstantiationResourceForm < Hyrax::Forms::ResourceForm(PhysicalIns
 
   attr_accessor :controller, :current_ability
 
-  self.required_fields += [:format, :location, :media_type, :holding_organization]
+  self.required_fields += [:location, :media_type, :holding_organization]
 
   self.single_valued_fields = [:title]
 

--- a/app/models/physical_instantiation.rb
+++ b/app/models/physical_instantiation.rb
@@ -12,7 +12,6 @@ class PhysicalInstantiation < ActiveFedora::Base
 
   before_save :save_instantiation_admin_data
 
-  validates :format, presence: { message: 'Your work must have a format.' }
   validates :location, presence: { message: 'Your work must have a location.' }
   validates :media_type, presence: { message: 'Your work must have a media type.' }
   validates :duration, format: { with: AMS::TimeCodeService.regex, allow_blank: true, message: "Invalid format for duration. Use HH:MM:SS, H:MM:SS, MM:SS, or M:SS" }

--- a/app/models/physical_instantiation_resource.rb
+++ b/app/models/physical_instantiation_resource.rb
@@ -40,7 +40,6 @@ class PhysicalInstantiationResource < Hyrax::Work
 
   def aapb_invalid_message
     msg = []
-    msg << "#{self.id} format is required" unless format.present?
     msg << "#{self.id} location is required" unless location.present?
     msg << "#{self.id} media_type is required" unless media_type.present?
     msg << "#{self.id} holding_organization is required" unless holding_organization.present?

--- a/app/parsers/pbcore_xml_parser.rb
+++ b/app/parsers/pbcore_xml_parser.rb
@@ -162,8 +162,8 @@ class PbcoreXmlParser < Bulkrax::XmlParser
   def instantiation_rows(instantiations, xml_asset, asset, asset_id)
     xml_records = []
     instantiations.each.with_index do |inst, i|
-      instantiation_class =  'PhysicalInstantiationResource' if inst.physical
-      instantiation_class ||= 'DigitalInstantiationResource' if inst.digital
+      instantiation_class = 'PhysicalInstantiationResource' if inst.nil? || inst.physical
+      instantiation_class ||= 'DigitalInstantiationResource' if inst&.digital
       next unless instantiation_class
       xml_record = AAPB::BatchIngest::PBCoreXMLMapper.new(inst.to_xml).send("#{instantiation_class.to_s.underscore}_attributes").merge!({ pbcore_xml: inst.to_xml, skip_file_upload_validation: true })
       # Find members of the asset that have the same class and local identifier. If no asset, then no digital instantiation can exist

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -171,7 +171,7 @@ module AAPB
 
       def physical_instantiation_resource_attributes
         @physical_instantiation_resource_attributes ||= instantiation_attributes.tap do |attrs|
-          attrs[:format] = pbcore.physical.value || nil
+          attrs[:format] = pbcore.physical.value if pbcore.physical.value.present?
         end
       end
 

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -171,7 +171,7 @@ module AAPB
 
       def physical_instantiation_resource_attributes
         @physical_instantiation_resource_attributes ||= instantiation_attributes.tap do |attrs|
-          attrs[:format] = pbcore.physical.value if pbcore.physical.value.present?
+          attrs[:format] = pbcore.physical.value || nil
         end
       end
 

--- a/spec/factories/physical_instantiation.rb
+++ b/spec/factories/physical_instantiation.rb
@@ -8,6 +8,10 @@ FactoryBot.define do
     local_instantiation_identifier { [ "1234" ] }
     location { "Test location" }
     media_type { "Test media_type" }
+
+    trait :without_format do
+      format { nil }
+    end
   end
 
   factory :minimal_physical_instantiation, class: PhysicalInstantiation do
@@ -16,5 +20,9 @@ FactoryBot.define do
     annotation { ["Minimal annotation"] }
     location { "Minimal location" }
     media_type { "Minimal media_type" }
+    
+    trait :without_format do
+      format { nil }
+    end
   end
 end

--- a/spec/models/physical_instantiation_spec.rb
+++ b/spec/models/physical_instantiation_spec.rb
@@ -45,7 +45,12 @@ RSpec.describe PhysicalInstantiation do
         expect(physical_instantiation.resource.dump(:ttl)).to match(/ebucore#hasFormat/)
         expect(physical_instantiation.format.include?("Test format")).to be true
       end
-    end
+      it "handles absence of format gracefully" do
+      physical_instantiation.format = nil
+      expect(physical_instantiation.resource.dump(:ttl)).not_to match(/ebucore#hasFormat/)
+      expect(physical_instantiation.format).to be_nil
+        end
+      end
 
     context "standard" do
       let(:physical_instantiation) { FactoryBot.build(:physical_instantiation) }


### PR DESCRIPTION
No longer require format for physical instantiations when:

- [x] Using update ingester
- [x] PBCore zipped ingester
- [x] Manually adding or updating a record
- [x] Pushing to AAPB

closes #940 