### PR TITLE
check for media type before ingesting

### DIFF
--- a/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_item_ingester.rb
@@ -19,6 +19,11 @@ module AAPB
           # the stack if the user cannot be converted to a Sipity::Entity.
           raise "Could not find or create Sipity Agent for user #{submitter}" unless sipity_agent
 
+          # This halts the Asset ingestion as well as subsequent Instantiations if media type is missing.
+          pbcore.instantiations.each do |instantiation|
+            raise "Missing media_type in instantiation" if instantiation.media_type.blank?
+          end
+
           batch_item_object = ingest_asset!
 
           pbcore_digital_instantiations.each do |pbcore_digital_instantiation|


### PR DESCRIPTION
Stops ingesting the Asset if the media_type is missing on any of the Instantiations, and then continues to the next Asset