### PR TITLE
i149 Fix editing Contributions on Asset edit form

### DIFF
--- a/app/forms/asset_resource_form.rb
+++ b/app/forms/asset_resource_form.rb
@@ -88,7 +88,7 @@ class AssetResourceForm < Hyrax::Forms::ResourceForm(AssetResource)
   def child_contributors
     child_contributions = []
     model.members.to_a.each do |member|
-      if( member.class == Contribution )
+      if [Contribution, ContributionResource].include?(member.class)
         child_contributions << [member.id, member.contributor_role, member.contributor.first , member.portrayal, member.affiliation]
       end
     end

--- a/app/transactions/ams/steps/handle_contributors.rb
+++ b/app/transactions/ams/steps/handle_contributors.rb
@@ -41,9 +41,15 @@ module Ams
             param_contributor[:admin_set_id] = change_set['admin_set_id']
             param_contributor[:title] = change_set["title"]
 
+            # FIXME: removing members this way doesn't work. The form does not pass _destroy, it simply
+            # doesn't pass the params for the contributor if it was removed. This is because the "Remove"
+            # button deletes the outer HTML of the input fields.
+            # Consider updating members by setting them equal to the contributors passed by params,
+            # effectively removing the members that were not passed.
+            # Importing / batch ingesting may handle deletion differently; verify whatever change made
+            # here works with those features
             to_destroy = ActiveModel::Type::Boolean.new.cast(param_contributor['_destroy'])
             if to_destroy
-              # FIXME: removing the member doesn't seem to work, destroy instead of unlink?
               destroys << param_contributor[:id]
               next
             end
@@ -57,12 +63,6 @@ module Ams
                 Hyrax.publisher.publish('object.metadata.updated', object: contributor_resource, user: user)
                 inserts << contributor_resource.id
               else
-                # param_contributor.slice(:contributor_role, :contributor, :affiliation, :portrayal).each do |attr, value|
-                #   contributor.send("#{attr}=", value)
-                # end
-                # Hyrax.persister.save(resource: contributor)
-                # Hyrax.index_adapter.save(resource: contribution)
-                # Hyrax.publisher.publish('object.metadata.updated', object: contributor, user: user)
                 contribution_form = Hyrax::Forms::ResourceForm.for(contributor)
                 sanitized_params = param_contributor.slice(:contributor_role, :contributor, :affiliation, :portrayal)
                 contribution_form.validate(sanitized_params)

--- a/app/transactions/ams/steps/handle_contributors.rb
+++ b/app/transactions/ams/steps/handle_contributors.rb
@@ -43,25 +43,43 @@ module Ams
 
             to_destroy = ActiveModel::Type::Boolean.new.cast(param_contributor['_destroy'])
             if to_destroy
+              # FIXME: removing the member doesn't seem to work, destroy instead of unlink?
               destroys << param_contributor[:id]
               next
             end
 
+            if param_contributor[:id].present?
+              contributor = Hyrax.query_service.find_by(id: param_contributor[:id])
+              if contributor.is_a?(Contribution)
+                param_contributor.delete(:id)
+                contributor.attributes.merge!(param_contributor)
+                contributor_resource = Hyrax.persister.save(resource: contributor)
+                Hyrax.publisher.publish('object.metadata.updated', object: contributor_resource, user: user)
+                inserts << contributor_resource.id
+              else
+                # param_contributor.slice(:contributor_role, :contributor, :affiliation, :portrayal).each do |attr, value|
+                #   contributor.send("#{attr}=", value)
+                # end
+                # Hyrax.persister.save(resource: contributor)
+                # Hyrax.index_adapter.save(resource: contribution)
+                # Hyrax.publisher.publish('object.metadata.updated', object: contributor, user: user)
+                contribution_form = Hyrax::Forms::ResourceForm.for(contributor)
+                sanitized_params = param_contributor.slice(:contributor_role, :contributor, :affiliation, :portrayal)
+                contribution_form.validate(sanitized_params)
+                Hyrax::Transactions::Container['change_set.apply'].call(contribution_form)
+                inserts << contributor.id
+              end
+            else
+              flat_values = param_contributor.slice(:contributor_role, :affiliation, :portrayal).values + param_contributor[:contributor]
+              next if flat_values.none?(&:present?)
 
-            contributor = Contribution.find(param_contributor[:id]) if param_contributor[:id].present?
-            if contributor
-              param_contributor.delete(:id)
-              contributor.attributes.merge!(param_contributor)
-              contributor_resource = Hyrax.persister.save(resource: contributor)
-              Hyrax.publisher.publish('object.metadata.updated', object: contributor_resource, user: user)
-              inserts << contributor_resource.id
-              next
+              contribution_attrs = param_contributor.symbolize_keys.except(:id) # IDs are blank for new records submitted by form
+              contribution_resource = Hyrax.persister.save(resource: ContributionResource.new(contribution_attrs))
+              Hyrax.index_adapter.save(resource: contribution_resource)
+              Hyrax.publisher.publish('object.deposited', object: contribution_resource, user: user)
+              Hyrax::AccessControlList.copy_permissions(source: target_permissions, target: contribution_resource)
+              inserts << contribution_resource.id
             end
-            contribution_resource = Hyrax.persister.save(resource: ContributionResource.new(param_contributor.symbolize_keys))
-            Hyrax.index_adapter.save(resource: contribution_resource)
-            Hyrax.publisher.publish('object.deposited', object: contribution_resource, user: user)
-            Hyrax::AccessControlList.copy_permissions(source: target_permissions, target: contribution_resource)
-            inserts << contribution_resource.id
           end
 
           update_members(change_set, inserts, destroys)


### PR DESCRIPTION
Ref:
- https://github.com/scientist-softserv/ams/issues/149

**This is the first step to resolving #149. More changes will be required to completely resolve the issue.** 

Changes: 
- Existing Contribution records will now show up in Asset forms 
- Editing existing Contributions (via Asset form) no longer throws an error and updates successfully 
- Adding new Contributions (via Asset form) no longer throws an error and saves successfully 

Not addressed:
- Deleting a Contribution will either fail silently or throw an error, depending on how you try deleting it 

Untested:
- How these changes affect Bulkrax imports / batch ingests 