### PR TITLE
Contributor updates

### DIFF
--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -145,6 +145,7 @@ module Hyrax
                 actor ||= Hyrax::CurationConcern.actor
                 # Moving contributor into Array before saving object
                 param_contributor[:contributor] = Array(param_contributor[:contributor])
+                param_contributor[:annotation] = param_contributor[:annotation].to_s if param_contributor.key?(:annotation)
                 param_contributor[:admin_set_id] = env.curation_concern.admin_set_id
                 param_contributor[:title] = env.attributes["title"]
 

--- a/app/actors/hyrax/actors/asset_actor.rb
+++ b/app/actors/hyrax/actors/asset_actor.rb
@@ -146,6 +146,8 @@ module Hyrax
                 # Moving contributor into Array before saving object
                 param_contributor[:contributor] = Array(param_contributor[:contributor])
                 param_contributor[:annotation] = param_contributor[:annotation].to_s if param_contributor.key?(:annotation)
+                param_contributor[:affiliation] = param_contributor[:affiliation].to_s if param_contributor.key?(:affiliation)
+                param_contributor[:portrayal] = param_contributor[:portrayal].to_s if param_contributor.key?(:portrayal)
                 param_contributor[:admin_set_id] = env.curation_concern.admin_set_id
                 param_contributor[:title] = env.attributes["title"]
 

--- a/app/forms/asset_resource_form.rb
+++ b/app/forms/asset_resource_form.rb
@@ -89,7 +89,7 @@ class AssetResourceForm < Hyrax::Forms::ResourceForm(AssetResource)
     child_contributions = []
     model.members.to_a.each do |member|
       if( member.internal_resource == 'Contribution' )
-        child_contributions << [member.id, member.contributor_role, member.contributor.first , member.portrayal, member.affiliation]
+        child_contributions << [member.id, member.contributor_role, member.contributor.first , member.portrayal, member.affiliation, member.annotation]
       end
     end
     child_contributions

--- a/app/forms/hyrax/asset_form.rb
+++ b/app/forms/hyrax/asset_form.rb
@@ -102,7 +102,7 @@ module Hyrax
       child_contributions = []
       model.ordered_members.to_a.each do |member|
          if( member.class == Contribution )
-            child_contributions << [member.id, member.contributor_role, member.contributor.first , member.portrayal, member.affiliation]
+            child_contributions << [member.id, member.contributor_role, member.contributor.first , member.portrayal, member.affiliation, member.annotation]
          end
        end
       child_contributions
@@ -172,7 +172,7 @@ module Hyrax
       end
     end
 
-    def bulkrax_importer_id 
+    def bulkrax_importer_id
       if model.admin_data
         model.admin_data.bulkrax_importer_id
       else

--- a/app/forms/hyrax/contribution_form.rb
+++ b/app/forms/hyrax/contribution_form.rb
@@ -1,14 +1,12 @@
-# Generated via
-#  `rails generate hyrax:work Contribution`
 module Hyrax
   class ContributionForm < Hyrax::Forms::WorkForm
     include SingleValuedForm
     include InheritParentTitle
-    
+
     self.model_class = ::Contribution
-    self.terms += [ :contributor_role, :portrayal]
+    self.terms += [:contributor_role, :portrayal, :annotation]
     self.terms -= [:language, :description, :relative_path, :import_url, :date_created, :resource_type, :creator, :keyword, :license, :rights_statement, :publisher, :subject, :identifier, :based_near, :related_url, :bibliographic_citation, :source]
     self.required_fields -= [:creator, :keyword, :rights_statement]
-    self.single_valued_fields = [:title, :contributor]
+    self.single_valued_fields = [:title, :contributor, :annotation]
   end
 end

--- a/app/forms/hyrax/contribution_form.rb
+++ b/app/forms/hyrax/contribution_form.rb
@@ -4,9 +4,9 @@ module Hyrax
     include InheritParentTitle
 
     self.model_class = ::Contribution
