### PR TITLE
Explicitly resets validation status in fix script

### DIFF
--- a/lib/fix/resave_asset_resources.rb
+++ b/lib/fix/resave_asset_resources.rb
@@ -20,6 +20,7 @@ module Fix
     def resave_asset_resource(resource:)
       result = { resource: resource }
       log.info "RESAVING #{resource.class} #{resource.id.id}..."
+      resource.set_validation_status
       Hyrax.persister.save(resource: resource)
       Hyrax.index_adapter.save(resource: resource)
       log.info "SAVED #{resource.class} #{resource.id.id}."


### PR DESCRIPTION
I had thought this was automatic on save, but not so, and this is what this script was needed to do, so let's just call it explicitly.

Closes #954