### PR TITLE
I148 fix contributor batch ingest

### DIFF
--- a/app/forms/contribution_resource_form.rb
+++ b/app/forms/contribution_resource_form.rb
@@ -26,7 +26,6 @@ class ContributionResourceForm < Hyrax::Forms::ResourceForm(ContributionResource
   end
   remove(
     %i(
-      affiliation
       based_near
       bibliographic_citation
       creator

--- a/app/services/aapb/batch_ingest/csv_item_ingester.rb
+++ b/app/services/aapb/batch_ingest/csv_item_ingester.rb
@@ -91,6 +91,7 @@ module AAPB
             end
 
             if model_object.is_a?(AssetResource)
+              destroy_current_contributors(model_object)
               attributes = set_asset_objects_attributes(model_object, attributes, ingest_type)
             end
 
@@ -155,6 +156,16 @@ module AAPB
             raise e
           end
           model_object
+        end
+
+        def destroy_current_contributors(work)
+          current_contributions = work.members.select { |member| member.internal_resource == 'Contribution' }
+          current_contributions.each do |contribution|
+            Hyrax.persister.delete(resource: contribution)
+            contribution_doc = SolrDocument.find(contribution.id)
+            Hyrax.index_adapter.delete(resource: contribution_doc)
+            work.member_ids -= [contribution.id]
+          end
         end
 
         def set_options

--- a/app/services/aapb/batch_ingest/csv_reader.rb
+++ b/app/services/aapb/batch_ingest/csv_reader.rb
@@ -43,7 +43,13 @@ module AAPB
           ((@workbook.first_column)..@workbook.last_column).each do |col|
             rowData << [@workbook.cell(1, col), @workbook.cell(row, col).to_s]
           end
+
           formatted_row_data = csv_row_to_hash(rowData)
+
+          # We want to take the Contribution batches and put them in as a nested attribute for the Asset instead
+          # this way the ingester would pass it as params, like how you would from the UI.  This way we don't
+          # see it in the UI because it doesn't get created through the form with all the access controls
+          formatted_row_data['Asset']['contributors'] = formatted_row_data.delete('Contribution') if formatted_row_data['Asset']
 
           @batch_items << Hyrax::BatchIngest::BatchItem.new(id_within_batch: row,
                                                             source_data: formatted_row_data.to_json, status: :initialized)

--- a/app/services/aapb/batch_ingest/csv_reader.rb
+++ b/app/services/aapb/batch_ingest/csv_reader.rb
@@ -30,7 +30,7 @@ module AAPB
 
       def validate_csv_header
         configured_keys = @options_structure.header_keys.sort
-        @header.sort.each do |key|
+        @header.sort.uniq.each do |key|
           raise("Unknown column `#{key}` Unable to parse CSV.") if configured_keys.exclude?(key)
         end
       end
@@ -135,6 +135,9 @@ module AAPB
       def validate_row_data row, node, child_node = nil
         fail_row = false
         if node.ingest_type == "update" || node.ingest_type == "add"
+          # When we update a contribution, we get rid of the old contributions and create new ones
+          return row if node.object_class == "Contribution"
+
           if child_node
             row[node.object_class].each do |c_data|
               if c_data.to_a.flatten.exclude?("id")

--- a/app/transactions/ams/steps/handle_contributors.rb
+++ b/app/transactions/ams/steps/handle_contributors.rb
@@ -25,10 +25,11 @@ module Ams
       private
 
       def extract_contributions(change_set)
-        return [] unless change_set.input_params.has_key?(:contributors)
+        return [] unless change_set.input_params.has_key?(:contributors) || change_set.input_params.has_key?('contributors')
 
-        contributors = change_set.input_params.delete(:contributors) || []
+        contributors = change_set.input_params.delete(:contributors) || change_set.input_params.delete('contributors') || []
         contrib = contributors.dup.map { |c| c.respond_to?(:to_unsafe_h) ? c.to_unsafe_h.with_indifferent_access : c.dup.with_indifferent_access }
+
         contrib.select { |contributor| contributor.values.any?(&:present?) }
       end
 

--- a/config/batch_ingest.yml
+++ b/config/batch_ingest.yml
@@ -87,6 +87,14 @@ ingest_types:
           - playlist_order
           - organization
           - proxy_start_time
+        children:
+        - object_class: Contribution
+          ingest_type: update
+          attributes:
+            - contributor
+            - contributor_role
+            - portrayal
+            - affiliation
   aapb_csv_reader_4:
     label: "AAPB CSV Asset Multivalue Attribute Addition Ingester"
     reader: "AAPB::BatchIngest::CSVReader"
@@ -135,6 +143,14 @@ ingest_types:
           - producing_organization
           - sonyci_id
           - special_collections
+        children:
+        - object_class: Contribution
+          ingest_type: update
+          attributes:
+            - contributor
+            - contributor_role
+            - portrayal
+            - affiliation
   zipped_pbcore_digital_instantiation:
     label: "AAPB Digital Instantiation PBCore - Zipped"
     reader: "AAPB::BatchIngest::ZippedPBCoreDigitalInstantiationReader"

--- a/spec/factories/asset_resources.rb
+++ b/spec/factories/asset_resources.rb
@@ -73,47 +73,60 @@ FactoryBot.define do
       ] }
     end
 
-    trait :with_digital_instantation_resource do
-      members { [ create(:digital_instantation_resource) ] }
+    trait :with_digital_instantiation_resource do
+      members { [ create(:digital_instantiation_resource) ] }
     end
 
-    trait :with_digital_instantation_resource_and_essence_track_resource do
-      members { [ create(:digital_instantation_resource, :aapb_moving_image_with_essence_track_resource) ] }
+    trait :with_digital_instantiation_resource_and_essence_track_resource do
+      members { [ create(:digital_instantiation_resource, :aapb_moving_image_with_essence_track_resource) ] }
     end
 
-    trait :with_two_digital_instantation_resources_and_essence_track_resources do
+    trait :with_two_digital_instantiation_resources_and_essence_track_resources do
       members { [
-        create(:digital_instantation_resource, :aapb_moving_image_with_essence_track_resource),
-        create(:digital_instantation_resource, :aapb_moving_image_with_essence_track_resource)
+        create(:digital_instantiation_resource, :aapb_moving_image_with_essence_track_resource),
+        create(:digital_instantiation_resource, :aapb_moving_image_with_essence_track_resource)
       ] }
     end
 
     trait :with_physical_digital_and_essence_track_resource do
       members { [
-        create(:physical_instantation_resource),
-        create(:digital_instantation_resource, :aapb_moving_image_with_essence_track_resource),
+        create(:physical_instantiation_resource),
+        create(:digital_instantiation_resource, :aapb_moving_image_with_essence_track_resource),
       ] }
     end
 
     trait :family do
-      members do
-        [
-          rand(2..4).times.map do
-            create(:digital_instantation_resource,
-              members: rand(2..4).times.map do
-                create(:essence_track_resource)
-              end
-            )
-          end,
-          rand(1..2).times.map do
-            create(:physical_instantation_resource,
-              members: rand(2..4).times.map do
-                create(:essence_track_resource)
-              end
-            )
-          end,
-          rand(2..4).times.map { create(:contribution_resource) }
-        ].flatten
+      after(:create) do |work|
+        digital_instantiations = rand(2..4).times.map do
+          digital_instantiation = create(:digital_instantiation_resource)
+
+          essence_tracks = rand(2..4).times.map do
+            create(:essence_track_resource)
+          end
+
+          digital_instantiation.member_ids = essence_tracks.map(&:id)
+          Hyrax.persister.save(resource: digital_instantiation)
+        end
+
+        physical_instantiations = rand(1..2).times.map do
+          physical_instantiation = create(:physical_instantiation_resource)
+
+          essence_tracks = rand(2..4).times.map do
+            create(:essence_track_resource)
+          end
+
+          physical_instantiation.member_ids = essence_tracks.map(&:id)
+          Hyrax.persister.save(resource: physical_instantiation)
+        end
+
+        contributions = rand(2..4).times.map do
+          create(:contribution_resource)
+        end
+
+        all_members = digital_instantiations + physical_instantiations + contributions
+        work.member_ids = all_members.flat_map(&:id)
+
+        Hyrax.persister.save(resource: work)
       end
     end
 

--- a/spec/factories/contribution_resources.rb
+++ b/spec/factories/contribution_resources.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :contribution_resource do
+    contributor  { ["Test Contributor"] }
+    contributor_role  { "Actor" }
+    portrayal  { "Test portrayal" }
+    affiliation  { "Test affiliation" }
+  end
+end

--- a/spec/factories/essence_track_resources.rb
+++ b/spec/factories/essence_track_resources.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :essence_track_resource, class: EssenceTrackResource do
+    sequence(:title) { |n| ["Test Essense Track #{n}"] }
+    track_type  { "Test Type" }
+    track_id  { ["1"] }
+  end
+end


### PR DESCRIPTION
## Remove `affiliation` from the removed properties

151ec039266d7473051485bcac4c108ead990a1b

This commit will remove affiliation from the form's removal, which means
it's back.  I think it was erroneously added in there to begin with.

## Fix a few fixtures

47f8b0313c6b4f75a1d96d8d8214194dbb57790b

This commit was started because I wanted to write tests and found errors
in the fixtures.  Ultimately, I didn't need a spec but thought I'd
include this anyway.

## Handle contribution object differently

97f2c9d00f72ccf2b7192d8ba46b807638fc21db

Since we don't want the Contribution objects to show in the view, it
shouldn't be handled via the forms.  Instead, we want it to be handled
as if it was being added through an Asset Resource form.  There's
currently a "Credits" dropdown that now handles this through the
handle_contributors transaction.

By adding the Contribution data to the formatted_row_data before it is
sent off to the make a Hyrax::BatchIngest::BatchItem, we can inject the
information there.

## Handle destroying current ContributionResources

44faa052d3a77044219c3d55b655127951ab2158

This commit will add logic for updates to destroy the current
ContributionResources.  In an update, we want to replace what's there
while in an add we want to add to what is already there.

## Add Contribution to batch_ingest.yml

1db0f4e6fee3112273e64745001bc5ac5cf59746

This commit will add the Contribution object_class to the
batch_ingest.yml so now it passes the validation.  We don't need an id
because we are creating brand new ContributionResource objects.