-    self.terms += [:contributor_role, :portrayal, :annotation]
+    self.terms += [:contributor_role, :affiliation, :portrayal, :annotation]
     self.terms -= [:language, :description, :relative_path, :import_url, :date_created, :resource_type, :creator, :keyword, :license, :rights_statement, :publisher, :subject, :identifier, :based_near, :related_url, :bibliographic_citation, :source]
     self.required_fields -= [:creator, :keyword, :rights_statement]
-    self.single_valued_fields = [:title, :contributor, :annotation]
+    self.single_valued_fields = [:title, :contributor, :contributor_role, :affiliation, :portrayal, :annotation]
   end
 end

--- a/app/input/child_contributors_input.rb
+++ b/app/input/child_contributors_input.rb
@@ -33,6 +33,12 @@ class ChildContributorsInput < MultiValueInput
       id: input_dom_id_prefix + "_affiliation"
     )
 
+    annotation_text_input_html_options = input_html_options.dup.merge(
+      name: "#{@builder.object_name}[contributors][][annotation]",
+      value: value[5],
+      placeholder: "Annotation",
+      id: input_dom_id_prefix + "_annotation"
+    )
     id_hidden_options = input_html_options.dup.merge(
         value: value[0],
         name: "#{@builder.object_name}[contributors][][id]",
@@ -48,6 +54,8 @@ class ChildContributorsInput < MultiValueInput
     portrayal_text_input_html_options[:class].delete(:required)
     affiliation_text_input_html_options.delete(:required)
     affiliation_text_input_html_options[:class].delete(:required)
+    annotation_text_input_html_options.delete(:required)
+    annotation_text_input_html_options[:class].delete(:required)
 
     if contributor_text_input_html_options[:title_value].blank?
       if @rendered_first_element
@@ -61,6 +69,7 @@ class ChildContributorsInput < MultiValueInput
     output += @builder.text_field(:contributor_name, contributor_text_input_html_options)
     output += @builder.text_field(:affiliation, affiliation_text_input_html_options)
     output += @builder.text_field(:portrayal, portrayal_text_input_html_options)
+    output += @builder.text_field(:annotation, annotation_text_input_html_options)
     output
   end
 end

--- a/app/models/ams/pbcore_xml_export_extension.rb
+++ b/app/models/ams/pbcore_xml_export_extension.rb
@@ -155,11 +155,21 @@ module AMS::PbcoreXmlExportExtension
   def add_contributions(xml)
     members(only: Contribution).each do |contribution|
       xml.pbcoreContributor do |contributor_node|
-        contributor_node.contributor { contributor_node.text(contribution&.contributor&.first) }
+        contributor_attrs = {}
+        contributor_attrs[:annotation] = contribution.annotation.first if contribution.annotation.present? && contribution.annotation.first.present?
+        contributor_attrs[:affiliation] = contribution.affiliation.first if contribution.affiliation.present? && contribution.affiliation.first.present?
 
-        # contributorRole is not required!
-        if contribution.contributor_role
-          contributor_node.contributorRole { contributor_node.text(contribution&.contributor_role&.first) }
+        contributor_node.contributor(contributor_attrs) do
+          contributor_node.text(contribution&.contributor&.first)
+        end
+
+        if contribution.contributor_role.present?
+          role_attrs = {}
+          role_attrs[:portrayal] = contribution.portrayal.first if contribution.portrayal.present? && contribution.portrayal.first.present?
+
+          contributor_node.contributorRole(role_attrs) do
+            contributor_node.text(contribution&.contributor_role&.first)
+          end
         end
       end
     end

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -11,7 +11,7 @@ class Contribution < ActiveFedora::Base
   property :bulkrax_identifier, predicate: ::RDF::URI("http://ams2.wgbh-mla.org/resource#bulkraxIdentifier"), multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
-  
+
   property :contributor, predicate: ::RDF::URI.new("http://www.w3.org/2006/vcard/ns#hasName"), multiple: false do |index|
     index.as :stored_searchable
   end
@@ -25,6 +25,10 @@ class Contribution < ActiveFedora::Base
   end
 
   property :affiliation, predicate: ::RDF::URI.new("http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAffiliation"), multiple: false, index_to_parent:true do |index|
+    index.as :stored_searchable
+  end
+
+  property :annotation, predicate: ::RDF::URI.new("http://pbcore.org#hasContributorAnnotation"), multiple: false do |index|
     index.as :stored_searchable
   end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -240,6 +240,10 @@ class SolrDocument
     self[solr_name('portrayal')]
   end
 
+  def annotation
+    self[solr_name('annotation')]
+  end
+
   def digital_format
     self[solr_name('digital_format')]
   end
@@ -359,11 +363,11 @@ class SolrDocument
   def clip_description
     self[solr_name('clip_description')]
   end
-  
+
   def rundown_description
     self[solr_name('rundown_description')]
   end
-  
+
   def all_dates
     [
       date,
@@ -540,11 +544,11 @@ class SolrDocument
     # this nonsensical ':symbol' option indicates that I am selecting the _ssim suffix from down in solrizer - default was _tesim, which was wrong for this field
     self[solr_name('md5', :symbol)]
   end
-  
+
   def ams1_legacy_metadata
     self[solr_name('ams1_legacy_metadata', :symbol)]
   end
-  
+
   def proxy_start_time
     self[solr_name('proxy_start_time', :symbol)]
   end

--- a/app/presenters/hyrax/contribution_presenter.rb
+++ b/app/presenters/hyrax/contribution_presenter.rb
@@ -2,6 +2,6 @@
 #  `rails generate hyrax:work Contribution`
 module Hyrax
   class ContributionPresenter < Hyrax::WorkShowPresenter
-    delegate :contributor_role, :portrayal, :affiliation,  to: :solr_document
+    delegate :contributor_role, :portrayal, :affiliation, :annotation, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/contribution_resource_presenter.rb
+++ b/app/presenters/hyrax/contribution_resource_presenter.rb
@@ -2,6 +2,6 @@
 #  `rails generate hyrax:work Contribution`
 module Hyrax
   class ContributionResourcePresenter < Hyrax::WorkShowPresenter
-    delegate :contributor_role, :portrayal, :affiliation,  to: :solr_document
+    delegate :contributor_role, :portrayal, :affiliation, :annotation, to: :solr_document
   end
 end

--- a/app/services/aapb/batch_ingest/bulkrax_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/bulkrax_xml_mapper.rb
@@ -166,6 +166,7 @@ module AAPB
         # pbcorecontributor ONLY
         affiliation: (person.affiliation if defined? person.affiliation),
         portrayal: (role.portrayal if role && defined? role.portrayal),
+        annotation: (role.annotation if role && defined? role.annotation)
       }
 
     end

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -161,11 +161,12 @@ module AAPB
 
       def person_attributes(person, role)
         {
-          contributor: (person.value if person),
+          contributor:      (person.value if person),
           contributor_role: (role.value if role),
           # pbcorecontributor ONLY
-          affiliation: (person.affiliation if defined? person.affiliation),
-          portrayal: (role.portrayal if role && defined? role.portrayal),
+          affiliation:      (person.respond_to?(:affiliation) ? person.affiliation : nil),
+          portrayal:        (role.respond_to?(:portrayal) ? role.portrayal : nil if role),
+          annotation:       (person.respond_to?(:annotation) ? person.annotation : nil)
         }
 
       end

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -167,8 +167,7 @@ module AAPB
           affiliation:      (person.respond_to?(:affiliation) ? person.affiliation : nil),
           portrayal:        (role.respond_to?(:portrayal) ? role.portrayal : nil),
           annotation:       (person.respond_to?(:annotation) ? person.annotation : nil)
-        }
-
+        }.compact
       end
 
       def physical_instantiation_resource_attributes

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -163,11 +163,10 @@ module AAPB
         {
           contributor:      (person.value if person),
           contributor_role: (role.value if role),
-          # pbcorecontributor ONLY
-          affiliation:      (person.respond_to?(:affiliation) ? person.affiliation : nil),
-          portrayal:        (role.respond_to?(:portrayal) ? role.portrayal : nil),
-          annotation:       (person.respond_to?(:annotation) ? person.annotation : nil)
-        }.compact
+          affiliation:      (person.affiliation if defined? person.affiliation),
+          portrayal:        (role.portrayal if role && defined? role.portrayal),
+          annotation:       (person.annotation if defined? person.annotation)
+        }
       end
 
       def physical_instantiation_resource_attributes

