### PR TITLE
Remove ContributionResource creation button

### DIFF
--- a/app/models/asset_resource.rb
+++ b/app/models/asset_resource.rb
@@ -9,8 +9,10 @@ class AssetResource < Hyrax::Work
   include AMS::WorkBehavior
   include AMS::CreateMemberMethods
 
-  self.valid_child_concerns = [DigitalInstantiationResource, PhysicalInstantiationResource, ContributionResource]
-
+  # Removed ContributionResource since we treat it more as nested metadata and never want
+  # to add it separately through a form. It is added in the Asset's metadata section.
+  self.valid_child_concerns = [DigitalInstantiationResource, PhysicalInstantiationResource]
+  
   VALIDATION_STATUSES = {
     valid: 'valid',
     missing_children: 'missing child record(s)',


### PR DESCRIPTION
Removes the button to create a ContributionResource from the AssetResource form. This is because ContributionResources are created as part of the asset's metadata (under the credits section) and not as a separate entity. ContributionResources are never created on their own or using a form.

This carries along from work to get the contribution behaviors working within the asset's `Credit` section. Initially they were created to be child resources but in reality they are treated as nested metadata so the full resource functionality is not needed or desired. 

### Note: 

This appears to have a larger implications in specs... I did a preliminary check in the UI to see if anything broke, but more testing should be done before fixing specs & merging.
