### PR TITLE
Update NGINX annotations

### DIFF
--- a/app/views/hyrax/batch_ingest/batches/new.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/new.html.erb
@@ -10,3 +10,19 @@
   <%= f.input :admin_set_id, collection: @admin_sets, required: true %>
   <%= f.button :submit,  value: 'Save' %>
 <% end %>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const form = document.querySelector('form');
+    const fileInput = document.querySelector('input[type="file"]');
+    const MAX_SIZE = 2 * 1024 * 1024; // 2MB in bytes
+
+    form.addEventListener('submit', function(e) {
+      if (fileInput.files.length > 0 && fileInput.files[0].size > MAX_SIZE) {
+        e.preventDefault();
+        alert('File size exceeds the 10MB limit. Please upload a file smaller than 2MB.');
+        fileInput.value = '';
+      }
+    });
+  });
+</script>

--- a/app/views/hyrax/batch_ingest/batches/new.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/new.html.erb
@@ -11,18 +11,31 @@
   <%= f.button :submit,  value: 'Save' %>
 <% end %>
 
+<%# Client-side validation to catch files exceeding the 2MB nginx upload limit
+    before they hit the server and return a confusing 413 error %>
+<div id="file-size-error" style="display:none; color:red; margin-top:8px;">
+  File size exceeds the 2MB limit. Please upload a smaller file.
+</div>
+
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     const form = document.querySelector('form');
     const fileInput = document.querySelector('input[type="file"]');
+    const submitButton = form.querySelector('input[type="submit"], button[type="submit"]');
+    const errorDiv = document.getElementById('file-size-error');
     const MAX_SIZE = 2 * 1024 * 1024; // 2MB in bytes
 
-    form.addEventListener('submit', function(e) {
+    fileInput.addEventListener('change', function() {
       if (fileInput.files.length > 0 && fileInput.files[0].size > MAX_SIZE) {
-        e.preventDefault();
-        alert('File size exceeds the 2MB limit. Please upload a file smaller than 2MB.');
+        errorDiv.style.display = 'block';
         fileInput.value = '';
+        submitButton.disabled = false;
+      } else {
+        errorDiv.style.display = 'none';
+        submitButton.disabled = false;
       }
     });
   });
 </script>
+
+

--- a/app/views/hyrax/batch_ingest/batches/new.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/new.html.erb
@@ -20,7 +20,7 @@
     form.addEventListener('submit', function(e) {
       if (fileInput.files.length > 0 && fileInput.files[0].size > MAX_SIZE) {
         e.preventDefault();
-        alert('File size exceeds the 10MB limit. Please upload a file smaller than 2MB.');
+        alert('File size exceeds the 2MB limit. Please upload a file smaller than 2MB.');
         fileInput.value = '';
       }
     });

--- a/app/views/hyrax/batch_ingest/batches/new.html.erb
+++ b/app/views/hyrax/batch_ingest/batches/new.html.erb
@@ -18,24 +18,30 @@
 </div>
 
 <script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const form = document.querySelector('form');
+function initFileValidation() {
     const fileInput = document.querySelector('input[type="file"]');
-    const submitButton = form.querySelector('input[type="submit"], button[type="submit"]');
+    const submitButton = document.querySelector('input[type="submit"]');
     const errorDiv = document.getElementById('file-size-error');
     const MAX_SIZE = 2 * 1024 * 1024; // 2MB in bytes
 
     fileInput.addEventListener('change', function() {
-      if (fileInput.files.length > 0 && fileInput.files[0].size > MAX_SIZE) {
-        errorDiv.style.display = 'block';
-        fileInput.value = '';
-        submitButton.disabled = false;
-      } else {
-        errorDiv.style.display = 'none';
-        submitButton.disabled = false;
-      }
-    });
-  });
+  if (fileInput.files.length === 0) return; // ignore the clear event
+
+  if (fileInput.files[0].size > MAX_SIZE) {
+    errorDiv.style.display = 'block';
+    fileInput.value = '';
+    submitButton.disabled = false;
+    submitButton.removeAttribute('data-disabled');
+  } else {
+    errorDiv.style.display = 'none';
+    submitButton.disabled = false;
+    submitButton.removeAttribute('data-disabled');
+  }
+});
+
+    }
+
+  initFileValidation();
+  document.addEventListener('turbo:load', initFileValidation);
+  document.addEventListener('turbolinks:load', initFileValidation);
 </script>
-
-

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -40,9 +40,9 @@ ingress:
         - path: /
   annotations:
     {
-      nginx.ingress.kubernetes.io/proxy-body-size: "10m",
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "300",
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "300",
+      nginx.org/client-max-body-size: "10m",
+      nginx.org/proxy-read-timeout: "120",
+      nginx.org/proxy-send-timeout: "120",
       cert-manager.io/cluster-issuer: letsencrypt-prod-dns,
     }
   tls:

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -40,7 +40,9 @@ ingress:
         - path: /
   annotations:
     {
-      nginx.ingress.kubernetes.io/proxy-body-size: "0",
+      nginx.ingress.kubernetes.io/proxy-body-size: "10m",
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "300",
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "300",
       cert-manager.io/cluster-issuer: letsencrypt-prod-dns,
     }
   tls:

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -40,7 +40,7 @@ ingress:
         - path: /
   annotations:
     {
-      nginx.org/client-max-body-size: "10m",
+      nginx.org/client-max-body-size: "2m",
       nginx.org/proxy-read-timeout: "120",
       nginx.org/proxy-send-timeout: "120",
       cert-manager.io/cluster-issuer: letsencrypt-prod-dns,

--- a/ops/prod-deploy.tmpl.yaml
+++ b/ops/prod-deploy.tmpl.yaml
@@ -40,7 +40,9 @@ ingress:
         - path: /
   annotations:
     {
-      nginx.ingress.kubernetes.io/proxy-body-size: "0",
+      nginx.org/client-max-body-size: "2m",
+      nginx.org/proxy-read-timeout: "120",
+      nginx.org/proxy-send-timeout: "120",
       cert-manager.io/cluster-issuer: letsencrypt-prod-dns,
     }
   tls:


### PR DESCRIPTION
- Updated `proxy-body-size` to `client-max-body-size` since it did not seem like proxy body size was being rendered when I increased it from 1mb to 2mb. We are using `NGINX Ingress Controller Version=5.3.3`, which (according to Claude) uses `client-max-body-size` annotation, as opposed to `ingress-nginx`, which uses `proxy-body-size`. I'm assuming when we had `proxy-body-size=1m` it was not doing anything and the default 1m was in play, so it wasn't noticed.
- Increased limit from 1mb to 2mb
- Added check and notice to user that appears before submitting an ingest that is larger than 2mb
- Added read/send timeouts to 2 minutes. 

This closes #1141 and avoids `entity too large` errors on ingests between 1-2MB, which catalogers have been experiencing.