--- a/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
+++ b/app/services/aapb/batch_ingest/pbcore_xml_mapper.rb
@@ -165,7 +165,7 @@ module AAPB
           contributor_role: (role.value if role),
           # pbcorecontributor ONLY
           affiliation:      (person.respond_to?(:affiliation) ? person.affiliation : nil),
-          portrayal:        (role.respond_to?(:portrayal) ? role.portrayal : nil if role),
+          portrayal:        (role.respond_to?(:portrayal) ? role.portrayal : nil),
           annotation:       (person.respond_to?(:annotation) ? person.annotation : nil)
         }
 

--- a/app/views/hyrax/asset_resources/_contributions.html.erb
+++ b/app/views/hyrax/asset_resources/_contributions.html.erb
@@ -14,6 +14,7 @@
           <th><%= t('.name') %></th>
           <th><%= t('.affiliation') %></th>
           <th><%= t('.portrayal') %></th>
+          <th><%= t('.annotation') %></th>
         </tr>
         </thead>
         <tbody>
@@ -23,6 +24,7 @@
           <td><%= contribution.solr_document.try(:contributor).try(:first) %></td>
           <td><%= contribution.solr_document.try(:affiliation).try(:first) %></td>
           <td><%= contribution.solr_document.try(:portrayal).try(:first) %></td>
