### PR TITLE
adds 'exhibit' as a valid Asset annotationType

### DIFF
--- a/app/forms/asset_resource_form.rb
+++ b/app/forms/asset_resource_form.rb
@@ -45,7 +45,7 @@ class AssetResourceForm < Hyrax::Forms::ResourceForm(AssetResource)
   end
 
   def multiple?(field)
-    if [:child_contributors, :child_annotations, :special_collection, :sonyci_id, :special_collection_category].include?(field.to_sym)
+    if [:child_contributors, :child_annotations, :special_collection, :exhibit, :sonyci_id, :special_collection_category].include?(field.to_sym)
       true
     else
       super

--- a/app/forms/hyrax/asset_form.rb
+++ b/app/forms/hyrax/asset_form.rb
@@ -67,7 +67,7 @@ module Hyrax
     end
 
     def self.multiple?(field)
-      if [:child_contributors, :child_annotations, :special_collection, :sonyci_id, :special_collection_category].include?(field.to_sym)
+      if [:child_contributors, :child_annotations, :special_collection, :exhibit, :sonyci_id, :special_collection_category].include?(field.to_sym)
         true
       else
         super

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -201,7 +201,7 @@ class Asset < ActiveFedora::Base
   property :rundown_description, predicate: ::RDF::URI.new('http://pbcore.org#hasRundownDescription'), multiple: :true do |index|
     index.as :stored_searchable
   end
-  
+
   property :producing_organization, predicate: ::RDF::URI.new("http://purl.org/dc/elements/1.1/creator"), multiple: true do |index|
     index.as :stored_searchable, :facetable
   end
@@ -293,6 +293,10 @@ class Asset < ActiveFedora::Base
     external_reference_url ||= find_annotation_attribute("external_reference_url")
   end
 
+  def exhibit
+    exhibit ||= find_annotation_attribute("exhibit")
+  end
+
   def mavis_number
     mavis_number ||= find_annotation_attribute("mavis_number")
   end
@@ -324,11 +328,11 @@ class Asset < ActiveFedora::Base
   def proxy_start_time
     proxy_start_time ||= find_annotation_attribute("proxy_start_time")
   end
-  
+
  def ams1_legacy_metadata
     ams1_legacy_metadata ||= find_annotation_attribute("ams1_legacy_metadata")
   end
-  
+
   def find_annotation_attribute(attribute)
     if admin_data.annotations.select { |a| a.annotation_type == attribute }.present?
       return admin_data.annotations.select { |a| a.annotation_type == attribute }.map(&:value)

--- a/app/models/asset_resource.rb
+++ b/app/models/asset_resource.rb
@@ -98,6 +98,10 @@ class AssetResource < Hyrax::Work
     external_reference_url ||= find_annotation_attribute("external_reference_url")
   end
 
+  def exhibit
+    exhibit ||= find_annotation_attribute("exhibit")
+  end
+
   def mavis_number
     mavis_number ||= find_annotation_attribute("mavis_number")
   end
@@ -129,11 +133,11 @@ class AssetResource < Hyrax::Work
   def proxy_start_time
     proxy_start_time ||= find_annotation_attribute("proxy_start_time")
   end
- 
+
   def ams1_legacy_metadata
     ams1_legacy_metadata ||= find_annotation_attribute("ams1_legacy_metadata")
-  end 
-  
+  end
+
   def find_annotation_attribute(attribute)
     if admin_data.annotations.select { |a| a.annotation_type == attribute }.present?
       return admin_data.annotations.select { |a| a.annotation_type == attribute }.map(&:value)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -432,6 +432,10 @@ class SolrDocument
     self[solr_name('special_collections', :symbol)]
   end
 
+  def exhibit
+    self[solr_name('exhibit', :symbol)]
+  end
+
   def transcript_status
     self[solr_name('transcript_status', :symbol)]
   end

--- a/app/presenters/hyrax/asset_presenter.rb
+++ b/app/presenters/hyrax/asset_presenter.rb
@@ -9,7 +9,7 @@ module Hyrax
              :program_title, :episode_title, :segment_title, :raw_footage_title, :promo_title, :clip_title, :description,
              :program_description, :episode_description, :segment_description, :raw_footage_description,
              :promo_description, :clip_description, :rundown_description, :copyright_date,
-             :level_of_user_access, :outside_url, :special_collections, :transcript_status, :organization,
+             :level_of_user_access, :outside_url, :special_collections, :exhibit, :transcript_status, :organization,
              :sonyci_id, :licensing_info, :producing_organization, :series_title, :series_description,
              :playlist_group, :playlist_order, :hyrax_batch_ingest_batch_id, :bulkrax_importer_id, :last_pushed, :last_update, :needs_update, :special_collection_category, :canonical_meta_tag, :cataloging_status,
              to: :solr_document

--- a/app/presenters/hyrax/asset_resource_presenter.rb
+++ b/app/presenters/hyrax/asset_resource_presenter.rb
@@ -11,7 +11,7 @@ module Hyrax
              :program_title, :episode_title, :segment_title, :raw_footage_title, :promo_title, :clip_title, :description,
              :program_description, :episode_description, :segment_description, :raw_footage_description,
              :promo_description, :clip_description, :rundown_description, :copyright_date, :validation_status_for_aapb,
-             :level_of_user_access, :outside_url, :special_collections, :transcript_status, :organization,
+             :level_of_user_access, :outside_url, :special_collections, :exhibit, :transcript_status, :organization,
              :sonyci_id, :licensing_info, :producing_organization, :series_title, :series_description,
              :playlist_group, :playlist_order, :hyrax_batch_ingest_batch_id, :bulkrax_importer_id, :last_pushed, :last_update, :needs_update, :special_collection_category, :canonical_meta_tag, :cataloging_status,
              to: :solr_document

