### PR TITLE
:bug: [i149 follow up] Users should be able to remove ALL contributors

### DIFF
--- a/app/assets/javascripts/work_actions/child_contributors_input.js
+++ b/app/assets/javascripts/work_actions/child_contributors_input.js
@@ -1,28 +1,84 @@
 $(document).ready(function() {
-  $('.form-group.child_contributors .remove').on('click', function(e) {
+  // Create and store a template row at initialization
+  function createTemplateRow() {
+    const $listing = $('.form-group.child_contributors .listing');
+    const $firstRow = $listing.find('li.field-wrapper').first();
+    const $template = $firstRow.clone();
+    
+    // Clear all inputs in the template
+    $template.find('input[type="text"], select').val('');
+    $template.find('input[type="hidden"]').remove();
+    
+    // Add a class to identify it as our template
+    $template.addClass('template-row').hide();
+    
+    // Add it to the listing
+    $listing.append($template);
+  }
+
+  // Create template row on page load
+  createTemplateRow();
+
+  // Handle remove button clicks
+  $('.form-group.child_contributors').on('click', '.remove', function(e) {
+    e.preventDefault();
+    
     var $wrapper = $(this).closest('li.field-wrapper');
+    var $listing = $wrapper.parent();
+    var $form = $('.edit_asset_resource');
     var contributorId = $wrapper.find('input[name$="[id]"]').val();
 
     if (contributorId && contributorId !== '') {
-      var $form = $(this).closest('form');
+      // Create hidden inputs
+      var idInput = document.createElement('input');
+      idInput.type = 'hidden';
+      idInput.name = 'asset_resource[contributors][][id]';
+      idInput.value = contributorId;
 
-      // Create a hidden input for the ID
-      var idInput = $('<input>')
-        .attr('type', 'hidden')
-        .attr('name', 'asset_resource[contributors][][id]')
-        .val(contributorId);
+      var destroyInput = document.createElement('input');
+      destroyInput.type = 'hidden';
+      destroyInput.name = 'asset_resource[contributors][][_destroy]';
+      destroyInput.value = 'true';
 
-      // Create a hidden input for _destroy flag
-      var destroyInput = $('<input>')
-        .attr('type', 'hidden')
-        .attr('name', 'asset_resource[contributors][][_destroy]')
-        .val('true');
-
-      // Add them to the form
-      $form.append(idInput);
-      $form.append(destroyInput);
+      // Append to form using vanilla JavaScript
+      $form[0].appendChild(idInput);
+      $form[0].appendChild(destroyInput);
     }
 
+    // Remove the wrapper
     $wrapper.remove();
+    
+    // Remove any existing warning messages
+    $listing.find('.has-warning').remove();
+
+    // If this was the last visible row (excluding template), show the template
+    if ($listing.find('li.field-wrapper:not(.template-row):visible').length === 0) {
+      const $newRow = $listing.find('.template-row').clone();
+      $newRow.removeClass('template-row').show();
+      $listing.append($newRow);
+    }
   });
+
+  // Handle add button clicks
+  $('.form-group.child_contributors').on('click', '.add', function(e) {
+    e.preventDefault();
+    const $listing = $(this).closest('.form-group').find('.listing');
+    const $template = $listing.find('.template-row');
+    
+    // Remove any existing warning messages
+    $listing.find('.has-warning').remove();
+    
+    if ($template.length) {
+      const $newRow = $template.clone();
+      $newRow.removeClass('template-row').show();
+      $listing.append($newRow);
+    }
+  });
+
+  // Override the FieldManager's validation message display
+  if (typeof FieldManager !== 'undefined') {
+    FieldManager.prototype.displayEmptyWarning = function() {
+      // Do nothing - this prevents the warning from being displayed
+    };
+  }
 });

--- a/app/assets/javascripts/work_actions/child_contributors_input.js
+++ b/app/assets/javascripts/work_actions/child_contributors_input.js
@@ -1,84 +1,138 @@
 $(document).ready(function() {
-  // Create and store a template row at initialization
-  function createTemplateRow() {
-    const $listing = $('.form-group.child_contributors .listing');
-    const $firstRow = $listing.find('li.field-wrapper').first();
-    const $template = $firstRow.clone();
-    
-    // Clear all inputs in the template
-    $template.find('input[type="text"], select').val('');
-    $template.find('input[type="hidden"]').remove();
-    
-    // Add a class to identify it as our template
-    $template.addClass('template-row').hide();
-    
-    // Add it to the listing
-    $listing.append($template);
-  }
-
-  // Create template row on page load
-  createTemplateRow();
-
-  // Handle remove button clicks
-  $('.form-group.child_contributors').on('click', '.remove', function(e) {
+  const $cleanTemplate = $('.form-group.child_contributors .listing li.field-wrapper').first().clone();
+  $cleanTemplate.find('input[type="text"], select').val('');
+  $cleanTemplate.find('input[type="hidden"]').remove();
+  
+  // Remove any existing click handlers from the add button
+  // This is crucial to prevent double-firing of events
+  $('.form-group.child_contributors').find('.add').off('click');
+  
+  $('.form-group.child_contributors').find('.add').on('click', function(e) {
     e.preventDefault();
+    e.stopPropagation(); // Prevent event bubbling to other handlers
     
-    var $wrapper = $(this).closest('li.field-wrapper');
-    var $listing = $wrapper.parent();
-    var $form = $('.edit_asset_resource');
-    var contributorId = $wrapper.find('input[name$="[id]"]').val();
-
+    const $listing = $('.form-group.child_contributors .listing');
+    $listing.find('.has-warning, .message').remove();
+    
+    const $lastRow = $listing.find('li.field-wrapper:visible').last();
+    
+    const hasContent = Array.from($lastRow.find('input[type="text"], select')).some(
+      input => input.value.trim() !== ''
+    );
+    
+    let $newRow;
+    if (hasContent) {
+      // If last row has content, clone it but clear all values
+      $newRow = $lastRow.clone();
+      $newRow.find('input[type="text"], select').val('');
+      $newRow.find('input[type="hidden"]').remove();
+    } else {
+      // If last row is empty, use the clean template
+      $newRow = $cleanTemplate.clone();
+    }
+    
+    $listing.append($newRow);
+    
+    $newRow.find('input, select').first().focus();
+    
+    return false;
+  });
+  
+  $('.form-group.child_contributors').find('.remove').off('click');
+  $('.form-group.child_contributors').find('.remove').on('click', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    const $wrapper = $(this).closest('li.field-wrapper');
+    const $listing = $wrapper.parent();
+    const $form = $('.edit_asset_resource');
+    const contributorId = $wrapper.find('input[name$="[id]"]').val();
+    
     if (contributorId && contributorId !== '') {
-      // Create hidden inputs
-      var idInput = document.createElement('input');
+      const idInput = document.createElement('input');
       idInput.type = 'hidden';
       idInput.name = 'asset_resource[contributors][][id]';
       idInput.value = contributorId;
-
-      var destroyInput = document.createElement('input');
+      
+      const destroyInput = document.createElement('input');
       destroyInput.type = 'hidden';
       destroyInput.name = 'asset_resource[contributors][][_destroy]';
       destroyInput.value = 'true';
-
-      // Append to form using vanilla JavaScript
+      
       $form[0].appendChild(idInput);
       $form[0].appendChild(destroyInput);
     }
-
-    // Remove the wrapper
+    
     $wrapper.remove();
     
-    // Remove any existing warning messages
-    $listing.find('.has-warning').remove();
-
-    // If this was the last visible row (excluding template), show the template
-    if ($listing.find('li.field-wrapper:not(.template-row):visible').length === 0) {
-      const $newRow = $listing.find('.template-row').clone();
-      $newRow.removeClass('template-row').show();
-      $listing.append($newRow);
+    if ($listing.find('li.field-wrapper').length === 0) {
+      $listing.append($cleanTemplate.clone());
     }
-  });
-
-  // Handle add button clicks
-  $('.form-group.child_contributors').on('click', '.add', function(e) {
-    e.preventDefault();
-    const $listing = $(this).closest('.form-group').find('.listing');
-    const $template = $listing.find('.template-row');
     
-    // Remove any existing warning messages
-    $listing.find('.has-warning').remove();
-    
-    if ($template.length) {
-      const $newRow = $template.clone();
-      $newRow.removeClass('template-row').show();
-      $listing.append($newRow);
-    }
+    return false;
   });
-
-  // Override the FieldManager's validation message display
+  
   if (typeof FieldManager !== 'undefined') {
-    FieldManager.prototype.displayEmptyWarning = function() {
-      // Do nothing - this prevents the warning from being displayed
+    FieldManager.prototype.displayEmptyWarning = function() { 
+      // Do nothing - prevent warnings
+    };
+    
+    // Completely disable the addToList method in FieldManager
+    FieldManager.prototype.addToList = function(event) {
+      event.preventDefault();
+      event.stopPropagation();
+      // Do nothing - prevent default behavior
+      return false;
     };
   }
+  
+  $(document).on('DOMNodeInserted', '.form-group.child_contributors .add, .form-group.child_contributors .remove', function() {
+    // Reattach our handlers
+    $(this).off('click');
+    
+    if ($(this).hasClass('add')) {
+      // Re-attach our add handler
+      $(this).on('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        // Trigger the static handler
+        $('.form-group.child_contributors').find('.add').first().trigger('click');
+        return false;
+      });
+    }
+    
+    if ($(this).hasClass('remove')) {
+      $(this).on('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const $wrapper = $(this).closest('li.field-wrapper');
+        const $listing = $wrapper.parent();
+        const $form = $('.edit_asset_resource');
+        const contributorId = $wrapper.find('input[name$="[id]"]').val();
+        
+        if (contributorId && contributorId !== '') {
+          const idInput = document.createElement('input');
+          idInput.type = 'hidden';
+          idInput.name = 'asset_resource[contributors][][id]';
+          idInput.value = contributorId;
+          
+          const destroyInput = document.createElement('input');
+          destroyInput.type = 'hidden';
+          destroyInput.name = 'asset_resource[contributors][][_destroy]';
+          destroyInput.value = 'true';
+          
+          $form[0].appendChild(idInput);
+          $form[0].appendChild(destroyInput);
+        }
+        
+        $wrapper.remove();
+        
+        if ($listing.find('li.field-wrapper').length === 0) {
+          $listing.append($cleanTemplate.clone());
+        }
+        
+        return false;
+      });
+    }
+  });
 });

--- a/app/assets/stylesheets/global/hyrax.scss
+++ b/app/assets/stylesheets/global/hyrax.scss
@@ -16,9 +16,9 @@
 @import 'hyrax/hyrax';
 
 // override to show metadata edit functionality on the first item as well
-.multi_value .listing li:first-of-type {
+.child_contributors.multi_value .listing li:first-of-type {
   width: 100%;
 }
-.multi_value .listing li:first-of-type .remove {
+.child_contributors.multi_value .listing li:first-of-type .remove {
   display: block;
 }

--- a/app/transactions/ams/steps/handle_contributors.rb
+++ b/app/transactions/ams/steps/handle_contributors.rb
@@ -29,33 +29,35 @@ module Ams
 
         contributors = change_set.input_params.delete(:contributors) || []
         contrib = contributors.dup.map { |c| c.respond_to?(:to_unsafe_h) ? c.to_unsafe_h.with_indifferent_access : c.dup.with_indifferent_access }
-        contrib.select { |contributor| contributor.values.any?(&:present?) }
+        
+        contrib.select { |contributor| contributor.values.any?(&:present?) || ActiveModel::Type::Boolean.new.cast(contributor['_destroy']) }
       end
 
       def create_or_update_contributions(change_set, contributions)
-        if contributions&.first&.[]("contributor")&.present?
-          inserts = []
-          destroys = []
-          contributions.each do |param_contributor|
-            param_contributor[:contributor] = Array(param_contributor['contributor'])
-            param_contributor[:admin_set_id] = change_set['admin_set_id']
-            param_contributor[:title] = change_set["title"]
-
-            to_destroy = ActiveModel::Type::Boolean.new.cast(param_contributor['_destroy'])
-            if to_destroy
-              destroys << param_contributor[:id]
-              next
-            end
-
-            contributor = Hyrax.query_service.find_by(id: param_contributor[:id]) if param_contributor[:id].present?
-            if contributor
-              param_contributor.delete(:id)
-              contributor_attributes = contributor.attributes.merge(param_contributor.symbolize_keys)
-              contributor_resource = Hyrax.persister.save(resource: ContributionResource.new(contributor_attributes))
-              Hyrax.publisher.publish('object.metadata.updated', object: contributor_resource, user: user)
-              inserts << contributor_resource.id
-              next
-            end
+        return unless contributions.present?
+        
+        inserts = []
+        destroys = []
+        
+        contributions.each do |param_contributor|
+          if ActiveModel::Type::Boolean.new.cast(param_contributor['_destroy'])
+            destroys << param_contributor[:id] if param_contributor[:id].present?
+          end
+        end
+        
+        contributions.select { |c| c["contributor"].present? && !ActiveModel::Type::Boolean.new.cast(c['_destroy']) }.each do |param_contributor|
+          param_contributor[:contributor] = Array(param_contributor['contributor'])
+          param_contributor[:admin_set_id] = change_set['admin_set_id']
+          param_contributor[:title] = change_set["title"]
+          
+          contributor = Hyrax.query_service.find_by(id: param_contributor[:id]) if param_contributor[:id].present?
+          if contributor
+            param_contributor.delete(:id)
+            contributor_attributes = contributor.attributes.merge(param_contributor.symbolize_keys)
+            contributor_resource = Hyrax.persister.save(resource: ContributionResource.new(contributor_attributes))
+            Hyrax.publisher.publish('object.metadata.updated', object: contributor_resource, user: user)
+            inserts << contributor_resource.id
+          else
             param_contributor.delete(:id)
             contribution_resource = Hyrax.persister.save(resource: ContributionResource.new(param_contributor.symbolize_keys))
             Hyrax.index_adapter.save(resource: contribution_resource)
@@ -63,10 +65,10 @@ module Ams
             Hyrax::AccessControlList.copy_permissions(source: target_permissions, target: contribution_resource)
             inserts << contribution_resource.id
           end
-
-          update_members(change_set, inserts, destroys)
-          destroy_contributions(destroys) if destroys.present?
         end
+        
+        update_members(change_set, inserts, destroys)
+        destroy_contributions(destroys) if destroys.present?
       end
 
       def update_members(change_set, inserts, destroys)


### PR DESCRIPTION
original PR:
- https://github.com/WGBH-MLA/ams/pull/983/files
Issue: 
 - https://github.com/notch8/ams/issues/149

This ticket was kicked back from QA. The observed issues are: 
- [x] User can't remove the last contributor even when they clicked to remove all the contributor items

  <details> 

  ![Zight Recording 2025-03-20 at 04 40 17 PM](https://github.com/user-attachments/assets/61f3b913-bffb-4a8e-a37d-4f455df40f03)

  </details> 


OTHER ISSUES: 
- [x] If a user removes all contributor items they can't add a new row by clicking "Add additional Contributor" (UPDATE: ref ticket)
- [x] if a user adds another contributor it duplicates the above field, if populated (UPDATE: Locally I rolled back before this sprint started and this behavior was already happening/not caused by our code changes. I will not create a bug ticket for this).


<details> 

![Zight Recording 2025-03-21 at 11 57 50 AM](https://github.com/user-attachments/assets/7e04eef6-60f7-4205-82fb-158428cb551c)


</details> 