+          <td><%= contribution.solr_document.try(:annotation).try(:first) %></td>
         </tr>
         <% end %>
         </tbody>

--- a/app/views/hyrax/assets/_contributions.html.erb
+++ b/app/views/hyrax/assets/_contributions.html.erb
@@ -14,6 +14,7 @@
           <th><%= t('.name') %></th>
           <th><%= t('.affiliation') %></th>
           <th><%= t('.portrayal') %></th>
+          <th><%= t('.annotation') %></th>
         </tr>
         </thead>
         <tbody>
@@ -23,6 +24,7 @@
           <td><%= contribution.solr_document.try(:contributor).try(:first) %></td>
           <td><%= contribution.solr_document.try(:affiliation).try(:first) %></td>
           <td><%= contribution.solr_document.try(:portrayal).try(:first) %></td>
+          <td><%= contribution.solr_document.try(:annotation).try(:first) %></td>
         </tr>
         <% end %>
         </tbody>

--- a/app/views/hyrax/contribution_resources/_attribute_rows.html.erb
+++ b/app/views/hyrax/contribution_resources/_attribute_rows.html.erb
@@ -2,3 +2,4 @@
 <%= presenter.attribute_to_html(:contributor_role) %>
 <%= presenter.attribute_to_html(:affiliation) %>
 <%= presenter.attribute_to_html(:portrayal) %>
+<%= presenter.attribute_to_html(:annotation) %>

--- a/app/views/hyrax/contributions/_attribute_rows.html.erb
+++ b/app/views/hyrax/contributions/_attribute_rows.html.erb
@@ -2,4 +2,5 @@
 <%= presenter.attribute_to_html(:contributor_role) %>
 <%= presenter.attribute_to_html(:affiliation) %>
 <%= presenter.attribute_to_html(:portrayal) %>
+<%= presenter.attribute_to_html(:annotation) %>
 

--- a/config/authorities/contributor_role.yml
+++ b/config/authorities/contributor_role.yml
@@ -5,6 +5,8 @@ terms:
     term: Adapter
   - id: Anchor
     term: Anchor
