### PR TITLE
Add note as annotationType

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -323,6 +323,10 @@ class Asset < ActiveFedora::Base
  def ams1_legacy_metadata
     ams1_legacy_metadata ||= find_annotation_attribute("ams1_legacy_metadata")
   end
+   
+ def note
+    note ||= find_annotation_attribute("note")
+  end
   
   def find_annotation_attribute(attribute)
     if admin_data.annotations.select { |a| a.annotation_type == attribute }.present?

--- a/app/models/asset_resource.rb
+++ b/app/models/asset_resource.rb
@@ -133,6 +133,10 @@ class AssetResource < Hyrax::Work
   def ams1_legacy_metadata
     ams1_legacy_metadata ||= find_annotation_attribute("ams1_legacy_metadata")
   end 
+
+   def note
+    note ||= find_annotation_attribute("note")
+  end
   
   def find_annotation_attribute(attribute)
     if admin_data.annotations.select { |a| a.annotation_type == attribute }.present?

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -532,6 +532,10 @@ class SolrDocument
   def ams1_legacy_metadata
     self[solr_name('ams1_legacy_metadata', :symbol)]
   end
+
+  def note
+    self[solr_name('note', :symbol)]
+  end
   
   def proxy_start_time
     self[solr_name('proxy_start_time', :symbol)]

--- a/config/batch_ingest.yml
+++ b/config/batch_ingest.yml
@@ -87,6 +87,7 @@ ingest_types:
           - playlist_order
           - organization
           - proxy_start_time
+          - note
   aapb_csv_reader_4:
     label: "AAPB CSV Asset Multivalue Attribute Addition Ingester"
     reader: "AAPB::BatchIngest::CSVReader"
@@ -135,6 +136,7 @@ ingest_types:
           - producing_organization
           - sonyci_id
           - special_collections
+          - note
   zipped_pbcore_digital_instantiation:
     label: "AAPB Digital Instantiation PBCore - Zipped"
     reader: "AAPB::BatchIngest::ZippedPBCoreDigitalInstantiationReader"

--- a/config/batch_ingest.yml
+++ b/config/batch_ingest.yml
@@ -136,7 +136,6 @@ ingest_types:
           - producing_organization
           - sonyci_id
           - special_collections
-          - note
   zipped_pbcore_digital_instantiation:
     label: "AAPB Digital Instantiation PBCore - Zipped"
     reader: "AAPB::BatchIngest::ZippedPBCoreDigitalInstantiationReader"

--- a/config/batch_ingest.yml
+++ b/config/batch_ingest.yml
@@ -87,7 +87,6 @@ ingest_types:
           - playlist_order
           - organization
           - proxy_start_time
-          - note
   aapb_csv_reader_4:
     label: "AAPB CSV Asset Multivalue Attribute Addition Ingester"
     reader: "AAPB::BatchIngest::CSVReader"

--- a/spec/support/pbcore_xpath_helpers.rb
+++ b/spec/support/pbcore_xpath_helpers.rb
@@ -83,6 +83,7 @@ module PBCoreXPathHelper
         transcript_url:                 '//pbcoreAnnotation[@annotationType="Transcript URL"]',
         transcript_source:              '//pbcoreAnnotation[@annotationType="Transcript Source"]',
         proxy_start_time:               '//pbcoreAnnotation[@annotationType="Proxy Start Time"]',
+        note:                           '//pbcoreAnnotation[@annotationType="Note"]',
         rights_summary:                 '//pbcoreRightsSummary/rightsSummary',
         rights_link:                    '//pbcoreRightsSummary/rightsLink',
         local_identifier:               '//pbcoreIdentifier[@source="Local Identifier"]',
@@ -192,6 +193,7 @@ module PBCoreXPathHelper
                    values_from_xpath(:special_collections) +
                    values_from_xpath(:transcript_status) +
                    values_from_xpath(:proxy_start_time) +
+                   values_from_xpath(:note) +
                    values_from_xpath(:licensing_info) +
                    values_from_xpath(:playlist_group) +
                    values_from_xpath(:playlist_order) +

--- a/spec/support/pbcore_xpath_helpers.rb
+++ b/spec/support/pbcore_xpath_helpers.rb
@@ -193,7 +193,6 @@ module PBCoreXPathHelper
                    values_from_xpath(:special_collections) +
                    values_from_xpath(:transcript_status) +
                    values_from_xpath(:proxy_start_time) +
-                   values_from_xpath(:note) +
                    values_from_xpath(:licensing_info) +
                    values_from_xpath(:playlist_group) +
                    values_from_xpath(:playlist_order) +


### PR DESCRIPTION
PR to add "Note" as a valid annotationType _specifically_ for PBCore Zipped ingest. This is to allow 68K minnesota records to be ingested that had multiple invalid annotationTypes that we have merged into a single "Note" annotationType