### PR TITLE
:bug: [i-149] a user should be able to remove all contributors

### DIFF
--- a/app/assets/javascripts/work_actions/child_contributors_input.js
+++ b/app/assets/javascripts/work_actions/child_contributors_input.js
@@ -1,4 +1,10 @@
 $(document).ready(function() {
+  var $template = $('.form-group.child_contributors .listing li.field-wrapper').first().clone();
+  
+  $('.form-group.child_contributors .has-warning, .form-group.child_contributors .message.has-warning').remove();
+  
+  $('.form-group.child_contributors .add').off('click');
+  
   $('.form-group.child_contributors .remove').on('click', function(e) {
     var $wrapper = $(this).closest('li.field-wrapper');
     var contributorId = $wrapper.find('input[name$="[id]"]').val();
@@ -6,23 +12,47 @@ $(document).ready(function() {
     if (contributorId && contributorId !== '') {
       var $form = $(this).closest('form');
 
-      // Create a hidden input for the ID
       var idInput = $('<input>')
         .attr('type', 'hidden')
         .attr('name', 'asset_resource[contributors][][id]')
         .val(contributorId);
 
-      // Create a hidden input for _destroy flag
       var destroyInput = $('<input>')
         .attr('type', 'hidden')
         .attr('name', 'asset_resource[contributors][][_destroy]')
         .val('true');
 
-      // Add them to the form
       $form.append(idInput);
       $form.append(destroyInput);
     }
 
     $wrapper.remove();
+  });
+
+  // Override the hydra-editor's warning display function
+  if (typeof FieldManager !== 'undefined') {
+    FieldManager.prototype.displayEmptyWarning = function() {
+      // Do nothing - this prevents the warning from being displayed
+    };
+  }
+
+  $('.form-group.child_contributors .add').on('click', function(e) {
+    e.preventDefault(); // Prevent default hydra-editor behavior
+    e.stopPropagation();
+    
+    $('.form-group.child_contributors .has-warning, .form-group.child_contributors .message.has-warning').remove();
+    
+    var $listing = $(this).closest('.form-group.child_contributors').find('.listing');
+    
+    var $templateToUse = $listing.children('li.field-wrapper').last().length > 0 
+      ? $listing.children('li.field-wrapper').last()
+      : $template;
+    
+    var $newField = $templateToUse.clone();
+    $newField.find('input').val('').removeAttr('required');
+    
+    $listing.append($newField);
+    
+    $newField.find('input').first().focus();
   });
 });

--- a/app/assets/stylesheets/global/hyrax.scss
+++ b/app/assets/stylesheets/global/hyrax.scss
@@ -15,10 +15,15 @@
 @import "hyrax/blacklight_gallery";
 @import 'hyrax/hyrax';
 
-// override to show metadata edit functionality on the first item as well
-.multi_value .listing li:first-of-type {
+/* Allow the first contributor in a list to be removable
+ * By default, many systems prevent removing the first item to ensure at least one remains
+ * This override ensures the first contributor:
+ * 1. Takes up full width (100%)
+ * 2. Shows the remove button (which is usually hidden for first items)
+ */
+.child_contributors.multi_value .listing li:first-of-type {
   width: 100%;
 }
-.multi_value .listing li:first-of-type .remove {
+.child_contributors.multi_value .listing li:first-of-type .remove {
   display: block;
 }

--- a/app/transactions/ams/steps/handle_contributors.rb
+++ b/app/transactions/ams/steps/handle_contributors.rb
@@ -34,7 +34,7 @@ module Ams
       end
 
       def create_or_update_contributions(change_set, contributions)
-        if contributions&.first&.[]("contributor")&.present?
+        if contributions.present?
           inserts = []
           destroys = []
           contributions.each do |param_contributor|
@@ -43,7 +43,7 @@ module Ams
             param_contributor[:title] = change_set["title"]
 
             to_destroy = ActiveModel::Type::Boolean.new.cast(param_contributor['_destroy'])
-            if to_destroy
+            if to_destroy && param_contributor[:id].present?
               destroys << param_contributor[:id]
               next
             end


### PR DESCRIPTION
original PR:
- https://github.com/WGBH-MLA/ams/pull/983/files
Issue: 
 - https://github.com/notch8/ams/issues/149

This ticket was kicked back from QA. The observed issues are: 
- [x] User can't remove the last contributor even when they clicked to remove all the contributor items

  <details> 

  ![Zight Recording 2025-03-20 at 04 40 17 PM](https://github.com/user-attachments/assets/61f3b913-bffb-4a8e-a37d-4f455df40f03)

  </details> 


OTHER ISSUES: 
- [x] If a user removes all contributor items they can't add a new row by clicking "Add additional Contributor". The user must refresh the page to get a row back. 

<details> 

![Zight Recording 2025-03-21 at 01 41 22 PM](https://github.com/user-attachments/assets/503bed59-91ad-4232-8d81-908bbbe82b07)


</details> 


**UPDATE:** 

![Zight Recording 2025-03-21 at 01 57 52 PM](https://github.com/user-attachments/assets/220ba74e-c238-4954-a36b-e80b1dc08291)