+  - id: Appearing
+    term: Appearing
   - id: Artist
     term: Artist
   - id: Artistic Director
@@ -55,6 +57,8 @@ terms:
     term: Copyright Holder
   - id: Costume Designer
     term: Costume Designer
+  - id: Crew
+    term: Crew
   - id: Describer
     term: Describer
   - id: Director

--- a/config/batch_ingest.yml
+++ b/config/batch_ingest.yml
@@ -96,6 +96,7 @@ ingest_types:
             - contributor_role
             - portrayal
             - affiliation
+            - annotation
   aapb_csv_reader_4:
     label: "AAPB CSV Asset Multivalue Attribute Addition Ingester"
     reader: "AAPB::BatchIngest::CSVReader"
@@ -153,6 +154,7 @@ ingest_types:
             - contributor_role
             - portrayal
             - affiliation
+            - annotation
   zipped_pbcore_digital_instantiation:
     label: "AAPB Digital Instantiation PBCore - Zipped"
     reader: "AAPB::BatchIngest::ZippedPBCoreDigitalInstantiationReader"

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -42,6 +42,7 @@ if ENV['SETTINGS__BULKRAX__ENABLED'] == 'true'
       'admin_data_gid' => { from: headers('admin_data_gid') },
       'affiliation' => { from: 'Contributor.affiliation' },
       'alternative_modes' => { from: headers('alternative_modes'), split: true, join: true },
+      'annotation' => { from: 'Contributor.annotation' },
       'annotation' => { from: headers('annotation'), split: true, join: true },
       'aspect_ratio' => { from: ["EssenceTrack.aspect_ratio"] },
       'asset_types' => { from: headers('asset_types'), split: true, join: true },

--- a/config/locales/asset.en.yml
+++ b/config/locales/asset.en.yml
@@ -9,6 +9,7 @@ en:
         role:      'Role'
         affiliation:      'Affiliation'
         portrayal:      'portrayal'
+        annotation:      'Annotation'
         name:      'name'
         credits:    'Credits'
       instantiations:

--- a/config/locales/asset_resource.en.yml
+++ b/config/locales/asset_resource.en.yml
@@ -9,6 +9,7 @@ en:
         role:      'Role'
         affiliation:      'Affiliation'
         portrayal:      'portrayal'
+        annotation:      'Annotation'
         name:      'name'
         credits:    'Credits'
       instantiations:

--- a/config/metadata/contribution_resource.yaml
+++ b/config/metadata/contribution_resource.yaml
@@ -55,3 +55,13 @@ attributes:
       required: false
       primary: false
       multiple: false
+  annotation:
+    type: string
+    multiple: false
+    index_to_parent: false
+    index_keys:
+      - "annotation_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: false

--- a/spec/factories/contribution.rb
+++ b/spec/factories/contribution.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     contributor_role  { "Actor" }
     portrayal  { "Test portrayal" }
     affiliation  { "Test affiliation" }
+    annotation  { "Test annotation" }
   end
 end

--- a/spec/factories/contribution_resources.rb
+++ b/spec/factories/contribution_resources.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     contributor_role  { "Actor" }
     portrayal  { "Test portrayal" }
     affiliation  { "Test affiliation" }
+    annotation  { "Test annotation" }
   end
 end

--- a/spec/factories/pbcore_xml/contributor.rb
+++ b/spec/factories/pbcore_xml/contributor.rb
@@ -9,11 +9,15 @@ FactoryBot.define do
     role { PBCore::Contributor::Role.new(value: Faker::Job.title)  }
 
     trait :with_portrayal do
-      role { PBCore::Contributor::Role.new(value: Faker::Job.title, portrayal: Faker::TvShows::GameOfThrones.character)  }      
+      role { PBCore::Contributor::Role.new(value: Faker::Job.title, portrayal: Faker::TvShows::GameOfThrones.character)  }
     end
 
     trait :with_affiliation do
       contributor { PBCore::Contributor::Contributor.new(value: Faker::FunnyName.two_word_name, affiliation: Faker::Company.name) }
