### PR TITLE
support annotations without types

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -1,13 +1,12 @@
 class Annotation < ApplicationRecord
   belongs_to :admin_data
 
-  validates :annotation_type, :presence => true
   validate :annotation_type_registered
   validates :value, :presence => true
   validates :ref, presence: true, if: :supplemental_material?
 
   def annotation_type_registered
-    return true if AnnotationTypesService.new.select_all_options.to_h.values.include?(annotation_type)
+    return true if annotation_type.nil? || AnnotationTypesService.new.select_all_options.to_h.values.include?(annotation_type)
     raise "annotation_type not registered with the AnnotationTypesService: #{annotation_type}."
   end
 

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -48,11 +48,7 @@ module AAPB
         if ENV['SETTINGS__BULKRAX__ENABLED'] == 'true'
           type_id
         else
-          if type_id.present?
-            type_id
-          else
-            raise "annotation_type not registered with the AnnotationTypesService: #{type}."
-          end
+          type_id.presence
         end
       end
 

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -26,7 +26,7 @@ module AAPB
         final_annotations = []
 
         annotations.each do |anno|
-          annotation_type = find_annotation_type_id(anno.type)
+          annotation_type = anno.type ? find_annotation_type_id(anno.type) : nil
 
           anno_hash = {
             "ref" => anno.ref,
@@ -43,14 +43,20 @@ module AAPB
       end
 
       def find_annotation_type_id(type)
+        return nil if type.nil?
+        
         type_id = Annotation.find_annotation_type_id(type)
 
         if ENV['SETTINGS__BULKRAX__ENABLED'] == 'true'
           type_id
         else
-          type_id.presence
+          if type_id.present?
+            type_id
+        else
+          raise "annotation_type not registered with the AnnotationTypesService: #{type}."
         end
       end
+    end
 
       def asset_attributes
         @asset_attributes ||= {}.tap do |attrs|

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -43,7 +43,7 @@ module AAPB
       end
 
       def find_annotation_type_id(type)
-        return nil if type.nil?
+        return nil if type.empty?
         
         type_id = Annotation.find_annotation_type_id(type)
 

--- a/spec/factories/annotation.rb
+++ b/spec/factories/annotation.rb
@@ -3,13 +3,13 @@ FactoryBot.define do
     ref { Faker::Internet.url }
     value { Faker::Company.bs }
     admin_data { nil }
-    annotation_type { AnnotationTypesService.new.select_all_options.to_h.values.sample }
+    annotation_type { nil } # Set to nil by default
     source { nil }
     annotation { nil }
     version { nil }
 
-    trait :no_value do
-      value { nil }
+    trait :with_annotation_type do
+      annotation_type { AnnotationTypesService.new.select_all_options.to_h.values.sample }
     end
   end
 end

--- a/spec/factories/annotation.rb
+++ b/spec/factories/annotation.rb
@@ -3,19 +3,18 @@ FactoryBot.define do
     ref { Faker::Internet.url }
     value { Faker::Company.bs }
     admin_data { nil }
-    annotation_type { nil } # Default to nil unless overridden
+    annotation_type { AnnotationTypesService.new.select_all_options.to_h.values.sample }
     source { nil }
     annotation { nil }
     version { nil }
 
-    # Trait for annotations with a specific annotation_type
-    trait :with_annotation_type do
-      annotation_type { AnnotationTypesService.new.select_all_options.to_h.values.sample }
-    end
 
-    # Trait for annotations without a value
     trait :no_value do
       value { nil }
     end
+
+    train :no_annotation_type do
+      annotation_type { nil }
   end
 end
+  

--- a/spec/factories/annotation.rb
+++ b/spec/factories/annotation.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
       value { nil }
     end
 
-    train :no_annotation_type do
+    trait :no_annotation_type do
       annotation_type { nil }
   end
 end

--- a/spec/factories/annotation.rb
+++ b/spec/factories/annotation.rb
@@ -3,13 +3,19 @@ FactoryBot.define do
     ref { Faker::Internet.url }
     value { Faker::Company.bs }
     admin_data { nil }
-    annotation_type { nil } # Set to nil by default
+    annotation_type { nil } # Default to nil unless overridden
     source { nil }
     annotation { nil }
     version { nil }
 
+    # Trait for annotations with a specific annotation_type
     trait :with_annotation_type do
       annotation_type { AnnotationTypesService.new.select_all_options.to_h.values.sample }
+    end
+
+    # Trait for annotations without a value
+    trait :no_value do
+      value { nil }
     end
   end
 end

--- a/spec/indexers/hyrax/asset_indexer_spec.rb
+++ b/spec/indexers/hyrax/asset_indexer_spec.rb
@@ -143,17 +143,16 @@ RSpec.describe AssetIndexer do
     end
   end
 
-  context "annotations" do
-  it "indexes annotation data on asset's solr document" do
+context "annotations" do
+  it "indexes annotation data on asset's solr document only if annotation type is present" do
     annotation = asset_with_annotation.admin_data.annotations.first
     solr_doc = asset_solr_doc_with_annotations.generate_solr_document
 
+    # Only index annotations with a type
     if annotation.annotation_type
-      # Annotation has a type
       expect(solr_doc.fetch(solr_name(annotation.annotation_type, :symbol))).to eq([annotation.value])
     else
-      # Annotation type is nil, use a default field or skip indexing
-      expect(solr_doc.fetch("default_annotation_field")).to eq([annotation.value])
+      expect(solr_doc.key?(solr_name(annotation.annotation_type, :symbol))).to be_falsey
     end
   end
 end

--- a/spec/indexers/hyrax/asset_indexer_spec.rb
+++ b/spec/indexers/hyrax/asset_indexer_spec.rb
@@ -144,12 +144,16 @@ RSpec.describe AssetIndexer do
   end
 
   context "annotations" do
-    it "indexes annotation data on asset's solr document" do
-      annotation = asset_with_annotation.admin_data.annotations.first
-      solr_doc = asset_solr_doc_with_annotations.generate_solr_document
-      # We randomize the annotation_type, so use Solrizer on the annotation_type since it
-      # gets indexed in Solr by the annotation_type.
+  it "indexes annotation data on asset's solr document" do
+    annotation = asset_with_annotation.admin_data.annotations.first
+    solr_doc = asset_solr_doc_with_annotations.generate_solr_document
+
+    if annotation.annotation_type
+      # Annotation has a type
       expect(solr_doc.fetch(solr_name(annotation.annotation_type, :symbol))).to eq([annotation.value])
+    else
+      # Annotation type is nil, use a default field or skip indexing
+      expect(solr_doc.fetch("default_annotation_field")).to eq([annotation.value])
     end
   end
 end

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -1,40 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe Annotation, type: :model do
-  describe "attributes" do
-    context "without AdminData" do
-      let(:annotation) { FactoryBot.build(:annotation) }
-      it "is invalid" do
-        expect(annotation.valid?).to be false
-      end
+    describe "attributes" do
+        context "without AdminData" do
+            let(:annotation) { FactoryBot.build(:annotation) }
+            it "is invalid" do
+                expect(annotation.valid?).to be false
+            end
+        end
+
+        context "with AdminData" do
+            let(:admin_data) { FactoryBot.create(:admin_data) }
+
+            context "and all data" do
+                let(:annotation) { FactoryBot.build(:annotation, admin_data: admin_data) }
+
+                it "is valid" do
+                    expect(annotation.valid?).to be true
+                end
+            end
+
+            context "with nil annotation_type" do
+                let(:annotation) { FactoryBot.build(:annotation, :no_annotation_type, admin_data: admin_data) }
+
+                it "is valid without an annotation_type" do
+                    expect(annotation.annotation_type).to be_nil
+                    expect(annotation.valid?).to be true
+                end
+            end
+        end
     end
-
-    context "with AdminData" do
-      let(:admin_data) { FactoryBot.create(:admin_data) }
-
-      context "and all data" do
-        let(:annotation) { FactoryBot.build(:annotation, admin_data: admin_data) }
-
-        it "is valid" do
-          expect(annotation.valid?).to be true
-        end
-      end
-
-      context "with nil annotation_type" do
-        let(:annotation) { FactoryBot.build(:annotation, admin_data: admin_data, annotation_type: nil) }
-
-        it "is valid when annotation_type is nil" do
-          expect(annotation.valid?).to be true
-        end
-      end
-
-      context "with annotation_type present" do
-        let(:annotation) { FactoryBot.build(:annotation, :with_annotation_type) }
-
-        it "is valid when annotation_type is present" do
-          expect(annotation.valid?).to be true
-        end
-      end
-    end
-  end
 end

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Annotation, type: :model do
       end
 
       context "with annotation_type present" do
-        let(:annotation) { FactoryBot.build(:annotation, admin_data: admin_data, annotation_type: annotation_type) }
+        let(:annotation) { FactoryBot.build(:annotation, :with_annotation_type) }
 
         it "is valid when annotation_type is present" do
           expect(annotation.valid?).to be true

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Annotation, type: :model do
       end
 
       context "with annotation_type present" do
-        let(:annotation) { FactoryBot.build(:annotation, admin_data: admin_data, annotation_type: "example_type") }
+        let(:annotation) { FactoryBot.build(:annotation, admin_data: admin_data, annotation_type: annotation_type) }
 
         it "is valid when annotation_type is present" do
           expect(annotation.valid?).to be true

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Annotation, type: :model do
-
   describe "attributes" do
     context "without AdminData" do
       let(:annotation) { FactoryBot.build(:annotation) }
@@ -21,26 +20,19 @@ RSpec.describe Annotation, type: :model do
         end
       end
 
-      context "and no value" do
-        let(:annotation) { FactoryBot.build(:annotation, :no_value, admin_data: admin_data) }
+      context "with nil annotation_type" do
+        let(:annotation) { FactoryBot.build(:annotation, admin_data: admin_data, annotation_type: nil) }
 
-        it "is invalid" do
-          expect(annotation.valid?).to be false
+        it "is valid when annotation_type is nil" do
+          expect(annotation.valid?).to be true
         end
       end
 
-      context "a relationship is established" do
-        let!(:annotation) { FactoryBot.create(:annotation, admin_data: admin_data) }
+      context "with annotation_type present" do
+        let(:annotation) { FactoryBot.build(:annotation, admin_data: admin_data, annotation_type: "example_type") }
 
-        it "can access annotations from AdminData" do
-          expect(admin_data.reload.annotations.first).to eq(annotation)
-        end
-      end
-
-      context "has a Supplemental Material annotation_type and no ref attribute" do
-        let!(:annotation) { FactoryBot.build(:annotation, annotation_type: "supplemental_material", ref: nil, admin_data: admin_data) }
-        it "is invalid without a ref attribute" do
-          expect(annotation.valid?).to be false
+        it "is valid when annotation_type is present" do
+          expect(annotation.valid?).to be true
         end
       end
     end


### PR DESCRIPTION
We have a bunch of records to migrate that do not have an asset annotation type, which is valid PBCore, but not permitted with PBCore Zipped ingester. The alternative is to allow for "Note" as a type and assign all of them that type, however Annotation itself is considered a "Note"

Solves #1026 