### PR TITLE
Default to physicalInstantiation Resources

### DIFF
--- a/app/services/aapb/batch_ingest/pbcore_xml_ingester_behavior.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_ingester_behavior.rb
@@ -19,9 +19,10 @@ module AAPB
         def pbcore_digital_instantiations
           pbcore.instantiations.select { |inst| inst.digital }
         end
-        
+
+        # both physical and unidentified format
         def pbcore_physical_instantiations
-          pbcore.instantiations.select { |inst| inst.physical }
+          pbcore.instantiations.reject { |inst| inst.digital }
         end
 
         def current_ability

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -171,7 +171,8 @@ module AAPB
 
       def physical_instantiation_resource_attributes
         @physical_instantiation_resource_attributes ||= instantiation_attributes.tap do |attrs|
-          attrs[:format] = pbcore.physical.value || nil
+          format = pbcore.physical&.value
+          attrs[:format] = format.present? ? pbcore.physical&.value : 'Instantiation format not provided'
         end
       end
 
@@ -190,7 +191,6 @@ module AAPB
           attrs[:standard]                        = pbcore.standard&.value
           attrs[:location]                        = pbcore.location&.value
           attrs[:media_type]                      = pbcore.media_type&.value
-          attrs[:format]                          = pbcore.physical&.value
           attrs[:generations]                     = pbcore.generations.map(&:value)
           attrs[:time_start]                      = pbcore.time_start&.value
           attrs[:duration]                        = pbcore.duration&.value&.gsub('?', '')


### PR DESCRIPTION
## Description

https://github.com/notch8/ams/issues/150

For PBCORE zip imports, this change causes imports to default to creating PhysicalInstantiationResource objects for unspecified instantiation formats in the PBCORE XML. These imports will no longer result in an error unless other error situations occur.

The Format shown on the object will say `Instantiation format not provided`

## Examples

Tested with zip file as provided in the issue. This zip file resulted in two Assets, each with a Physical Instantiation Resource. The third xml document failed to create an asset due to an invalid Annotation Type. 

<details>
<summary>Screenshots</summary>

### The batch ingest view
![Screenshot 2025-03-20 at 7 13 46 PM](https://github.com/user-attachments/assets/76d6a1d2-717e-4376-8c3f-aac14f64a5e5)

### Screenshots of the Asset & Physical Instantiation

![screencapture-ams-test-concern-asset-resources-cpb-aacip-41-300zpgv8-2025-03-20-19_23_32](https://github.com/user-attachments/assets/7e0ce55d-b711-4dab-97f2-45e478747744)

![screencapture-ams-test-concern-parent-cpb-aacip-315-18dfn550-physical-instantiations-cpb-aacip-3e91eb97656-2025-03-20-19_14_12](https://github.com/user-attachments/assets/48729343-566c-4cec-97c4-eccccb924952)

</details>