--- a/config/authorities/annotation_types.yml
+++ b/config/authorities/annotation_types.yml
@@ -5,6 +5,8 @@ terms:
     term: Captions URL
   - id: cataloging_status
     term: cataloging status
+  - id: exhibit
+    term: Exhibit
   - id: external_reference_url
     term: External Reference URL
   - id: level_of_user_access

--- a/config/batch_ingest.yml
+++ b/config/batch_ingest.yml
@@ -81,6 +81,7 @@ ingest_types:
           - cataloging_status
           - outside_url
           - special_collections
+          - exhibit
           - transcript_status
           - sonyci_id
           - licensing_info
@@ -146,6 +147,7 @@ ingest_types:
           - producing_organization
           - sonyci_id
           - special_collections
+          - exhibit
         children:
         - object_class: Contribution
           ingest_type: update

--- a/spec/factories/pbcore_xml/pbcore_description_document.rb
+++ b/spec/factories/pbcore_xml/pbcore_description_document.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
           build(:pbcore_annotation, type: "cataloging status", value: "Minimally Cataloged"),
           build(:pbcore_annotation, type: "Outside URL", value: Faker::Internet.url),
           build(:pbcore_annotation, type: "special_collections" , value: Faker::TvShows::Simpsons.character),
+          build(:pbcore_annotation, type: "exhibit" , value: Faker::Lorem.word),
           build(:pbcore_annotation, type: "Licensing Info" , value: Faker::Lorem.paragraph),
           build(:pbcore_annotation, type: "Playlist Group" , value: Faker::Lorem.word),
           build(:pbcore_annotation, type: "Playlist Order" , value: rand(1..5)),

--- a/spec/models/ams/pbcore_xml_export_extension_spec.rb
+++ b/spec/models/ams/pbcore_xml_export_extension_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AMS::PbcoreXmlExportExtension, :pbcore_xpath_helper, skip: 'TODO:
         :description, :program_description, :episode_description, :series_description,
         :segment_description, :clip_description, :rundown_description, :promo_description,
         :raw_footage_description, :audience_level, :audience_rating, :asset_types,
-        :genre, :rights_summary, :sonyci_id, :special_collections,
+        :genre, :rights_summary, :sonyci_id, :special_collections, :exhibit,
         :rights_link, :local_identifier, :pbs_nola_code, :eidr_id, :topics,
         :date, :broadcast_date, :copyright_date, :created_date, :subject,
         :producing_organization]

--- a/spec/presenters/hyrax/asset_presenter_spec.rb
+++ b/spec/presenters/hyrax/asset_presenter_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Hyrax::AssetPresenter do
       :clip_title, :program_description, :episode_description,
       :segment_description, :raw_footage_description, :promo_description,
       :clip_description, :rundown_description, :copyright_date, :level_of_user_access, :outside_url,
-      :special_collections, :transcript_status, :sonyci_id, :licensing_info,
+      :special_collections, :exhibit, :transcript_status, :sonyci_id, :licensing_info,
       :cataloging_status, :canonical_meta_tag, :special_collection_category,
       :playlist_group, :playlist_order, :organization
     ] }

--- a/spec/services/aapb/batch_ingest/pbcore_xml_item_ingester_spec.rb
+++ b/spec/services/aapb/batch_ingest/pbcore_xml_item_ingester_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLItemIngester, reset_data: false do
       end
 
       it 'ingests Annotations' do
-        expect(@admin_data.annotations.length).to eq(11)
+        expect(@admin_data.annotations.length).to eq(12)
       end
 
       it 'propagates additional batch items as part of the batch' do

--- a/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
+++ b/spec/services/aapb/batch_ingest/pbcore_xml_mapper_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe AAPB::BatchIngest::PBCoreXMLMapper, :pbcore_xpath_helper do
         ENV['SETTINGS__BULKRAX__ENABLED'] = bulkrax_setting
 
         expect(attrs).to have_key :annotations
-        expect(attrs[:annotations].length).to eq (11)
+        expect(attrs[:annotations].length).to eq (12)
 
         # Every Annotation in the attrs should have a value from the PBCore
         attrs[:annotations].each do |anno|

--- a/spec/support/pbcore_xpath_helpers.rb
+++ b/spec/support/pbcore_xpath_helpers.rb
@@ -68,6 +68,7 @@ module PBCoreXPathHelper
         cataloging_status:              '//pbcoreAnnotation[@annotationType="cataloging status"]',
         outside_url:                    '//pbcoreAnnotation[@annotationType="Outside URL"]',
         special_collections:            '//pbcoreAnnotation[@annotationType="special_collections"]',
+        exhibit:                        '//pbcoreAnnotation[@annotationType="exhibit"]',
         transcript_status:              '//pbcoreAnnotation[@annotationType="Transcript Status"]',
         licensing_info:                 '//pbcoreAnnotation[@annotationType="Licensing Info"]',
         playlist_group:                 '//pbcoreAnnotation[@annotationType="Playlist Group"]',
@@ -191,6 +192,7 @@ module PBCoreXPathHelper
                    values_from_xpath(:cataloging_status) +
                    values_from_xpath(:outside_url) +
                    values_from_xpath(:special_collections) +
+                   values_from_xpath(:exhibit) +
                    values_from_xpath(:transcript_status) +
                    values_from_xpath(:proxy_start_time) +
                    values_from_xpath(:licensing_info) +


### PR DESCRIPTION
Adding this to prepare for the eventual use of Exhibit AnnotationType to assign guids to exhibits in wagtail/dream-aapb.

for https://github.com/WGBH-MLA/dream-aapb/issues/48#issue-4752834799