+    end
+
+    trait :with_annotation do
+      contributor { PBCore::Contributor::Contributor.new(value: Faker::FunnyName.two_word_name, annotation: Faker::Lorem.sentence) }
     end
 
     initialize_with { new(attributes) }

--- a/spec/factories/pbcore_xml/pbcore_description_document.rb
+++ b/spec/factories/pbcore_xml/pbcore_description_document.rb
@@ -84,7 +84,7 @@ FactoryBot.define do
 
       contributors do
         [
-          build(:pbcore_contributor, :with_portrayal, :with_affiliation)
+          build(:pbcore_contributor, :with_portrayal, :with_affiliation, :with_annotation)
         ]
       end
 

--- a/spec/features/create_asset_spec.rb
+++ b/spec/features/create_asset_spec.rb
@@ -124,6 +124,7 @@ RSpec.feature 'Create and Validate Asset', js: true, asset_form_helpers: true, c
       fill_in('asset_child_contributors_0_contributor', with: contribution_attributes[:contributor].first)
       fill_in('asset_child_contributors_0_portrayal', with: contribution_attributes[:portrayal])
       fill_in('asset_child_contributors_0_affiliation', with: contribution_attributes[:affiliation])
+      fill_in('asset_child_contributors_0_annotation', with: contribution_attributes[:annotation])
 
       click_link "Relationships" # define adminset relation
       find("#asset_admin_set_id option[value='#{admin_set_id}']").select_option
@@ -159,6 +160,7 @@ RSpec.feature 'Create and Validate Asset', js: true, asset_form_helpers: true, c
         expect(page).to have_content contribution_attributes[:contributor].first
         expect(page).to have_content contribution_attributes[:portrayal]
         expect(page).to have_content contribution_attributes[:affiliation]
+        expect(page).to have_content contribution_attributes[:annotation]
         expect(page).to have_content contribution_attributes[:contributor_role]
       end
     end

--- a/spec/jobs/push_to_aapb_job_spec.rb
+++ b/spec/jobs/push_to_aapb_job_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe PushToAAPBJob, type: :job do
         allow(Push).to receive(:find).and_return(push)
         allow(push).to receive(:push_ids).and_return([])
 
-        clear_enqueued_jobs  # clears anything enqueued by factory callbacks
+        # Call the method under test and assert expectations below.
+        described_class.perform_now(id: id, user: user)
       end
 
       it 'reschedules the job' do
-        described_class.perform_now(id: id, user: user)
         expect(delivery_instance).not_to have_received(:deliver)
         expect(described_class).to have_been_enqueued.with(hash_including(id: push.id, user: user)).exactly(:once)
       end

--- a/spec/jobs/push_to_aapb_job_spec.rb
+++ b/spec/jobs/push_to_aapb_job_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe PushToAAPBJob, type: :job do
         allow(Push).to receive(:find).and_return(push)
         allow(push).to receive(:push_ids).and_return([])
 
-        # Call the method under test and assert expectations below.
+        clear_enqueued_jobs  # clears anything enqueued by factory callbacks
         described_class.perform_now(id: id, user: user)
       end
 

--- a/spec/jobs/push_to_aapb_job_spec.rb
+++ b/spec/jobs/push_to_aapb_job_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe PushToAAPBJob, type: :job do
         allow(push).to receive(:push_ids).and_return([])
 
         clear_enqueued_jobs  # clears anything enqueued by factory callbacks
-        described_class.perform_now(id: id, user: user)
       end
 
       it 'reschedules the job' do
+        described_class.perform_now(id: id, user: user)
         expect(delivery_instance).not_to have_received(:deliver)
         expect(described_class).to have_been_enqueued.with(hash_including(id: push.id, user: user)).exactly(:once)
       end

--- a/spec/jobs/push_to_aapb_job_spec.rb
+++ b/spec/jobs/push_to_aapb_job_spec.rb
@@ -40,13 +40,21 @@ RSpec.describe PushToAAPBJob, type: :job do
         allow(Push).to receive(:find).and_return(push)
         allow(push).to receive(:push_ids).and_return([])
 
