### PR TITLE
ingesters now do two things around missing PI format. 

### DIFF
--- a/app/services/aapb/batch_ingest/csv_item_ingester.rb
+++ b/app/services/aapb/batch_ingest/csv_item_ingester.rb
@@ -78,7 +78,7 @@ module AAPB
           attributes["admin_set_id"] = @batch_item.batch.admin_set_id
 
           unless %w[Asset DigitalInstantiation EssenceTrack].include?(node.object_class)
-            attributes["format"] = attributes["format"].present? ? attributes["format"] : '   '
+            attributes["format"] = attributes["format"].presence || 'Unavailable' if with_data.key?("format")
           end
 
           if ingest_type == "new"

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -171,8 +171,10 @@ module AAPB
 
       def physical_instantiation_resource_attributes
         @physical_instantiation_resource_attributes ||= instantiation_attributes.tap do |attrs|
-          format = pbcore.physical&.value
-          attrs[:format] = format.present? ? pbcore.physical&.value : 'Instantiation format not provided'
+          if pbcore.physical&.present?
+            attrs[:format] = pbcore.physical&.value.presence || 'Unavailable'
+          end
+
         end
       end
 


### PR DESCRIPTION
If heading/tag exists but is empty, an 'Unavailable' placeholder is added, if the heading/tag does not exist it just doesn't add it to the metadata.