### PR TITLE
update-build-action-trigger-merge-to-develop

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches:
       - develop
-      - main
+  push:
+    branches:
+      - develop
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -54,7 +56,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         with:
           limit-access-to-actor: true
-      - name: Build and push
+      - name: Build and push base/web
         uses: docker/build-push-action@v3
         with:
           context: .


### PR DESCRIPTION
### Summary

This PR updates the GitHub Actions workflow trigger to ensure CI runs not only on pull requests *targeting* `develop`, but also when changes are *merged into* `develop`.

### Changes

- Added `push` trigger on `develop` in the `on:` block.
- This ensures builds occur post-merge, closing the gap in CI coverage.

### Why

Previously, CI wouldn't run after merging a PR into `develop`, which could let errors through if something unexpected passed review. This aligns CI behavior with common expectations for protected branches.

### Test Plan

- After merging this PR, push an empty commit to `develop` to validate CI runs:
