### PR TITLE
🐛 Fix gateway error

### DIFF
--- a/app/controllers/pushes_controller.rb
+++ b/app/controllers/pushes_controller.rb
@@ -12,10 +12,10 @@ class PushesController < ApplicationController
   end
 
   def create
-    @push = Push.new(user_id: current_user.id, pushed_id_csv: pushed_id_csv_from_id_field )
+    @push = Push.create(user_id: current_user.id, status: 'pending')
     if @push.valid?
-      PushToAAPBJob.perform_later(ids: @push.push_ids, user: current_user)
-      @push.save!
+      SavePushJob.perform_later(push: @push, pushed_id_csv: pushed_id_csv_from_id_field)
+      PushToAAPBJob.perform_later(id: @push.id, user: current_user)
       redirect_to @push
     else
       render :new

--- a/app/jobs/push_to_aapb_job.rb
+++ b/app/jobs/push_to_aapb_job.rb
@@ -16,13 +16,24 @@ class PushToAAPBJob < ApplicationJob
   # Runs the search, compiles the results, and delivers them.
   # NOTE: named arguments to #perform are accessed in other methods via
   #   #named_arguments (see ApplicationJob#named_arguments).
-  def perform(ids:, user:)
-    delivery.deliver
+  def perform(id:, user:)
+    push = Push.find(id)
+
+    if push.push_ids.present?
+      delivery.deliver
+    else
+      PushToAAPBJob.set(wait: 1.minute).perform_later(id: id, user: user)
+      @rescheduled = true
+    end
   end
 
-  after_perform { notification.send_success }
+  after_perform { notification.send_success } unless @rescheduled
 
   private
+
+    def ids
+      @ids ||= Push.find(named_arguments[:id]).push_ids
+    end
 
     def delivery
       @delivery ||= AMS::Export::Delivery::AAPBDelivery.new(export_results: results)
@@ -33,7 +44,7 @@ class PushToAAPBJob < ApplicationJob
     end
 
     def search
-      @search ||= AMS::Export::Search::CombinedIDSearch.new(ids: named_arguments[:ids], user: named_arguments[:user], model_class_name: 'Asset')
+      @search ||= AMS::Export::Search::CombinedIDSearch.new(ids: ids, user: named_arguments[:user], model_class_name: 'Asset')
     end
 
     def notification

--- a/app/jobs/save_push_job.rb
+++ b/app/jobs/save_push_job.rb
@@ -1,0 +1,14 @@
+class SavePushJob < ApplicationJob
+  queue_as :push_to_aapb
+
+  def perform(push:, pushed_id_csv:)
+    begin
+      push.pushed_id_csv = pushed_id_csv
+      push.status = 'pushed'
+      push.save!
+    rescue => e
+      Rails.logger.error("SavePushJob failed for push ID #{push.id}: #{e.message}")
+      push.update(status: "Push Error: #{e.message}")
+    end
+  end
+end

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -13,7 +13,7 @@ class Push < ApplicationRecord
   # TODO: we could just use a serialized field for push_ids rather than manually
   # converting it to CSV and back again. Would require migration of course.
   def push_ids
-    pushed_id_csv.to_s.split(',')
+    Array(pushed_id_csv&.to_s&.split(','))
   end
 
   private

--- a/app/views/pushes/show.html.erb
+++ b/app/views/pushes/show.html.erb
@@ -1,15 +1,21 @@
 <h3>Push #<%= @push.id %></h3>
 
 <h5>Initiated by <%= @push.user.email %> at <%= @push.created_at.strftime('%m-%e-%y %H:%M') %></h5>
-
-<h5>Included IDs</h5>
-<% @ids = @push.pushed_id_csv.split(',') %>
-<ul>
-  <% @ids.each do |id| %>
-    <li>
-      <%= id %>
-    </li>
-  <% end %>  
-</ul>
-
+<% status = @push.status %>
+<% if status.present? %>
+  <h5>Status: <%= status %></h5>
+<% end %>
+<% @ids = Array(@push.pushed_id_csv&.split(',')) %>
+<% if @ids.blank? && @push.status == 'pending' %>
+  <p>IDs are being saved to this record, refresh periodically.</p>
+<% else %>
+  <h5>Included IDs</h5>
+  <ul>
+    <% @ids.each do |id| %>
+      <li>
+        <%= id %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
 <%= link_to "Back To Pushes", pushes_path %>

