### PR TITLE
Fix `Contribution` internal resource bug

### DIFF
--- a/app/transactions/ams/steps/handle_contributors.rb
+++ b/app/transactions/ams/steps/handle_contributors.rb
@@ -52,6 +52,7 @@ module Ams
             if contributor
               param_contributor.delete(:id)
               contributor_attributes = contributor.attributes.merge(param_contributor.symbolize_keys)
+              contributor_attributes.delete(:internal_resource)
               contributor_resource = Hyrax.persister.save(resource: ContributionResource.new(contributor_attributes))
               Hyrax.publisher.publish('object.metadata.updated', object: contributor_resource, user: user)
               inserts << contributor_resource.id


### PR DESCRIPTION
Given a Contribution that hasn't been migrated to a Valkyrie Resource, when we look at the contributor attrs, we already have an internal resource but that needs to be deleted so it can be automatically generated otherwise we set the string like "#<Class:0x00...>" as the `internal_resource`.  The `internal_resource` should be "Contribution".

Ref:
- https://github.com/notch8/ams/issues/151