### PR TITLE
Make requested fields single value only for instantiations.

### DIFF
--- a/app/forms/digital_instantiation_resource_form.rb
+++ b/app/forms/digital_instantiation_resource_form.rb
@@ -16,6 +16,8 @@ class DigitalInstantiationResourceForm < Hyrax::Forms::ResourceForm(DigitalInsta
 
   self.required_fields += [:title, :location, :holding_organization]
 
+  self.single_valued_fields = [:location, :alternative_modes, :standard, :tracks, :channel_configuration]
+
   class_attribute :field_groups
 
   #removing id, created_at & updated_at from attributes

--- a/app/forms/digital_instantiation_resource_form.rb
+++ b/app/forms/digital_instantiation_resource_form.rb
@@ -10,6 +10,7 @@ class DigitalInstantiationResourceForm < Hyrax::Forms::ResourceForm(DigitalInsta
   include Hyrax::FormFields(:digital_instantiation_resource)
   include DisabledFields
   include ChildCreateButton
+  include SingleValuedForm
   include InheritParentTitle
 
   attr_accessor :controller, :current_ability

--- a/app/forms/physical_instantiation_resource_form.rb
+++ b/app/forms/physical_instantiation_resource_form.rb
@@ -18,7 +18,7 @@ class PhysicalInstantiationResourceForm < Hyrax::Forms::ResourceForm(PhysicalIns
 
   self.required_fields += [:format, :location, :media_type, :holding_organization]
 
-  self.single_valued_fields = [:title]
+  self.single_valued_fields = [:title, :location, :alternative_modes, :standard, :tracks, :channel_configuration]
 
   #removing id, created_at & updated_at from attributes
   instantiation_admin_data_attributes = (InstantiationAdminData.attribute_names.dup - ['id', 'created_at', 'updated_at']).map &:to_sym


### PR DESCRIPTION
Following fields have been made single value instead of multi-value:

- Location
- Alternative Modes
- Standard
- Tracks
- Channel Configuration