--- a/db/migrate/20250516192817_push.rb
+++ b/db/migrate/20250516192817_push.rb
@@ -1,0 +1,5 @@
+class Push < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pushes, :status, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_07_194231) do
+ActiveRecord::Schema.define(version: 2025_05_16_192817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -470,6 +470,7 @@ ActiveRecord::Schema.define(version: 2024_03_07_194231) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.string "status"
   end
 
   create_table "qa_local_authorities", force: :cascade do |t|

--- a/db/schema.test.rb
+++ b/db/schema.test.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_07_053156) do
+ActiveRecord::Schema.define(version: 2025_05_16_192817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -470,6 +470,7 @@ ActiveRecord::Schema.define(version: 2024_03_07_053156) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.string "status"
   end
 
   create_table "qa_local_authorities", force: :cascade do |t|

--- a/spec/controllers/pushes_controller_spec.rb
+++ b/spec/controllers/pushes_controller_spec.rb
@@ -96,19 +96,20 @@ RSpec.describe PushesController, type: :controller do
     let(:params) { { id_field: asset_resource_ids.join("\n") } }
 
     # The params with which we expect to run the PushToAAPBJob
-    let(:expected_job_params) { { user: user, ids: asset_resource_ids } }
+    let(:expected_job_params) { { id: Push.last.id, user: user } }
+    let(:pushed_id_csv) { params.fetch(:id_field, '').split(/\s+/).reject(&:empty?).uniq.join(',') }
 
     # Hook up the mocks
     before do
+      ActiveJob::Base.queue_adapter = :test
+      post :create, params: params
       allow(PushToAAPBJob).to receive(:perform_later).with(expected_job_params)
     end
 
     it 'creates a new Push instance and calls :perform_later on ' \
       'ExportRecordJob with correct search params' do
-      expect { post :create, params: params }.to change { Push.count }.by(1)
-      expect(PushToAAPBJob).to have_received(:perform_later).
-                              with(expected_job_params).
-                              exactly(1).times
+      expect(SavePushJob).to have_been_enqueued.with(push: Push.last, pushed_id_csv: pushed_id_csv).exactly(:once)
+      expect(PushToAAPBJob).to have_been_enqueued.with(expected_job_params).exactly(:once)
     end
   end
 end

--- a/spec/jobs/push_to_aapb_job_spec.rb
+++ b/spec/jobs/push_to_aapb_job_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe PushToAAPBJob, type: :job do
-  describe '.perform_now' do
+  include ActiveJob::TestHelper
 
-    let(:ids) { Array.new(500) { SecureRandom.uuid } }
+  describe '.perform_now' do
+    let(:push) { create(:push, user_id: user.id, status: 'pending') }
+    let(:id) { push.id }
     let(:user) { create(:user) }
 
     let(:delivery_instance) { instance_double(AMS::Export::Delivery::AAPBDelivery) }
@@ -16,13 +18,36 @@ RSpec.describe PushToAAPBJob, type: :job do
       allow_any_instance_of(described_class).to receive(:delivery).and_return(delivery_instance)
       allow_any_instance_of(described_class).to receive(:notification).and_return(notification_instance)
 
-      # Call the method under test and assert expectations below.
-      described_class.perform_now(ids: ids, user: user)
     end
 
-    it 'call #deliver of its AMS::Export::Delivery::AAPBDelivery instance' do
-      expect(delivery_instance).to have_received(:deliver)
-      expect(notification_instance).to have_received(:send_success)
+    context 'when push ids are present' do
+      before do
+        allow(Push).to receive(:find).and_return(push)
+        allow(push).to receive(:push_ids).and_return(Array.new(500) { SecureRandom.uuid })
+
+        # Call the method under test and assert expectations below.
+        described_class.perform_now(id: id, user: user)
+      end
+
+      it 'call #deliver of its AMS::Export::Delivery::AAPBDelivery instance' do
+        expect(delivery_instance).to have_received(:deliver)
+        expect(notification_instance).to have_received(:send_success)
+      end
+    end
+
+    context 'when push ids are not present' do
+      before do
+        allow(Push).to receive(:find).and_return(push)
+        allow(push).to receive(:push_ids).and_return([])
+
+        # Call the method under test and assert expectations below.
+        described_class.perform_now(id: id, user: user)
+      end
+
+      it 'reschedules the job' do
+        expect(delivery_instance).not_to have_received(:deliver)
+        expect(PushToAAPBJob).to have_been_enqueued.with({ id: push.id, user: user }).exactly(:once)
+      end
     end
   end
 end


### PR DESCRIPTION
We think the gateway error was happening because the Push object was taking too long to save.  Now the Push object is being saved in Sidekiq so the user will be redirected immediately to the Push show page after hitting `Send To AAPB`.  A few changes to the Push show page were made to display a status if it has one (old Pushes will not have statuses).

Ref:
- https://github.com/notch8/ams/issues/156