-        # Call the method under test and assert expectations below.
+        # Prevent ActiveJob from trying to use real scheduling
+        allow(described_class).to receive(:set).and_return(described_class)
+        allow(described_class).to receive(:perform_later)
+
         described_class.perform_now(id: id, user: user)
       end
 
-      it 'reschedules the job' do
+      it 'does not deliver the push and reschedules the job' do
         expect(delivery_instance).not_to have_received(:deliver)
-        expect(described_class).to have_been_enqueued.with(hash_including(id: push.id, user: user)).exactly(:once)
+
+        expect(described_class).to have_received(:set)
+        .with(wait: anything)
+
+        expect(described_class).to have_received(:perform_later)
+        .with(hash_including(id: push.id, user: user))
       end
     end
   end

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -42,18 +42,22 @@ RSpec.describe Contribution do
         expect(contribution.portrayal.include?("Test portrayal")).to be true
       end
     end
+
     context "affiliation" do
       it "has affiliation" do
-        contribution.portrayal = "Test affiliation"
+        contribution.affiliation = "Test affiliation"
         expect(contribution.resource.dump(:ttl)).to match(/ebucore\/ebucore#hasAffiliation/)
-        expect(contribution.portrayal.include?("Test affiliation")).to be true
+        expect(contribution.affiliation.include?("Test affiliation")).to be true
       end
     end
+
     context "annotation" do
       it "has annotation" do
         contribution.annotation = "Test annotation"
-        expect(contribution.resource.dump(:ttl)).to match(/http:\/\/ams2.wgbh-mla.org\/resource#annotation/)
+        expect(contribution.resource.dump(:ttl)).to match(/pbcore.org#hasContributorAnnotation/)
         expect(contribution.annotation.include?("Test annotation")).to be true
       end
     end
   end
+
+end

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -49,5 +49,11 @@ RSpec.describe Contribution do
         expect(contribution.portrayal.include?("Test affiliation")).to be true
       end
     end
+    context "annotation" do
+      it "has annotation" do
+        contribution.annotation = "Test annotation"
+        expect(contribution.resource.dump(:ttl)).to match(/http:\/\/ams2.wgbh-mla.org\/resource#annotation/)
+        expect(contribution.annotation.include?("Test annotation")).to be true
+      end
+    end
   end
-end

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Contribution do
     context "annotation" do
       it "has annotation" do
         contribution.annotation = "Test annotation"
-        expect(contribution.resource.dump(:ttl)).to match(/http:\/\/ams2.wgbh-mla.org\/resource#annotation/)
+        expect(contribution.resource.dump(:ttl)).to match(/http:\/\/ams2\.wgbh-mla\.org\/resource#annotation/)
         expect(contribution.annotation.include?("Test annotation")).to be true
       end
     end

--- a/spec/support/pbcore_xpath_helpers.rb
+++ b/spec/support/pbcore_xpath_helpers.rb
@@ -222,6 +222,7 @@ module PBCoreXPathHelper
           affiliation: contributor.xpath('//contributor').first.attributes['affiliation'].value,
           contributor_role: contributor.xpath('//contributorRole').first.text,
           portrayal: contributor.xpath('//contributorRole').first.attributes['portrayal'].value,
+          annotation: contributor.xpath('//contributor').first.attributes['annotation'].value
         }
       end
     end

--- a/spec/support/pbcore_xpath_helpers.rb
+++ b/spec/support/pbcore_xpath_helpers.rb
@@ -222,7 +222,6 @@ module PBCoreXPathHelper
           affiliation: contributor.xpath('//contributor').first.attributes['affiliation'].value,
           contributor_role: contributor.xpath('//contributorRole').first.text,
           portrayal: contributor.xpath('//contributorRole').first.attributes['portrayal'].value,
-          annotation: contributor.xpath('//contributor').first.attributes['annotation'].value
         }
       end
     end

--- a/spec/support/pbcore_xpath_helpers.rb
+++ b/spec/support/pbcore_xpath_helpers.rb
@@ -217,14 +217,12 @@ module PBCoreXPathHelper
 
     def contributors_attrs
       noko.xpath('//pbcoreContributor').map do |contributor|
-        contributor_node = contributor.xpath('contributor').first
-        role_node = contributor.xpath('contributorRole').first
         {
-          contributor: contributor_node&.text,
-          affiliation: contributor_node&.attributes&.[]('affiliation')&.value,
-          contributor_role: role_node&.text,
-          portrayal: role_node&.attributes&.[]('portrayal')&.value,
-          annotation: contributor_node&.attributes&.[]('annotation')&.value
+          contributor: contributor.xpath('//contributor').first.text,
+          affiliation: contributor.xpath('//contributor').first.attributes['affiliation'].value,
+          contributor_role: contributor.xpath('//contributorRole').first.text,
+          portrayal: contributor.xpath('//contributorRole').first.attributes['portrayal'].value,
+          annotation: contributor.xpath('//contributor').first.attributes['annotation'].value
         }
       end
     end

--- a/spec/support/pbcore_xpath_helpers.rb
+++ b/spec/support/pbcore_xpath_helpers.rb
@@ -217,12 +217,14 @@ module PBCoreXPathHelper
 
     def contributors_attrs
       noko.xpath('//pbcoreContributor').map do |contributor|
+        contributor_node = contributor.xpath('contributor').first
+        role_node = contributor.xpath('contributorRole').first
         {
-          contributor: contributor.xpath('//contributor').first.text,
-          affiliation: contributor.xpath('//contributor').first.attributes['affiliation'].value,
-          contributor_role: contributor.xpath('//contributorRole').first.text,
-          portrayal: contributor.xpath('//contributorRole').first.attributes['portrayal'].value,
-          annotation: contributor.xpath('//contributor').first.attributes['annotation'].value
+          contributor: contributor_node&.text,
+          affiliation: contributor_node&.attributes&.[]('affiliation')&.value,
+          contributor_role: role_node&.text,
+          portrayal: role_node&.attributes&.[]('portrayal')&.value,
+          annotation: contributor_node&.attributes&.[]('annotation')&.value
         }
       end
     end

--- a/spec/support/pbcore_xpath_helpers.rb
+++ b/spec/support/pbcore_xpath_helpers.rb
@@ -217,11 +217,14 @@ module PBCoreXPathHelper
 
     def contributors_attrs
       noko.xpath('//pbcoreContributor').map do |contributor|
+        contributor_node = contributor.xpath('contributor').first
+        role_node = contributor.xpath('contributorRole').first
         {
-          contributor: contributor.xpath('//contributor').first.text,
-          affiliation: contributor.xpath('//contributor').first.attributes['affiliation'].value,
-          contributor_role: contributor.xpath('//contributorRole').first.text,
-          portrayal: contributor.xpath('//contributorRole').first.attributes['portrayal'].value,
+          contributor: contributor_node&.text,
+          affiliation: contributor_node&.attributes&.[]('affiliation')&.value,
+          contributor_role: role_node&.text,
+          portrayal: role_node&.attributes&.[]('portrayal')&.value,
+          annotation: contributor_node&.attributes&.[]('annotation')&.value
         }
       end
     end


### PR DESCRIPTION
Changes based on [document](https://docs.google.com/document/d/1RSpxsEJJco1tgliJ__Pm-zuSL53N98TdqmHKcXdaY4A/edit?tab=t.0) provided by Owen. This PR covers the following:

1. Support one additional PBCore attribute in the contributor element: `annotation`
2. Add 2 new items to the role controlled vocabulary:
`Appearing`: an on-air contributor (like cast)
`Crew`: a contributor the the production
3. Fixes existing bug that ignored `affiliation` and `portrayal` inputs. These should now map into pbcore/xml.

Still to do:

- [ ] Test push of these types of records to AAPB